### PR TITLE
fix: attach original exception when throwing a general error

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -221,7 +221,7 @@ public class GoFeatureFlagProvider implements FeatureProvider {
 
             }
         } catch (IOException e) {
-            throw new GeneralError("unknown error while retrieving flag " + key);
+            throw new GeneralError("unknown error while retrieving flag " + key, e);
         }
     }
 


### PR DESCRIPTION
## This PR
When throwing `GeneralException` the original exception was not attached.
This PR ensures that we attach it so ease the debugging.

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/581
