### PR TITLE
docs: fixed broken doc links

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,3 +1,3 @@
 # OpenFeature Java Hooks
 
-Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. They operate similarly to middleware in many web frameworks. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/flag-evaluation/hooks.md) for more details.
+Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. They operate similarly to middleware in many web frameworks. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md) for more details.

--- a/providers/README.md
+++ b/providers/README.md
@@ -1,3 +1,3 @@
 # OpenFeature Java Providers
 
-Providers are responsible for performing flag evaluation. They provide an abstraction between the underlying flag management system and OpenFeature itself. This allows providers to be changed without requiring a major code refactor. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/provider/providers.md) for more details.
+Providers are responsible for performing flag evaluation. They provide an abstraction between the underlying flag management system and OpenFeature itself. This allows providers to be changed without requiring a major code refactor. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/sections/02-providers.md) for more details.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
In one of the [spec prs](https://github.com/open-feature/spec/pull/118) docs were restructured, but the links in this repository were not updated to reflect the changes. This PR simply updates the broken links here


### Related Issues
N/A

### Notes
N/A

### Follow-up Tasks
N/A

### How to test
N/A

