### PR TITLE
chore: flagd constructor refactoring

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -17,61 +17,92 @@ A feature flag daemon with a Unix philosophy.
 
 ## Usage
 
-The `FlagdProvider` communicates with flagd via the gRPC protocol. Instantiate a new FlagdProvider instance, and configure the OpenFeature SDK to use it:
+The `FlagdProvider` communicates with flagd via the gRPC protocol. Instantiate a new FlagdProvider instance, and
+configure the OpenFeature SDK to use it:
 
 ```java
-FlagdProvider provider = new FlagdProvider();
-OpenFeatureAPI.getInstance().setProvider(provider);
+// Create a flagd instance with default options
+FlagdProvider flagd = new FlagdProvider();
+// Set flagd as the OpenFeature Provider
+OpenFeatureAPI.getInstance().setProvider(flagd);
 ```
 
-Options can be defined in the constructor or as environment variables, with constructor options having the highest precedence.
+Options can be defined in the constructor or as environment variables, with constructor options having the highest
+precedence.
 
-| Option name           | Environment variable name       | Type    | Default   | Values        |
-| --------------------- | ------------------------------- | ------- | --------- | ------------- |
-| host                  | FLAGD_HOST                      | string  | localhost |               |
-| port                  | FLAGD_PORT                      | number  | 8013      |               |
-| tls                   | FLAGD_TLS                       | boolean | false     |               |
-| socketPath            | FLAGD_SOCKET_PATH               | string  | -         |               |
-| certPath              | FLAGD_SERVER_CERT_PATH          | string  | -         |               |
-| cache                 | FLAGD_CACHE                     | string  | lru       | lru,disabled  |
-| maxCacheSize          | FLAGD_MAX_CACHE_SIZE            | int     | 1000      |               |
-| maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES  | int     | 5         |               |
+Default options can be overridden through a `FlagdOptions` based constructor or set to be picked up from the environment
+variables.
 
