### PR TITLE
feat: exposed eventStreamAliveSync to allow application authors to block until event stream is alive

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -638,6 +638,8 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
     /**
      * Call .wait() on this to block until the event stream is alive.
+     * Can be used in instances where the provider being connected to the event stream is a prerequisite
+     * to execution (e.g. testing). Not necessary for standard usage.
      *
      * @return eventStreamAliveSync
      */

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -87,6 +87,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
     private int maxEventStreamRetries = DEFAULT_MAX_EVENT_STREAM_RETRIES;
 
     private ReadWriteLock lock = new ReentrantReadWriteLock();
+    private Object eventStreamAliveSync;
 
     /**
      * Create a new FlagdProvider instance.
@@ -183,6 +184,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         this.eventStreamAlive = false;
         this.cache = new FlagdCache(cache, maxCacheSize);
         this.maxEventStreamRetries = maxEventStreamRetries;
+        this.eventStreamAliveSync = new Object();
         this.handleEvents();
     }
 
@@ -603,6 +605,9 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
             l.lock();
             this.eventStreamAlive = alive;
             if (alive) {
+                synchronized (this.eventStreamAliveSync) {
+                    this.eventStreamAliveSync.notify(); // notify any waiters that the event stream is alive
+                }
                 // reset attempts on successful connection
                 this.eventStreamAttempt = 1;
                 this.eventStreamRetryBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
@@ -629,5 +634,14 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         Thread.sleep(this.eventStreamRetryBackoff);
 
         this.handleEvents();
+    }
+
+    /**
+     * Call .wait() on this to block until the event stream is alive.
+     *
+     * @return eventStreamAliveSync
+     */
+    public Object getEventStreamAliveSync() {
+        return this.eventStreamAliveSync;
     }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Exposes a sync mechanism to allow users of flagd provider to block until the event stream is alive.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

