### PR TITLE
feat: flagd manual otel interceptor for grpc

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -1,144 +1,151 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>dev.openfeature.contrib</groupId>
-		<artifactId>parent</artifactId>
-		<version>0.1.0</version>
-		<relativePath>../../pom.xml</relativePath>
-	</parent>
-	<groupId>dev.openfeature.contrib.providers</groupId>
-	<artifactId>flagd</artifactId>
-	<version>0.5.8</version> <!--x-release-please-version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.openfeature.contrib</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.1.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <groupId>dev.openfeature.contrib.providers</groupId>
+    <artifactId>flagd</artifactId>
+    <version>0.5.8</version> <!--x-release-please-version -->
 
-	<name>flagd</name>
-	<description>FlagD provider for Java</description>
-	<url>https://openfeature.dev</url>
+    <name>flagd</name>
+    <description>FlagD provider for Java</description>
+    <url>https://openfeature.dev</url>
 
-	<developers>
-		<developer>
-			<id>toddbaert</id>
-			<name>Todd Baert</name>
-			<organization>OpenFeature</organization>
-			<url>https://openfeature.dev/</url>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>toddbaert</id>
+            <name>Todd Baert</name>
+            <organization>OpenFeature</organization>
+            <url>https://openfeature.dev/</url>
+        </developer>
+    </developers>
 
-	<dependencies>
-		<!-- we inherent dev.openfeature.javasdk and the test dependencies from the parent pom -->
+    <dependencies>
+        <!-- we inherent dev.openfeature.javasdk and the test dependencies from the parent pom -->
 
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-netty</artifactId>
-			<version>1.54.1</version>
-		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>1.54.1</version>
+        </dependency>
 
-		<dependency>
-			<!-- we only support unix sockets on linux, via epoll native lib -->
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport-native-epoll</artifactId>
-			<version>4.1.92.Final</version>
-			<!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
-			<classifier>linux-x86_64</classifier>
-		</dependency>
+        <dependency>
+            <!-- we only support unix sockets on linux, via epoll native lib -->
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.92.Final</version>
+            <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
+            <classifier>linux-x86_64</classifier>
+        </dependency>
 
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-protobuf</artifactId>
-			<version>1.54.1</version>
-		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.54.1</version>
+        </dependency>
 
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-stub</artifactId>
-			<version>1.54.1</version>
-		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>1.54.1</version>
+        </dependency>
 
-		<dependency>
-			<!-- necessary for Java 9+ -->
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>annotations-api</artifactId>
-			<version>6.0.53</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <!-- necessary for Java 9+ -->
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>annotations-api</artifactId>
+            <version>6.0.53</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-			<version>4.4</version>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
 
-	<build>
-		<!-- required for protobuf generation -->
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.25.0</version>
+        </dependency>
+    </dependencies>
 
-		<plugins>
-			<plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-						<id>update-schemas-submodule</id>
-						<phase>validate</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-						<configuration>
-							<!-- run: git submodule update \-\-init \-\-recursive -->
-							<executable>git</executable>
-							<arguments>
-								<argument>submodule</argument>
-								<argument>update</argument>
-								<argument>--init</argument>
-								<argument>--recursive</argument>
-							</arguments>
-						</configuration>
-          </execution>
-					<execution>
-						<id>copy-protobuf-definition</id>
-						<phase>validate</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-						<configuration>
-							<!-- run: cp schemas/protobuf/schema/v1/schema.proto src/main/proto/ -->
-							<executable>cp</executable>
-							<arguments>
-								<argument>schemas/protobuf/schema/v1/schema.proto</argument>
-								<argument>src/main/proto/</argument>
-							</arguments>
-						</configuration>
-          </execution>
-        </executions>
-      </plugin>
+    <build>
+        <!-- required for protobuf generation -->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
 