-For better flexibility on provider arguments, please use `FLagdOptions` based provider constructor
+### Supported environmental variables
+
+| Option name           | Environment variable name      | Type    | Default   | Values       |
+|-----------------------|--------------------------------|---------|-----------|--------------|
+| host                  | FLAGD_HOST                     | string  | localhost |              |
+| port                  | FLAGD_PORT                     | number  | 8013      |              |
+| tls                   | FLAGD_TLS                      | boolean | false     |              |
+| socketPath            | FLAGD_SOCKET_PATH              | string  | null      |              |
+| certPath              | FLAGD_SERVER_CERT_PATH         | string  | null      |              |
+| cache                 | FLAGD_CACHE                    | string  | lru       | lru,disabled |
+| maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int     | 1000      |              |
+| maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int     | 5         |              |
+
+### OpenTelemetry support
+
+OpenTelemetry support can be enabled either through [automatic instrumentation](https://opentelemetry.io/docs/instrumentation/java/automatic/) 
+or with [manual instrumentation](https://opentelemetry.io/docs/instrumentation/java/manual/). 
+
+For manual instrumentation, flagd provider can be constructed with an `OpenTelemetry` instance.
 
 ```java
-FlagdProvider flagdProvider =
-        new FlagdProvider(FlagdOptions.builder()
-                            .host("localhost")
-                            .port(8023)
-                            .openTelemetry(openTelemetry).build());
+FlagdOptions options = 
+        FlagdOptions.builder()
+                    .openTelemetry(openTelemetry)
+                    .build();
 
+FlagdProvider flagdProvider = new FlagdProvider(options);
 ```
+
+Please refer [OpenTelemetry example](https://opentelemetry.io/docs/instrumentation/java/manual/#example) for best 
+practice guideline.
+
+Telemetry configuration combined with [flagd telemetry ](https://github.com/open-feature/flagd/blob/main/docs/configuration/flagd_telemetry.md)
+allows distributed tracing.
 
 ### Unix socket support
 
-Unix socket communication with flag is facilitated via usage of the linux-native `epoll` library on `linux-x86_64` only (ARM support is pending relase of `netty-transport-native-epoll` v5). Unix sockets are not supported on other platforms or architectures.
+Unix socket communication with flag is facilitated via usage of the linux-native `epoll` library on `linux-x86_64`
+only (ARM support is pending relase of `netty-transport-native-epoll` v5). Unix sockets are not supported on other
+platforms or architectures.
 
 ### Reconnection
 
-Reconnection is supported by the underlying GRPCBlockingStub. If connection to flagd is lost, it will reconnect automatically.
+Reconnection is supported by the underlying GRPCBlockingStub. If connection to flagd is lost, it will reconnect
+automatically.
 
 ### Deadline (gRPC call timeout)
 
 The deadline for an individual flag evaluation can be configured by calling `setDeadline(< deadline in millis >)`.
-If the gRPC call is not completed within this deadline, the gRPC call is terminated with the error `DEADLINE_EXCEEDED` and the evaluation will default.
+If the gRPC call is not completed within this deadline, the gRPC call is terminated with the error `DEADLINE_EXCEEDED`
+and the evaluation will default.
 The default deadline is 500ms, though evaluations typically take on the order of 10ms.
 
 ### TLS
 
 Though not required in deployments where flagd runs on the same host as the workload, TLS is available.
 
-:warning: Note that there's a [vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268) in [netty](https://github.com/netty/netty), a transitive dependency of the underlying gRPC libraries used in the flagd-provider that fails to correctly validate certificates. This will be addressed in netty v5.
+:warning: Note that there's a [vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268)
+in [netty](https://github.com/netty/netty), a transitive dependency of the underlying gRPC libraries used in the
+flagd-provider that fails to correctly validate certificates. This will be addressed in netty v5.
 
 ## Caching
 
-The provider attempts to establish a connection to flagd's event stream (up to 5 times by default). If the connection is successful and caching is enabled each flag returned with reason `STATIC` is cached until an event is received concerning the cached flag (at which point it is removed from cache).
+The provider attempts to establish a connection to flagd's event stream (up to 5 times by default). If the connection is
+successful and caching is enabled each flag returned with reason `STATIC` is cached until an event is received
+concerning the cached flag (at which point it is removed from cache).
 
-On invocation of a flag evaluation (if caching is available) an attempt is made to retrieve the entry from cache, if found the flag is returned with reason `CACHED`.
+On invocation of a flag evaluation (if caching is available) an attempt is made to retrieve the entry from cache, if
+found the flag is returned with reason `CACHED`.
 
-By default, the provider is configured to use [least recently used (lru)](https://commons.apache.org/proper/commons-collections/apidocs/org/apache/commons/collections4/map/LRUMap.html) caching with up to 1000 entries.
+By default, the provider is configured to
+use [least recently used (lru)](https://commons.apache.org/proper/commons-collections/apidocs/org/apache/commons/collections4/map/LRUMap.html)
+caching with up to 1000 entries.

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -44,7 +44,7 @@ FlagdProvider flagdProvider =
         new FlagdProvider(FlagdOptions.builder()
                             .host("localhost")
                             .port(8023)
-                            .telemetrySdk(telemetrySdk).build());
+                            .openTelemetry(openTelemetry).build());
 
 ```
 

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -37,6 +37,17 @@ Options can be defined in the constructor or as environment variables, with cons
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE            | int     | 1000      |               |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES  | int     | 5         |               |
 
+For better flexibility on provider arguments, please use `FLagdOptions` based provider constructor
+
+```java
+FlagdProvider flagdProvider =
+        new FlagdProvider(FlagdOptions.builder()
+                            .host("localhost")
+                            .port(8023)
+                            .telemetrySdk(telemetrySdk).build());
+
+```
+
 ### Unix socket support
 
 Unix socket communication with flag is facilitated via usage of the linux-native `epoll` library on `linux-x86_64` only (ARM support is pending relase of `netty-transport-native-epoll` v5). Unix sockets are not supported on other platforms or architectures.

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>flagd</artifactId>
-    <version>0.5.8-snapshot</version> <!--x-release-please-version -->
+    <version>0.5.8</version> <!--x-release-please-version -->
 
     <name>flagd</name>
     <description>FlagD provider for Java</description>
@@ -38,7 +38,7 @@
             <!-- we only support unix sockets on linux, via epoll native lib -->
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.92.Final</version>
+            <version>4.1.91.Final</version>
             <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
             <classifier>linux-x86_64</classifier>
         </dependency>
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
+            <artifactId>opentelemetry-sdk</artifactId>
             <version>1.25.0</version>
         </dependency>
     </dependencies>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>flagd</artifactId>
-    <version>0.5.8</version> <!--x-release-please-version -->
+    <version>0.5.8-snapshot</version> <!--x-release-please-version -->
 
     <name>flagd</name>
     <description>FlagD provider for Java</description>
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
+            <artifactId>opentelemetry-api</artifactId>
             <version>1.25.0</version>
         </dependency>
     </dependencies>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>flagd</artifactId>
-    <version>0.5.8-snapshot</version> <!--x-release-please-version -->
+    <version>0.5.8</version> <!--x-release-please-version -->
 
     <name>flagd</name>
     <description>FlagD provider for Java</description>
@@ -38,7 +38,7 @@
             <!-- we only support unix sockets on linux, via epoll native lib -->
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.91.Final</version>
+            <version>4.1.92.Final</version>
             <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
             <classifier>linux-x86_64</classifier>
         </dependency>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -1,0 +1,46 @@
+package dev.openfeature.contrib.providers.flagd;
+
+final class Config {
+    static final String DEFAULT_PORT = "8013";
+    static final String DEFAULT_TLS = "false";
+    static final String DEFAULT_HOST = "localhost";
+
+    static final int DEFAULT_DEADLINE = 500;
+    static final int DEFAULT_MAX_CACHE_SIZE = 1000;
+
+    static final String HOST_ENV_VAR_NAME = "FLAGD_HOST";
+    static final String PORT_ENV_VAR_NAME = "FLAGD_PORT";
+    static final String TLS_ENV_VAR_NAME = "FLAGD_TLS";
+    static final String SOCKET_PATH_ENV_VAR_NAME = "FLAGD_SOCKET_PATH";
+    static final String SERVER_CERT_PATH_ENV_VAR_NAME = "FLAGD_SERVER_CERT_PATH";
+    static final String CACHE_ENV_VAR_NAME = "FLAGD_CACHE";
+    static final String MAX_CACHE_SIZE_ENV_VAR_NAME = "FLAGD_MAX_CACHE_SIZE";
+    static final String MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME = "FLAGD_MAX_EVENT_STREAM_RETRIES";
+
+    static final String STATIC_REASON = "STATIC";
+    static final String CACHED_REASON = "CACHED";
+
+    static final String FLAG_KEY_FIELD = "flag_key";
+    static final String CONTEXT_FIELD = "context";
+    static final String VARIANT_FIELD = "variant";
+    static final String VALUE_FIELD = "value";
+    static final String REASON_FIELD = "reason";
+
+    static final String LRU_CACHE = "lru";
+    static final String DEFAULT_CACHE = LRU_CACHE;
+
+    static final int DEFAULT_MAX_EVENT_STREAM_RETRIES = 5;
+    static final int BASE_EVENT_STREAM_RETRY_BACKOFF_MS = 1000;
+
+    static String fallBackToEnvOrDefault(String key, String defaultValue) {
+        return System.getenv(key) != null ? System.getenv(key) : defaultValue;
+    }
+
+    static int fallBackToEnvOrDefault(String key, int defaultValue) {
+        try {
+            return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/EventStreamCallback.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/EventStreamCallback.java
@@ -4,7 +4,7 @@ package dev.openfeature.contrib.providers.flagd;
  * Defines behaviour required of event stream callbacks.
  */
 interface EventStreamCallback {
-    void setEventStreamAlive(Boolean alive);
+    void setEventStreamAlive(boolean alive);
 
     void restartEventStream() throws Exception;
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/EventStreamObserver.java
@@ -11,8 +11,8 @@ import com.google.protobuf.Value;
  */
 @Slf4j
 public class EventStreamObserver implements StreamObserver<EventStreamResponse> {
-    private EventStreamCallback callback;
-    private FlagdCache cache;
+    private final EventStreamCallback callback;
+    private final FlagdCache cache;
 
     private static final String configurationChange = "configuration_change";
     private static final String providerReady = "provider_ready";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdCache.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdCache.java
@@ -7,6 +7,8 @@ import org.apache.commons.collections4.map.LRUMap;
 
 import dev.openfeature.sdk.ProviderEvaluation;
 
+import static dev.openfeature.contrib.providers.flagd.Config.LRU_CACHE;
+
 /**
  * Exposes caching mechanism for flag evaluations.
  */
@@ -14,7 +16,6 @@ public class FlagdCache {
     private Map<String,ProviderEvaluation<? extends Object>> store;
     private Boolean enabled = false;
 
-    static final String LRU_CACHE = "lru";
     static final String DISABLED = "disabled";
 
     FlagdCache(String cache, int maxCacheSize) {
@@ -27,8 +28,7 @@ public class FlagdCache {
                 return;
             case LRU_CACHE:
             default:
-                this.store = Collections
-                        .synchronizedMap(new LRUMap<String, ProviderEvaluation<? extends Object>>(maxCacheSize));
+                this.store = Collections.synchronizedMap(new LRUMap<>(maxCacheSize));
         }
 
         this.enabled = true;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -7,48 +7,55 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 import javax.annotation.Nullable;
 
 /**
- * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd.
- * <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
+ * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd
+ * <p>
+ *  <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
  */
 final class FlagdGrpcInterceptor implements ClientInterceptor {
     private static final TextMapSetter<Metadata> SETTER = new Setter();
 
-    private final OpenTelemetry openTelemetry;
+    private final OpenTelemetrySdk openTelemetry;
 
-    FlagdGrpcInterceptor(final OpenTelemetry openTelemetry) {
+    FlagdGrpcInterceptor(final OpenTelemetrySdk openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 
-    @Override public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,
-                                                                         CallOptions callOptions, Channel channel) {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
 
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override public void start(Listener<RespT> responseListener, Metadata headers) {
-                openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
+            @Override
+            public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+                openTelemetry.getPropagators()
+                        .getTextMapPropagator()
+                        .inject(Context.current(), headers, SETTER);
+
                 super.start(responseListener, headers);
             }
         };
     }
 
     /**
-     * Setter implements TextMapSetter with carrier check.
+     * Setter implements TextMapSetter with carrier check
      */
     static class Setter implements TextMapSetter<Metadata> {
-        @Override public void set(@Nullable Metadata carrier, String key, String value) {
+        @Override
+        public void set(@Nullable Metadata carrier, String key, String value) {
             if (carrier == null) {
                 return;
             }
 
-            carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+            carrier.put(io.grpc.Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
         }
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -14,9 +14,8 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import javax.annotation.Nullable;
 
 /**
- * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd
- * <p>
- *  <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
+ * FlagdGrpcInterceptor is an interceptor for grpc communication from java-sdk to flagd.
+ * <a href="https://github.com/open-telemetry/opentelemetry-java-docs">credits</a>
  */
 final class FlagdGrpcInterceptor implements ClientInterceptor {
     private static final TextMapSetter<Metadata> SETTER = new Setter();
@@ -27,30 +26,24 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
         this.openTelemetry = openTelemetry;
     }
 
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+    @Override public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,
+                                                                         CallOptions callOptions, Channel channel) {
 
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override
-            public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
-                openTelemetry.getPropagators()
-                        .getTextMapPropagator()
-                        .inject(Context.current(), headers, SETTER);
-
+            @Override public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+                openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
                 super.start(responseListener, headers);
             }
         };
     }
 
     /**
-     * Setter implements TextMapSetter with carrier check
+     * Setter implements TextMapSetter with carrier check.
      */
     static class Setter implements TextMapSetter<Metadata> {
-        @Override
-        public void set(@Nullable Metadata carrier, String key, String value) {
+        @Override public void set(@Nullable Metadata carrier, String key, String value) {
             if (carrier == null) {
                 return;
             }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -22,7 +23,7 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
 
     private final OpenTelemetry openTelemetry;
 
-    FlagdGrpcInterceptor(final OpenTelemetry openTelemetry) {
+    FlagdGrpcInterceptor(@Nonnull final OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -32,7 +32,8 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override public void start(Listener<RespT> responseListener, Metadata headers) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
                 openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
                 super.start(responseListener, headers);
             }
@@ -43,7 +44,8 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
      * Setter implements TextMapSetter with carrier check.
      */
     static class Setter implements TextMapSetter<Metadata> {
-        @Override public void set(@Nullable Metadata carrier, String key, String value) {
+        @Override
+        public void set(@Nullable Metadata carrier, String key, String value) {
             if (carrier == null) {
                 return;
             }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -7,9 +7,9 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 import javax.annotation.Nullable;
 
@@ -20,9 +20,9 @@ import javax.annotation.Nullable;
 final class FlagdGrpcInterceptor implements ClientInterceptor {
     private static final TextMapSetter<Metadata> SETTER = new Setter();
 
-    private final OpenTelemetrySdk openTelemetry;
+    private final OpenTelemetry openTelemetry;
 
-    FlagdGrpcInterceptor(final OpenTelemetrySdk openTelemetry) {
+    FlagdGrpcInterceptor(final OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdGrpcInterceptor.java
@@ -32,7 +32,7 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
         final ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
 
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(call) {
-            @Override public void start(Listener<RespT> responseListener, io.grpc.Metadata headers) {
+            @Override public void start(Listener<RespT> responseListener, Metadata headers) {
                 openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), headers, SETTER);
                 super.start(responseListener, headers);
             }
@@ -48,7 +48,7 @@ final class FlagdGrpcInterceptor implements ClientInterceptor {
                 return;
             }
 
-            carrier.put(io.grpc.Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+            carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
         }
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -1,6 +1,6 @@
 package dev.openfeature.contrib.providers.flagd;
 
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.api.OpenTelemetry;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -79,8 +79,8 @@ public class FlagdOptions {
             fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES);
 
     /**
-     * Inject OpenTelemetrySdk for the library runtime. Providing sdk will initiate distributed tracing for flagd grpc
+     * Inject OpenTelemetry for the library runtime. Providing sdk will initiate distributed tracing for flagd grpc
      * connectivity.
      * */
-    private OpenTelemetrySdk telemetrySdk;
+    private OpenTelemetry openTelemetry;
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -1,0 +1,86 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import lombok.Builder;
+import lombok.Getter;
+
+import static dev.openfeature.contrib.providers.flagd.Config.CACHE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_CACHE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_HOST;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_CACHE_SIZE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_EVENT_STREAM_RETRIES;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_PORT;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_TLS;
+import static dev.openfeature.contrib.providers.flagd.Config.HOST_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_CACHE_SIZE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.PORT_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SERVER_CERT_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SOCKET_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.TLS_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.fallBackToEnvOrDefault;
+
+
+/**
+ * FlagdOptions is a builder to build flagd provider options.
+ * */
+@Builder
+@Getter
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class FlagdOptions {
+
+    /**
+     * flagd connection host.
+     * */
+    @Builder.Default
+    private String host = fallBackToEnvOrDefault(HOST_ENV_VAR_NAME, DEFAULT_HOST);
+
+    /**
+     * flagd connection port.
+     * */
+    @Builder.Default
+    private int port = Integer.parseInt(fallBackToEnvOrDefault(PORT_ENV_VAR_NAME, DEFAULT_PORT));
+
+    /**
+     * Use TLS connectivity.
+     * */
+    @Builder.Default
+    private boolean tls = Boolean.parseBoolean(fallBackToEnvOrDefault(TLS_ENV_VAR_NAME, DEFAULT_TLS));
+
+    /**
+     * TLS certificate overriding if TLS connectivity is used.
+     * */
+    @Builder.Default
+    private String certPath = fallBackToEnvOrDefault(SERVER_CERT_PATH_ENV_VAR_NAME, null);
+
+    /**
+     * Unix socket path to flagd.
+     * */
+    @Builder.Default
+    private String socketPath = fallBackToEnvOrDefault(SOCKET_PATH_ENV_VAR_NAME, null);
+
+    /**
+     * Cache type to use. Supports - lru, disabled.
+     * */
+    @Builder.Default
+    private String cacheType = fallBackToEnvOrDefault(CACHE_ENV_VAR_NAME, DEFAULT_CACHE);
+
+    /**
+     * Max cache size.
+     * */
+    @Builder.Default
+    private int maxCacheSize = fallBackToEnvOrDefault(MAX_CACHE_SIZE_ENV_VAR_NAME, DEFAULT_MAX_CACHE_SIZE);
+
+    /**
+     * Max event stream connection retries.
+     * */
+    @Builder.Default
+    private int maxEventStreamRetries =
+            fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES);
+
+    /**
+     * Inject OpenTelemetrySdk for the library runtime. Providing sdk will initiate distributed tracing for flagd grpc
+     * connectivity.
+     * */
+    private OpenTelemetrySdk telemetrySdk;
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -19,6 +19,8 @@ import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.MutableStructure;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -26,11 +28,6 @@ import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLException;
@@ -45,66 +42,86 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static dev.openfeature.contrib.providers.flagd.Config.BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
+import static dev.openfeature.contrib.providers.flagd.Config.CACHED_REASON;
+import static dev.openfeature.contrib.providers.flagd.Config.CACHE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.CONTEXT_FIELD;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_CACHE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_DEADLINE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_HOST;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_CACHE_SIZE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_EVENT_STREAM_RETRIES;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_PORT;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_TLS;
+import static dev.openfeature.contrib.providers.flagd.Config.FLAG_KEY_FIELD;
+import static dev.openfeature.contrib.providers.flagd.Config.HOST_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_CACHE_SIZE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.PORT_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.REASON_FIELD;
+import static dev.openfeature.contrib.providers.flagd.Config.SERVER_CERT_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SOCKET_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.STATIC_REASON;
+import static dev.openfeature.contrib.providers.flagd.Config.TLS_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.VALUE_FIELD;
+import static dev.openfeature.contrib.providers.flagd.Config.VARIANT_FIELD;
+import static dev.openfeature.contrib.providers.flagd.Config.fallBackToEnvOrDefault;
+
 /**
  * OpenFeature provider for flagd.
  */
 @Slf4j
+@SuppressWarnings("PMD.TooManyStaticImports")
 public class FlagdProvider implements FeatureProvider, EventStreamCallback {
+    private static final String FLAGD_PROVIDER = "flagD Provider";
 
-    static final String PROVIDER_NAME = "flagD Provider";
-    static final String DEFAULT_PORT = "8013";
-    static final String DEFAULT_TLS = "false";
-    static final String DEFAULT_HOST = "localhost";
-    static final int DEFAULT_DEADLINE = 500;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    static final String HOST_ENV_VAR_NAME = "FLAGD_HOST";
-    static final String PORT_ENV_VAR_NAME = "FLAGD_PORT";
-    static final String TLS_ENV_VAR_NAME = "FLAGD_TLS";
-    static final String SOCKET_PATH_ENV_VAR_NAME = "FLAGD_SOCKET_PATH";
-    static final String SERVER_CERT_PATH_ENV_VAR_NAME = "FLAGD_SERVER_CERT_PATH";
-    static final String CACHE_ENV_VAR_NAME = "FLAGD_CACHE";
-    static final String MAX_CACHE_SIZE_ENV_VAR_NAME = "FLAGD_MAX_CACHE_SIZE";
-    static final String MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME = "FLAGD_MAX_EVENT_STREAM_RETRIES";
+    private final ServiceBlockingStub serviceBlockingStub;
+    private final ServiceStub serviceStub;
+    private final int maxEventStreamRetries;
+    private final Object eventStreamAliveSync;
+    private final FlagdCache cache;
+    private final ResolveStrategy strategy;
 
-    static final String STATIC_REASON = "STATIC";
-    static final String CACHED_REASON = "CACHED";
-
-    static final String FLAG_KEY_FIELD = "flag_key";
-    static final String CONTEXT_FIELD = "context";
-    static final String VARIANT_FIELD = "variant";
-    static final String VALUE_FIELD = "value";
-    static final String REASON_FIELD = "reason";
-
-    static final String LRU_CACHE = "lru";
-    static final String DISABLED = "disabled";
-    static final String DEFAULT_CACHE = LRU_CACHE;
-    static final int DEFAULT_MAX_CACHE_SIZE = 1000;
-
-    static final int DEFAULT_MAX_EVENT_STREAM_RETRIES = 5;
-    static final int BASE_EVENT_STREAM_RETRY_BACKOFF_MS = 1000;
-
-    private long deadline = DEFAULT_DEADLINE;
-
-    private ServiceBlockingStub serviceBlockingStub;
-    private ServiceStub serviceStub;
-
-    private Tracer tracer;
-
-    private Boolean eventStreamAlive;
-    private FlagdCache cache;
-
+    private boolean eventStreamAlive;
     private int eventStreamAttempt = 1;
     private int eventStreamRetryBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
-    private int maxEventStreamRetries;
+    private long deadline = DEFAULT_DEADLINE;
 
-    private ReadWriteLock lock = new ReentrantReadWriteLock();
-    private Object eventStreamAliveSync;
+    /**
+     * Create a new FlagdProvider instance with default options.
+     */
+    public FlagdProvider() {
+        this(FlagdOptions.builder().build());
+    }
+
+    /**
+     * Create a new FlagdProvider instance with customized options.
+     *
+     * @param options {@link FlagdOptions} with
+     */
+    public FlagdProvider(final FlagdOptions options) {
+        final ManagedChannel channel = nettyChannel(options);
+        this.serviceStub = ServiceGrpc.newStub(channel);
+        this.serviceBlockingStub = ServiceGrpc.newBlockingStub(channel);
+        this.strategy = options.getTelemetrySdk() == null
+                ? new SimpleResolving()
+                : new TracedResolving(options.getTelemetrySdk());
+
+        this.maxEventStreamRetries = options.getMaxEventStreamRetries();
+        this.cache = new FlagdCache(options.getCacheType(), options.getMaxCacheSize());
+        this.eventStreamAliveSync = new Object();
+        this.handleEvents();
+    }
 
     /**
      * Create a new FlagdProvider instance.
+     * This constructor is deprecated use constructor with {@link FlagdOptions} for flexible instance creation.
      *
      * @param socketPath unix socket path
      */
+    @Deprecated
     public FlagdProvider(String socketPath) {
         this(
                 buildServiceBlockingStub(null, null, null, null, socketPath),
@@ -116,6 +133,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
     /**
      * Create a new FlagdProvider instance.
+     * This constructor is deprecated use constructor with {@link FlagdOptions} for flexible instance creation.
      *
      * @param socketPath            unix socket path
      * @param cache                 caching implementation to use (lru)
@@ -124,6 +142,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
      *                              flagd's event stream,
      *                              on successful connection the attempts are reset
      */
+    @Deprecated
     public FlagdProvider(String socketPath, String cache, int maxCacheSize, int maxEventStreamRetries) {
         this(
                 buildServiceBlockingStub(null, null, null, null, socketPath),
@@ -133,14 +152,15 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
     /**
      * Create a new FlagdProvider instance.
+     * This constructor is deprecated use constructor with {@link FlagdOptions} for flexible instance creation.
      *
      * @param host     flagd server host, defaults to "localhost"
      * @param port     flagd server port, defaults to 8013
      * @param tls      use TLS, defaults to false
      * @param certPath path for server certificate, defaults to null to, using
      *                 system certs
-     *
      */
+    @Deprecated
     public FlagdProvider(String host, int port, boolean tls, String certPath) {
         this(
                 buildServiceBlockingStub(host, port, tls, certPath, null),
@@ -152,6 +172,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
     /**
      * Create a new FlagdProvider instance.
+     * This constructor is deprecated use constructor with {@link FlagdOptions} for flexible instance creation
      *
      * @param host                  flagd server host, defaults to "localhost"
      * @param port                  flagd server port, defaults to 8013
@@ -164,8 +185,8 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
      * @param maxEventStreamRetries limit of the number of attempts to connect to
      *                              flagd's event stream,
      *                              on successful connection the attempts are reset
-     *
      */
+    @Deprecated
     public FlagdProvider(String host, int port, boolean tls, String certPath, String cache,
             int maxCacheSize, int maxEventStreamRetries) {
         this(
@@ -174,40 +195,14 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
                 cache, maxCacheSize, maxEventStreamRetries);
     }
 
-    /**
-     * Create a new FlagdProvider instance.
-     */
-    public FlagdProvider() {
-        this(
-                buildServiceBlockingStub(null, null, null, null, null),
-                buildServiceStub(null, null, null, null, null),
-                fallBackToEnvOrDefault(CACHE_ENV_VAR_NAME, DEFAULT_CACHE),
-                fallBackToEnvOrDefault(MAX_CACHE_SIZE_ENV_VAR_NAME, DEFAULT_MAX_CACHE_SIZE),
-                fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES));
-    }
-
-
-    /**
-     * Create a new FlagdProvider instance with manual telemetry sdk.
-     */
-    public FlagdProvider(OpenTelemetry openTelemetry) {
-        this(
-                buildServiceBlockingStub(openTelemetry),
-                buildServiceStub(null, null, null, null, null),
-                fallBackToEnvOrDefault(CACHE_ENV_VAR_NAME, DEFAULT_CACHE),
-                fallBackToEnvOrDefault(MAX_CACHE_SIZE_ENV_VAR_NAME, DEFAULT_MAX_CACHE_SIZE),
-                fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES));
-
-        this.tracer = openTelemetry.getTracer("OpenFeature/dev.openfeature.contrib.providers.flagd");
-    }
-
-    FlagdProvider(ServiceBlockingStub serviceBlockingStub, ServiceStub serviceStub, String cache,
-            int maxCacheSize, int maxEventStreamRetries) {
+    FlagdProvider(ServiceBlockingStub serviceBlockingStub, ServiceStub serviceStub, String cache, int maxCacheSize,
+                  int maxEventStreamRetries) {
         this.serviceBlockingStub = serviceBlockingStub;
         this.serviceStub = serviceStub;
-        this.eventStreamAlive = false;
-        this.cache = new FlagdCache(cache, maxCacheSize);
+        this.strategy = new SimpleResolving();
+
         this.maxEventStreamRetries = maxEventStreamRetries;
+        this.cache = new FlagdCache(cache, maxCacheSize);
         this.eventStreamAliveSync = new Object();
         this.handleEvents();
     }
@@ -239,12 +234,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
     @Override
     public Metadata getMetadata() {
-        return new Metadata() {
-            @Override
-            public String getName() {
-                return PROVIDER_NAME;
-            }
-        };
+        return () -> FLAGD_PROVIDER;
     }
 
     @Override
@@ -307,6 +297,25 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
     public FlagdProvider setDeadline(long deadlineMs) {
         this.deadline = deadlineMs;
         return this;
+    }
+
+    @Override
+    public void setEventStreamAlive(boolean alive) {
+        Lock l = this.lock.writeLock();
+        try {
+            l.lock();
+            this.eventStreamAlive = alive;
+            if (alive) {
+                synchronized (this.eventStreamAliveSync) {
+                    this.eventStreamAliveSync.notify(); // notify any waiters that the event stream is alive
+                }
+                // reset attempts on successful connection
+                this.eventStreamAttempt = 1;
+                this.eventStreamRetryBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
+            }
+        } finally {
+            l.unlock();
+        }
     }
 
     /**
@@ -430,6 +439,10 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         return value;
     }
 
+    /**
+     * Intended to be removed along with multi-option constructors.
+     * */
+    @Deprecated
     private static NettyChannelBuilder channelBuilder(String host, Integer port, Boolean tls, String certPath,
             String socketPath) {
         host = host != null ? host : fallBackToEnvOrDefault(HOST_ENV_VAR_NAME, DEFAULT_HOST);
@@ -470,33 +483,68 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         }
     }
 
+    /**
+     * This method is a helper to build a {@link ManagedChannel} from provided {@link FlagdOptions}.
+     * */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "certificate path is a user input")
+    private static ManagedChannel nettyChannel(final FlagdOptions options) {
+        // we have a socket path specified, build a channel with a unix socket
+        if (options.getSocketPath() != null) {
+            return NettyChannelBuilder
+                    .forAddress(new DomainSocketAddress(options.getSocketPath()))
+                    .eventLoopGroup(new EpollEventLoopGroup())
+                    .channelType(EpollDomainSocketChannel.class)
+                    .usePlaintext()
+                    .build();
+        }
+
+        // build a TCP socket
+        try {
+            final NettyChannelBuilder builder = NettyChannelBuilder.forAddress(options.getHost(), options.getPort());
+            if (options.isTls()) {
+                SslContextBuilder sslContext = GrpcSslContexts.forClient();
+
+                if (options.getCertPath() != null) {
+                    final File file = new File(options.getCertPath());
+                    if (file.exists()) {
+                        sslContext.trustManager(file);
+                    }
+                }
+
+                builder.sslContext(sslContext.build());
+            } else {
+                builder.usePlaintext();
+            }
+
+            // telemetry interceptor if option is provided
+            if (options.getTelemetrySdk() != null) {
+                builder.intercept(new FlagdGrpcInterceptor(options.getTelemetrySdk()));
+            }
+
+            return builder.build();
+        } catch (SSLException ssle) {
+            SslConfigException sslConfigException = new SslConfigException("Error with SSL configuration.");
+            sslConfigException.initCause(ssle);
+            throw sslConfigException;
+        }
+    }
+
+    /**
+     * Intended to be removed along with multi-option constructors.
+     * */
+    @Deprecated
     private static ServiceBlockingStub buildServiceBlockingStub(String host, Integer port, Boolean tls, String certPath,
             String socketPath) {
         return ServiceGrpc.newBlockingStub(channelBuilder(host, port, tls, certPath, socketPath).build());
     }
 
-    private static ServiceBlockingStub buildServiceBlockingStub(OpenTelemetry telemetry) {
-        return ServiceGrpc
-                .newBlockingStub(channelBuilder(null, null, null, null, null)
-                        .intercept(new FlagdGrpcInterceptor(telemetry)).build());
-    }
-
+    /**
+     * Intended to be removed along with multi-option constructors.
+     * */
+    @Deprecated
     private static ServiceStub buildServiceStub(String host, Integer port, Boolean tls, String certPath,
             String socketPath) {
         return ServiceGrpc.newStub(channelBuilder(host, port, tls, certPath, socketPath).build());
-    }
-
-    private static String fallBackToEnvOrDefault(String key, String defaultValue) {
-        return System.getenv(key) != null ? System.getenv(key) : defaultValue;
-    }
-
-    private static int fallBackToEnvOrDefault(String key, int defaultValue) {
-        try {
-            int value = System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
-            return value;
-        } catch (Exception e) {
-            return defaultValue;
-        }
     }
 
     private void handleEvents() {
@@ -504,24 +552,6 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         this.serviceStub.eventStream(EventStreamRequest.getDefaultInstance(), responseObserver);
     }
 
-    @Override
-    public void setEventStreamAlive(Boolean alive) {
-        Lock l = this.lock.writeLock();
-        try {
-            l.lock();
-            this.eventStreamAlive = alive;
-            if (alive) {
-                synchronized (this.eventStreamAliveSync) {
-                    this.eventStreamAliveSync.notify(); // notify any waiters that the event stream is alive
-                }
-                // reset attempts on successful connection
-                this.eventStreamAttempt = 1;
-                this.eventStreamRetryBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
-            }
-        } finally {
-            l.unlock();
-        }
-    }
 
     private <T> Boolean isEvaluationCacheable(ProviderEvaluation<T> evaluation) {
         String reason = evaluation.getReason();
@@ -538,8 +568,10 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         return available;
     }
 
-    // a generic resolve method that takes a resolverRef and an optional converter lambda to transform the result
-    private <ValT extends Object, ReqT extends Message, ResT extends Message> ProviderEvaluation<ValT> resolve(
+    /**
+     * A generic resolve method that takes a resolverRef and an optional converter lambda to transform the result.
+     * */
+    private <ValT, ReqT extends Message, ResT extends Message> ProviderEvaluation<ValT> resolve(
             String key, EvaluationContext ctx, ReqT request, Function<ReqT, ResT> resolverRef,
             Convert<ValT, Object> converter) {
 
@@ -554,35 +586,20 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
 
         // build the gRPC request
         Message req = request.newBuilderForType()
-                .setField(this.getFieldDescriptor(request, FLAG_KEY_FIELD), (Object) key)
-                .setField(this.getFieldDescriptor(request, CONTEXT_FIELD), this.convertContext(ctx))
+                .setField(getFieldDescriptor(request, FLAG_KEY_FIELD), key)
+                .setField(getFieldDescriptor(request, CONTEXT_FIELD), this.convertContext(ctx))
                 .build();
 
         // run the referenced resolver method
-        final ResT response;
-
-        if (tracer != null) {
-            final Span span = tracer.spanBuilder("resolve")
-                    .setSpanKind(SpanKind.CLIENT)
-                    .startSpan();
-            span.setAttribute("feature_flag.key", key);
-            span.setAttribute("feature_flag.provider_name", "flagd");
-            try (Scope scope = span.makeCurrent()) {
-                response = resolverRef.apply((ReqT) req);
-            } finally {
-                span.end();
-            }
-        } else {
-            response = resolverRef.apply((ReqT) req);
-        }
+        Message response = strategy.resolve(resolverRef, req, key);
 
         // parse the response
-        ValT value = converter == null ? this.getField(response, VALUE_FIELD)
-                : converter.convert(this.getField(response, VALUE_FIELD));
-        ProviderEvaluation<ValT> result = (ProviderEvaluation<ValT>) ProviderEvaluation.<ValT>builder()
+        ValT value = converter == null ? getField(response, VALUE_FIELD)
+                : converter.convert(getField(response, VALUE_FIELD));
+        ProviderEvaluation<ValT> result = ProviderEvaluation.<ValT>builder()
                 .value(value)
-                .variant(this.getField(response, VARIANT_FIELD))
-                .reason(this.getField(response, REASON_FIELD))
+                .variant(getField(response, VARIANT_FIELD))
+                .reason(getField(response, REASON_FIELD))
                 .build();
 
         // cache if cache enabled
@@ -590,18 +607,20 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
             this.cache.put(key, result);
         }
 
-        return (ProviderEvaluation<ValT>) result;
+        return result;
     }
 
-    private <T> T getField(Message message, String name) {
-        return (T) message.getField(this.getFieldDescriptor(message, name));
+    private static  <T> T getField(Message message, String name) {
+        return (T) message.getField(getFieldDescriptor(message, name));
     }
 
-    private FieldDescriptor getFieldDescriptor(Message message, String name) {
+    private static FieldDescriptor getFieldDescriptor(Message message, String name) {
         return message.getDescriptorForType().findFieldByName(name);
     }
 
-    // a converter lambda
+    /**
+     * A converter lambda.
+     * */
     @FunctionalInterface
     private interface Convert<OutT extends Object, InT extends Object> {
         OutT convert(InT value);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -105,9 +105,9 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         final ManagedChannel channel = nettyChannel(options);
         this.serviceStub = ServiceGrpc.newStub(channel);
         this.serviceBlockingStub = ServiceGrpc.newBlockingStub(channel);
-        this.strategy = options.getTelemetrySdk() == null
+        this.strategy = options.getOpenTelemetry() == null
                 ? new SimpleResolving()
-                : new TracedResolving(options.getTelemetrySdk());
+                : new TracedResolving(options.getOpenTelemetry());
 
         this.maxEventStreamRetries = options.getMaxEventStreamRetries();
         this.cache = new FlagdCache(options.getCacheType(), options.getMaxCacheSize());
@@ -517,8 +517,8 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
             }
 
             // telemetry interceptor if option is provided
-            if (options.getTelemetrySdk() != null) {
-                builder.intercept(new FlagdGrpcInterceptor(options.getTelemetrySdk()));
+            if (options.getOpenTelemetry() != null) {
+                builder.intercept(new FlagdGrpcInterceptor(options.getOpenTelemetry()));
             }
 
             return builder.build();

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -186,6 +186,10 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
                 fallBackToEnvOrDefault(MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, DEFAULT_MAX_EVENT_STREAM_RETRIES));
     }
 
+
+    /**
+     * Create a new FlagdProvider instance with manual telemetry sdk.
+     */
     public FlagdProvider(OpenTelemetrySdk telemetrySdk) {
         this(
                 buildServiceBlockingStub(telemetrySdk),
@@ -557,7 +561,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
         // run the referenced resolver method
         final ResT response;
 
-        if (tracer != null){
+        if (tracer != null) {
             final Span span = tracer.spanBuilder("resolve")
                     .setSpanKind(SpanKind.CLIENT)
                     .startSpan();
@@ -567,7 +571,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
             } finally {
                 span.end();
             }
-        }else {
+        } else {
             response = resolverRef.apply((ReqT) req);
         }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -566,6 +566,7 @@ public class FlagdProvider implements FeatureProvider, EventStreamCallback {
                     .setSpanKind(SpanKind.CLIENT)
                     .startSpan();
             span.setAttribute("feature_flag.key", key);
+            span.setAttribute("feature_flag.provider_name", "flagd");
             try (Scope scope = span.makeCurrent()) {
                 response = resolverRef.apply((ReqT) req);
             } finally {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/ResolveStrategy.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/ResolveStrategy.java
@@ -1,0 +1,13 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import com.google.protobuf.Message;
+
+import java.util.function.Function;
+
+/**
+ * Request to Response resolving strategy.
+ * */
+public interface ResolveStrategy {
+    <ReqT extends Message, ResT extends Message> ResT resolve(final Function<ReqT, ResT> resolverRef, final Message req,
+                                                              final String key);
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/ResolveStrategy.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/ResolveStrategy.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 /**
  * Request to Response resolving strategy.
  * */
-public interface ResolveStrategy {
+interface ResolveStrategy {
     <ReqT extends Message, ResT extends Message> ResT resolve(final Function<ReqT, ResT> resolverRef, final Message req,
                                                               final String key);
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/SimpleResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/SimpleResolving.java
@@ -1,0 +1,17 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import com.google.protobuf.Message;
+
+import java.util.function.Function;
+
+/**
+ * {@link SimpleResolving} is a simple request to response resolver.
+ */
+public class SimpleResolving implements ResolveStrategy {
+
+    @Override
+    public <ReqT extends Message, ResT extends Message> ResT resolve(final Function<ReqT, ResT> resolverRef,
+                                                                     final Message req, final String key) {
+        return resolverRef.apply((ReqT) req);
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/SimpleResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/SimpleResolving.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 /**
  * {@link SimpleResolving} is a simple request to response resolver.
  */
-public class SimpleResolving implements ResolveStrategy {
+class SimpleResolving implements ResolveStrategy {
 
     @Override
     public <ReqT extends Message, ResT extends Message> ResT resolve(final Function<ReqT, ResT> resolverRef,

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 /**
  * {@link TracedResolving} a request to response resolver with tracing for telemetry.
  */
-public class TracedResolving implements ResolveStrategy {
+class TracedResolving implements ResolveStrategy {
 
     private final Tracer tracer;
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
@@ -7,6 +7,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 
+import javax.annotation.Nonnull;
 import java.util.function.Function;
 
 /**
@@ -16,7 +17,7 @@ public class TracedResolving implements ResolveStrategy {
 
     private final Tracer tracer;
 
-    TracedResolving(OpenTelemetry telemetry) {
+    TracedResolving(@Nonnull OpenTelemetry telemetry) {
         this.tracer = telemetry.getTracer("OpenFeature/dev.openfeature.contrib.providers.flagd");
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
@@ -1,0 +1,37 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import com.google.protobuf.Message;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+import java.util.function.Function;
+
+/**
+ * {@link TracedResolving} a request to response resolver with tracing for telemetry.
+ */
+public class TracedResolving implements ResolveStrategy {
+
+    private final Tracer tracer;
+
+    TracedResolving(OpenTelemetrySdk sdk) {
+        this.tracer = sdk.getTracer("OpenFeature/dev.openfeature.contrib.providers.flagd");
+    }
+
+    @Override
+    public <ReqT extends Message, ResT extends Message> ResT resolve(final Function<ReqT, ResT> resolverRef,
+                                                                     final Message req, final String key) {
+
+        final Span span = tracer.spanBuilder("resolve").setSpanKind(SpanKind.CLIENT).startSpan();
+        span.setAttribute("feature_flag.key", key);
+        span.setAttribute("feature_flag.provider_name", "flagd");
+
+        try (Scope scope = span.makeCurrent()) {
+            return resolverRef.apply((ReqT) req);
+        } finally {
+            span.end();
+        }
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/TracedResolving.java
@@ -1,11 +1,11 @@
 package dev.openfeature.contrib.providers.flagd;
 
 import com.google.protobuf.Message;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 import java.util.function.Function;
 
@@ -16,8 +16,8 @@ public class TracedResolving implements ResolveStrategy {
 
     private final Tracer tracer;
 
-    TracedResolving(OpenTelemetrySdk sdk) {
-        this.tracer = sdk.getTracer("OpenFeature/dev.openfeature.contrib.providers.flagd");
+    TracedResolving(OpenTelemetry telemetry) {
+        this.tracer = telemetry.getTracer("OpenFeature/dev.openfeature.contrib.providers.flagd");
     }
 
     @Override

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagProviderBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagProviderBuilderTest.java
@@ -1,0 +1,30 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_CACHE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_HOST;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_CACHE_SIZE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_EVENT_STREAM_RETRIES;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_PORT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class FlagProviderBuilderTest {
+
+    @Test
+    public void TestDefaults() {
+        final FlagdOptions builder = FlagdOptions.builder().build();
+
+        assertEquals(builder.getHost(),DEFAULT_HOST );
+        assertEquals(Integer.toString(builder.getPort()),DEFAULT_PORT );
+        assertFalse(builder.isTls());
+        assertNull(builder.getCertPath());
+        assertNull(builder.getSocketPath());
+        assertEquals(builder.getCacheType(),DEFAULT_CACHE );
+        assertEquals(builder.getMaxCacheSize(), DEFAULT_MAX_CACHE_SIZE);
+        assertEquals(builder.getMaxEventStreamRetries(), DEFAULT_MAX_EVENT_STREAM_RETRIES);
+        assertNull(builder.getTelemetrySdk());
+    }
+}

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagProviderBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagProviderBuilderTest.java
@@ -25,6 +25,6 @@ public class FlagProviderBuilderTest {
         assertEquals(builder.getCacheType(),DEFAULT_CACHE );
         assertEquals(builder.getMaxCacheSize(), DEFAULT_MAX_CACHE_SIZE);
         assertEquals(builder.getMaxEventStreamRetries(), DEFAULT_MAX_EVENT_STREAM_RETRIES);
-        assertNull(builder.getTelemetrySdk());
+        assertNull(builder.getOpenTelemetry());
     }
 }


### PR DESCRIPTION
A follow-up of #286
___

## This PR

Is a refactoring for flagd provider constructor. Current constructors are difficult to maintain and with more options, we run into complexity of breaking the construction contract. Plus, mix & match of args becomes difficult (reason for #286 to have a simple constructor to get feature done)

This PR introduces a builder. The builder builds argument options with built-in default derivations (instead of relying on nulls constructor args).

Example,

```java
FlagdProvider flagdProvider =
        new FlagdProvider(FlagdOptions.builder()
                            .host("localhost")
                            .port(8023)
                            .openTelemetry(openTelemetry).build());
```

Along with the changes, I am deprecating `old` constructors. We shall aim to keep them as `@Deprecated` for next release. And then, we shall remove them from the release after. 

Follow-up efforts - unit tests and improvements on testing 