### PR TITLE
feat!: update sdk, absorb changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <!-- provided -->    
             <groupId>dev.openfeature</groupId>
             <artifactId>javasdk</artifactId>
-            <!-- 0.1.0 or greater -->
-            <version>[0.1,)</version> 
+            <!-- 0.2.0 or greater -->
+            <version>[0.2,)</version>
             <!-- use the version provided at runtime -->
             <scope>provided</scope>
         </dependency>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -145,14 +145,14 @@ public class FlagdProvider implements FeatureProvider {
     }
 
     @Override
-    public ProviderEvaluation<Structure> getObjectEvaluation(String key, Structure defaultValue,
+    public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue,
         EvaluationContext ctx) {
         ResolveObjectRequest request = ResolveObjectRequest.newBuilder()
             .setFlagKey(key)
             .setContext(this.convertContext(ctx))
             .build();
         ResolveObjectResponse r = this.serviceStub.resolveObject(request);
-        return ProviderEvaluation.<Structure>builder()
+        return ProviderEvaluation.<Value>builder()
             .value(this.convertObjectResponse(r.getValue()))
             .variant(r.getVariant())
             .reason(this.mapReason(r.getReason()))
@@ -174,10 +174,10 @@ public class FlagdProvider implements FeatureProvider {
     }
 
     /**
-     * Recursively convert protobuf structure to openfeature structure.
+     * Recursively convert protobuf structure to openfeature value.
      */
-    private Structure convertObjectResponse(com.google.protobuf.Struct protobuf) {
-        return new Structure(this.convertProtobufMap(protobuf.getFieldsMap()).asStructure().asMap());
+    private Value convertObjectResponse(com.google.protobuf.Struct protobuf) {
+        return this.convertProtobufMap(protobuf.getFieldsMap());
     }
 
     /**
@@ -268,9 +268,7 @@ public class FlagdProvider implements FeatureProvider {
             builder.setBoolValue(value.asBoolean());
         } else if (value.isString()) {
             builder.setStringValue(value.asString());
-        } else if (value.isInteger()) {
-            builder.setNumberValue(Double.valueOf(value.asInteger()));
-        }  else if (value.isDouble()) {
+        } else if (value.isNumber()) {
             builder.setNumberValue(value.asDouble());
         } else {
             builder.setNullValue(null);
@@ -290,7 +288,7 @@ public class FlagdProvider implements FeatureProvider {
         } else if (protobuf.hasNumberValue()) {
             value = new Value(protobuf.getNumberValue());
         } else {
-            value = new Value((Boolean) null);
+            value = new Value();
         }
         return value;
     }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
@@ -121,8 +121,9 @@ class FlagdProviderTest {
         assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
         assertEquals(DEFAULT, floatDetails.getReason());
 
-        FlagEvaluationDetails<Structure> objectDetails = api.getClient().getObjectDetails(FLAG_KEY, new Structure());
-        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asMap().get(INNER_STRUCT_KEY).asString());
+        FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY, new Value());
+        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
+            .asMap().get(INNER_STRUCT_KEY).asString());
         assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
         assertEquals(DEFAULT, objectDetails.getReason());
     }
@@ -196,7 +197,8 @@ class FlagdProviderTest {
 
         OpenFeatureAPI.getInstance().setProvider(new FlagdProvider(serviceBlockingStubMock));
 
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY, false, new EvaluationContext());
+        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient()
+            .getBooleanDetails(FLAG_KEY, false, new EvaluationContext());
         assertEquals(Reason.UNKNOWN, booleanDetails.getReason()); // reason should be converted to UNKNOWN
     }
 }


### PR DESCRIPTION
Absorb new SDK changes, naming using `Value` instead of `Structure`.

~Won't pass CI until we have a new SDK release.~ done