### PR TITLE
chore: add SBOM generation per module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo uses _Release Please_ to release packages. Release Please sets up a ru
 
 ### Software Bill of Materials (SBOM)
 
-We now publish SBOMs with all of our releases. You can find them in Maven Central alongside the artifacts.
+We publish SBOMs with all of our releases. You can find them in Maven Central alongside the artifacts.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The project includes:
 
 This repo uses _Release Please_ to release packages. Release Please sets up a running PR that tracks all changes for the library components, and maintains the versions according to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), generated when [PRs are merged](https://github.com/amannn/action-semantic-pull-request). When Release Please's running PR is merged, any changed artifacts are published.
 
+### Software Bill of Materials (SBOM)
+
+We now publish SBOMs with all of our releases. You can find them in Maven Central alongside the artifacts.
+
 ## Contributing
 
 see: [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,34 @@
             </plugin>
             <!-- end source & javadoc -->
 
+            <!-- SBOM generation -->
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.3</version>
+                <configuration>
+                    <projectType>library</projectType>
+                    <schemaVersion>1.3</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeRuntimeScope>true</includeRuntimeScope>
+                    <includeSystemScope>true</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                    <includeLicenseText>false</includeLicenseText>
+                    <outputFormat>all</outputFormat>
+                </configuration>
+                <executions>
+                    <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <!-- "makeAggregateBom" pollutes each module with the deps of other modules, so we use "makeBom" -->
+                        <goal>makeBom</goal>
+                    </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- sign the jars -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Adds SBOM generation, similarly to java-sdk, but per module. This will be published with the existing maven artifacts.

Closes: https://github.com/open-feature/java-sdk-contrib/issues/176