### PR TITLE
fix: make flagsmith classes public

### DIFF
--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
  * FlagsmithProvider is the JAVA provider implementation for the feature flag solution Flagsmith.
  */
 @Slf4j
-class FlagsmithProvider implements FeatureProvider {
+public class FlagsmithProvider implements FeatureProvider {
 
     private static final String NAME = "Flagsmith Provider";
     private static FlagsmithClient flagsmith;

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class FlagsmithProvider implements FeatureProvider {
 
     private static final String NAME = "Flagsmith Provider";
-    private static FlagsmithClient flagsmith;
+    private FlagsmithClient flagsmith;
     private FlagsmithProviderOptions options;
 
     public FlagsmithProvider(FlagsmithProviderOptions options) {

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
@@ -16,7 +16,7 @@ import okhttp3.Interceptor;
 @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"}, justification = "The headers need to be mutable")
 @Builder(toBuilder = true)
 @Getter
-class FlagsmithProviderOptions {
+public class FlagsmithProviderOptions {
 
     /**
      * Your API Token.


### PR DESCRIPTION
Making access modifiers for supposedly public classes public.