-			<plugin>
-				<groupId>org.xolstice.maven.plugins</groupId>
-				<artifactId>protobuf-maven-plugin</artifactId>
-				<version>0.6.1</version>
-				<configuration>
-					<protocArtifact>com.google.protobuf:protoc:3.21.1:exe:${os.detected.classifier}</protocArtifact>
-					<pluginId>grpc-java</pluginId>
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.48.1:exe:${os.detected.classifier}</pluginArtifact>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-							<goal>compile-custom</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>update-schemas-submodule</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <!-- run: git submodule update \-\-init \-\-recursive -->
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>submodule</argument>
+                                <argument>update</argument>
+                                <argument>--init</argument>
+                                <argument>--recursive</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-protobuf-definition</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <!-- run: cp schemas/protobuf/schema/v1/schema.proto src/main/proto/ -->
+                            <executable>cp</executable>
+                            <arguments>
+                                <argument>schemas/protobuf/schema/v1/schema.proto</argument>
+                                <argument>src/main/proto/</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:3.21.1:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.48.1:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>flagd</artifactId>
-    <version>0.5.8</version> <!--x-release-please-version -->
+    <version>0.5.8-snapshot</version> <!--x-release-please-version -->
 
     <name>flagd</name>
     <description>FlagD provider for Java</description>
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
+            <artifactId>opentelemetry-api</artifactId>
             <version>1.25.0</version>
         </dependency>
     </dependencies>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -14,9 +14,8 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import javax.annotation.Nullable;
 
 /**
- * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd
- * <p>
- *  <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
+ * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd.
+ * <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
  */
 final class FlagdGrpcInterceptor implements ClientInterceptor {
     private static final TextMapSetter<Metadata> SETTER = new Setter();
@@ -27,30 +26,24 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
         this.openTelemetry = openTelemetry;
     }
 
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+    @Override public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,
+                                                                         CallOptions callOptions, Channel channel) {
 
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override
-            public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
-                openTelemetry.getPropagators()
-                        .getTextMapPropagator()
-                        .inject(Context.current(), headers, SETTER);
-
+            @Override public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+                openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
                 super.start(responseListener, headers);
             }
         };
     }
 
     /**
-     * Setter implements TextMapSetter with carrier check
+     * Setter implements TextMapSetter with carrier check.
      */
     static class Setter implements TextMapSetter<Metadata> {
-        @Override
-        public void set(@Nullable Metadata carrier, String key, String value) {
+        @Override public void set(@Nullable Metadata carrier, String key, String value) {
             if (carrier == null) {
                 return;
             }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -1,0 +1,61 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+import javax.annotation.Nullable;
+
+/**
+ * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd
+ * <p>
+ *  <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
+ */
+final class FlagdGrpcInterceptor implements ClientInterceptor {
+    private static final TextMapSetter<Metadata> SETTER = new Setter();
+
+    private final OpenTelemetrySdk openTelemetry;
+
+    FlagdGrpcInterceptor(final OpenTelemetrySdk openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+
+        final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
+            @Override
+            public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+                openTelemetry.getPropagators()
+                        .getTextMapPropagator()
+                        .inject(Context.current(), headers, SETTER);
+
+                super.start(responseListener, headers);
+            }
+        };
+    }
+
+    /**
+     * Setter implements TextMapSetter with carrier check
+     */
+    static class Setter implements TextMapSetter<Metadata> {
+        @Override
+        public void set(@Nullable Metadata carrier, String key, String value) {
+            if (carrier == null) {
+                return;
+            }
+
+            carrier.put(io.grpc.Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+        }
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -7,9 +7,9 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 import javax.annotation.Nullable;
 
@@ -20,9 +20,9 @@ import javax.annotation.Nullable;
 final class FlagdGrpcInterceptor implements ClientInterceptor {
     private static final TextMapSetter<Metadata> SETTER = new Setter();
 
-    private final OpenTelemetrySdk openTelemetry;
+    private final OpenTelemetry openTelemetry;
 
-    FlagdGrpcInterceptor(final OpenTelemetrySdk openTelemetry) {
+    FlagdGrpcInterceptor(final OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -32,7 +32,7 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+            @Override public void start(Listener<RespT> responseListener, Metadata headers) {
                 openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
                 super.start(responseListener, headers);
             }
@@ -48,7 +48,7 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
                 return;
             }
 
-            carrier.put(io.grpc.Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+            carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
         }
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -186,6 +186,10 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
                 fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES));
     }
 
+
+    /**
+     * Create a new FlagdProvider instance with manual telemetry sdk.
+     */
     public FlagdProvider(OpenTelemetrySdk telemetrySdk) {
         this(
                 buildServiceBlockingStub(telemetrySdk),
@@ -557,7 +561,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         // run the referenced resolver method
         final ResT response;
 
-        if (tracer != null){
+        if (tracer != null) {
             final Span span = tracer.spanBuilder("resolve")
                     .setSpanKind(SpanKind.CLIENT)
                     .startSpan();
@@ -567,7 +571,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
             } finally {
                 span.end();
             }
-        }else {
+        } else {
             response = resolverRef.apply((ReqT) req);
         }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -566,6 +566,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
                     .setSpanKind(SpanKind.CLIENT)
                     .startSpan();
             span.setAttribute("feature_flag.key", key);
+            span.setAttribute("feature_flag.provider_name", "flagd");
             try (Scope scope = span.makeCurrent()) {
                 response = resolverRef.apply((ReqT) req);
             } finally {


### PR DESCRIPTION
## This PR

Fixes https://github.com/open-feature/java-sdk-contrib/issues/283 by introducing manual tracing [1] for flagd Java sdk 

This PR introduce a new constructor to provide an OpenTelemetry SDK. Internally, this is used to intercept grpc communication and add simple span for evaluation.

```
 OpenFeatureAPI api = OpenFeatureAPI.getInstance();
api.setProvider(new FlagdProvider(optenTelemetry));
```   

With a proper setup, we get distributed telemetry for flagd ecosystem

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/8186721/233698140-00db2fbb-bf1c-4b1f-a68c-2957848e771e.png">


<img width="757" alt="image" src="https://user-images.githubusercontent.com/8186721/233697848-0c5a0d17-6e72-4f15-b86c-aa46add4bb1b.png">

Note - a follow-up refactoring is ready to improve constructor behavior https://github.com/open-feature/java-sdk-contrib/pull/294 

[1] - https://opentelemetry.io/docs/instrumentation/java/manual/