### PR TITLE
feat: replace OS class with interface

### DIFF
--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvVarProvider.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvVarProvider.java
@@ -13,14 +13,14 @@ import java.util.function.Function;
 public final class EnvVarProvider implements FeatureProvider {
     private static final String NAME = "Environment Variables Provider";
 
-    private final OS os;
+    private final EnvironmentGateway environmentGateway;
 
     public EnvVarProvider() {
-        os = new OS();
+        this.environmentGateway = new OS();
     }
 
-    public EnvVarProvider(OS os) {
-        this.os = os;
+    public EnvVarProvider(EnvironmentGateway environmentGateway) {
+        this.environmentGateway = environmentGateway;
     }
 
     @Override
@@ -57,7 +57,7 @@ public final class EnvVarProvider implements FeatureProvider {
             String key,
             Function<String, T> parse
     ) {
-        final String value = os.getenv(key);
+        final String value = environmentGateway.getEnvironmentVariable(key);
 
         if (value == null) {
             throw new FlagNotFoundError();

--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentGateway.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentGateway.java
@@ -1,7 +1,7 @@
 package dev.openfeature.contrib.providers.envvar;
 
 /**
- * This is an abstraction to fetch an environment variables. It can be used to support
+ * This is an abstraction to fetch environment variables. It can be used to support
  * environment-specific access or provide additional functionality, like prefixes,
  * casing and even sources like spring configurations which come from different sources.
  * Also, a test double could implement this interface, making the tests independent of the actual environment.

--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentGateway.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentGateway.java
@@ -1,0 +1,11 @@
+package dev.openfeature.contrib.providers.envvar;
+
+/**
+ * This is an abstraction to fetch an environment variables. It can be used to support
+ * environment-specific access or provide additional functionality, like prefixes,
+ * casing and even sources like spring configurations which come from different sources.
+ * Also, a test double could implement this interface, making the tests independent of the actual environment.
+ */
+public interface EnvironmentGateway {
+    String getEnvironmentVariable(String key);
+}

--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/OS.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/OS.java
@@ -4,8 +4,8 @@ package dev.openfeature.contrib.providers.envvar;
  * This internal class abstracts away Java's {@link System} class for test purposes.
  * It is not intended to be used directly.
  */
-class OS {
-    public String getenv(String name) {
-        return System.getenv(name);
+class OS implements EnvironmentGateway {
+    public String getEnvironmentVariable(String key) {
+        return System.getenv(key);
     }
 }

--- a/providers/env-var/src/test/java/dev/openfeature/contrib/providers/envvar/EnvVarProviderTest.java
+++ b/providers/env-var/src/test/java/dev/openfeature/contrib/providers/envvar/EnvVarProviderTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EnvVarProviderTest {
+
     @Test
     void shouldThrowOnGetObjectEvaluation() {
         assertThrows(
@@ -181,14 +182,11 @@ class EnvVarProviderTest {
             String variableName,
             String value
     ) {
-        return new EnvVarProvider(new OS() {
-            @Override
-            public String getenv(String name) {
-                if (name.equals(variableName)) {
-                    return value;
-                } else {
-                    return null;
-                }
+        return new EnvVarProvider(name -> {
+            if (name.equals(variableName)) {
+                return value;
+            } else {
+                return null;
             }
         });
     }


### PR DESCRIPTION
## This PR
-introduces a new interface abstracting the access of environment variables

### Related Issues
Fixes #257

### Notes
I left the default constructor of the class `EnvVarProvider` intact, in case it is already used somewhere. If it is ok, I'd rather kill it, but this would introduce a breaking change.

### How to test
The existing unit tests now uses an implementation of the newly created interface (as lambda, as it is a functional interface). No additional testing is required as the interface doesn't contain any logic.

