### PR TITLE
chore: remove STATIC -> DEFAULT mapping

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -160,16 +160,11 @@ public class FlagdProvider implements FeatureProvider {
     }
 
     // Map FlagD reasons to Java SDK reasons.
-    private Reason mapReason(String flagDreason) {
-        if (!EnumUtils.isValidEnum(Reason.class, flagDreason)) {
-            // until we have "STATIC" in the spec and SDK, we map STATIC to DEFAULT
-            if ("STATIC".equals(flagDreason)) {
-                return Reason.DEFAULT;
-            } else {
-                return Reason.UNKNOWN;
-            }
+    private Reason mapReason(String flagdReason) {
+        if (!EnumUtils.isValidEnum(Reason.class, flagdReason)) {
+            return Reason.UNKNOWN;
         } else {
-            return Reason.valueOf(flagDreason);
+            return Reason.valueOf(flagdReason);
         }
     }
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
@@ -148,12 +148,12 @@ class FlagdProviderTest {
             }};
         final String STRUCT_ATTR_INNER_VALUE = "struct-inner-value";
         final Structure STRUCT_ATTR_VALUE = new Structure().add(STRUCT_ATTR_INNER_KEY, STRUCT_ATTR_INNER_VALUE);
-        final String STATIC = "STATIC";
+        final String DEFAULT_STRING = "DEFAULT";
 
         ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
             .setValue(true)
             .setVariant(BOOL_VARIANT)
-            .setReason(STATIC.toString())
+            .setReason(DEFAULT_STRING.toString())
             .build();
 
         ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);


### PR DESCRIPTION
This is no longer needed. Flagd no longer returns this non-standard code.