### PR TITLE
fix: issue on unknown field

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -1,6 +1,8 @@
 package dev.openfeature.contrib.providers.gofeatureflag;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -44,7 +46,8 @@ import java.util.stream.Collectors;
 public class GoFeatureFlagProvider implements FeatureProvider {
     private static final String NAME = "GO Feature Flag Provider";
     private static final ObjectMapper requestMapper = new ObjectMapper();
-    private static final ObjectMapper responseMapper = new ObjectMapper();
+    private static final ObjectMapper responseMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private HttpUrl parsedEndpoint;
     // httpClient is the instance of the OkHttpClient used by the provider
     private OkHttpClient httpClient;
@@ -197,7 +200,10 @@ public class GoFeatureFlagProvider implements FeatureProvider {
                 if (Reason.DISABLED.name().equalsIgnoreCase(goffResp.getReason())) {
                     // we don't set a variant since we are using the default value, and we are not able to know
                     // which variant it is.
-                    return ProviderEvaluation.<T>builder().value(defaultValue).reason(Reason.DISABLED.name()).build();
+                    return ProviderEvaluation.<T>builder()
+                            .value(defaultValue)
+                            .variant(goffResp.getVariationType())
+                            .reason(Reason.DISABLED.name()).build();
                 }
 
                 if (ErrorCode.FLAG_NOT_FOUND.name().equalsIgnoreCase(goffResp.getErrorCode())) {

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -284,6 +284,16 @@ class GoFeatureFlagProviderTest {
         assertEquals("True", res.getVariant());
     }
 
+    @Test
+    void should_not_fail_if_receive_an_unknown_field_in_response() throws InvalidOptions {
+        GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
+        ProviderEvaluation<Boolean> res = g.getBooleanEvaluation("unknown_field", false, this.evaluationContext);
+        assertEquals(true, res.getValue());
+        assertNull(res.getErrorCode());
+        assertEquals(Reason.TARGETING_MATCH.toString(), res.getReason());
+        assertEquals("True", res.getVariant());
+    }
+
     private String readMockResponse(String filename) throws IOException {
         String file = getClass().getClassLoader().getResource("mock_responses/" + filename).getFile();
         byte[] bytes = Files.readAllBytes(Paths.get(file));

--- a/providers/go-feature-flag/src/test/resources/mock_responses/unknown_field.json
+++ b/providers/go-feature-flag/src/test/resources/mock_responses/unknown_field.json
@@ -1,0 +1,11 @@
+{
+  "trackEvents": true,
+  "variationType": "True",
+  "failed": false,
+  "version": 0,
+  "reason": "TARGETING_MATCH",
+  "errorCode": "",
+  "value": true,
+  "unknown_field": true,
+  "unknown_field2": "unknown_field2"
+}


### PR DESCRIPTION
## This PR
Version `1.4.0` of the GO Feature Flag relay proxy is adding a new field in the JSON response and this was breaking the provider.

This PR provides a fix to ignore if unknown fields are present in the JSON response.

### Related Issues
Fixes: https://github.com/thomaspoignant/go-feature-flag/issues/582

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

