### PR TITLE
feat: Support apiKey for GO Feature Flag relay proxy v1.7.0

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -191,12 +191,12 @@ public class GoFeatureFlagProvider implements FeatureProvider {
                             requestMapper.writeValueAsBytes(goffRequest),
                             MediaType.get("application/json; charset=utf-8")));
 
-            if(this.apiKey!=null && !"".equals(this.apiKey)){
+            if (this.apiKey != null && !"".equals(this.apiKey)) {
                 reqBuilder.addHeader("Authorization", "Bearer " + this.apiKey);
             }
 
             try (Response response = this.httpClient.newCall(reqBuilder.build()).execute()) {
-                if (response.code() == HTTP_UNAUTHORIZED){
+                if (response.code() == HTTP_UNAUTHORIZED) {
                     throw new GeneralError("invalid token used to contact GO Feature Flag relay proxy instance");
                 }
                 if (response.code() >= HTTP_BAD_REQUEST) {

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -38,4 +38,15 @@ public class GoFeatureFlagProviderOptions {
      */
     @Getter
     private Long keepAliveDuration;
+
+    /**
+     *  (optional) If the relay proxy is configured to authenticate the requests, you should provide
+     *  an API Key to the provider.
+     *
+     *  Please ask the administrator of the relay proxy to provide an API Key.
+     *  (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
+     *  Default: null
+     */
+    @Getter
+    private String apiKey;
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -42,7 +42,6 @@ public class GoFeatureFlagProviderOptions {
     /**
      *  (optional) If the relay proxy is configured to authenticate the requests, you should provide
      *  an API Key to the provider.
-     *
      *  Please ask the administrator of the relay proxy to provide an API Key.
      *  (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
      *  Default: null

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -40,6 +40,9 @@ class GoFeatureFlagProviderTest {
             if (request.getPath().contains("fail_500")) {
                 return new MockResponse().setResponseCode(500);
             }
+            if (request.getPath().contains("fail_401")) {
+                return new MockResponse().setResponseCode(401);
+            }
             if (request.getPath().startsWith("/v1/feature/")) {
                 String flagName = request.getPath().replace("/v1/feature/", "").replace("/eval", "");
                 return new MockResponse()
@@ -117,6 +120,17 @@ class GoFeatureFlagProviderTest {
     void should_throw_an_error_if_endpoint_not_available() throws InvalidOptions {
         GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
         assertThrows(GeneralError.class, () -> g.getBooleanEvaluation("fail_500", false, this.evaluationContext));
+    }
+
+    @Test
+    void should_throw_an_error_if_invalid_api_key() throws InvalidOptions {
+        GoFeatureFlagProvider g = new GoFeatureFlagProvider(
+                GoFeatureFlagProviderOptions.builder()
+                        .endpoint(this.baseUrl.toString())
+                        .timeout(1000)
+                        .apiKey("invalid_api_key")
+                        .build());
+        assertThrows(GeneralError.class, () -> g.getBooleanEvaluation("fail_401", false, this.evaluationContext));
     }
 
     @Test


### PR DESCRIPTION
## This PR
Support apiKey for GO Feature Flag relay proxy v1.7.0
### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/thomaspoignant/go-feature-flag/issues/666