### PR TITLE
chore: remove gpg from pr checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Configure GPG Key
-        run: |
-          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import
-        env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-
       - name: Maven Verify
         run: mvn --batch-mode --settings release/m2-settings.xml verify
         env:


### PR DESCRIPTION
Signing isn't included in the `verify` maven goal, so we don't need it in this workflow at all. Having it breaks PRs from forks because the GPG key is a secret.

Only the publish needs it, it's in the `install` goal, which happens in the release-please workflow.