### PR TITLE
feat: otel hook improvements

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -50,4 +50,4 @@ Consider following code example for usage,
 
 Options can be provided through `OpenTelemetryHookOptions` based constructor.
 
-- setErrorStatus: Control Span error status. Default is true - Span status is set to Error if an error occurs.
+- setErrorStatus: Control Span error status. Default is false - Span status is unchanged for hook error.

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -21,8 +21,33 @@ enabling enhanced observability use cases, such as A/B testing or progressive fe
 
 OpenFeature provider various ways to register hooks. The location that a hook is registered affects when the hook is
 run. It's recommended to register the `OpenTelemetryHook` globally in most situations, but it's possible to only enable
-the hook on specific clients. You should **never** register the `OpenTelemetryHook` globally and on a client.
+the hook on specific clients. You should **never** register the `OpenTelemetryHook` both globally and on a client.
 
+Consider following code example for usage,
+
+```java
+    final Tracer tracer = ... // derive Tracer from OpenTelemetry
+    
+    // Set OpenTelemetry hook globally
+    OpenFeatureAPI.getInstance().addHooks(new OpenTelemetryHook());
+
+    // OpenFeature client
+    final Client client = api.getClient();    
+     
+    // Derive span from OTEL tracer
+    Span span = tracer.spanBuilder("boolEvalLogic").startSpan();
+    
+    // flag evaluation - Hook's span is derived from current context
+    try(Scope ignored =  span.makeCurrent()) {
+        final Boolean boolEval = client.getBooleanValue(FLAG_KEY, false);
+    } finally {
+        span.end();
+    }
 ```
-     OpenFeatureAPI.getInstance().addHooks(new OpenTelemetryHook());
-```
+
+
+### Options
+
+Options can be provided through `OpenTelemetryHookOptions` based constructor.
+
+- setErrorStatus: Control Span error status. Default is true - Span status is set to Error if an error occurs.

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -50,4 +50,4 @@ Consider following code example for usage,
 
 Options can be provided through `OpenTelemetryHookOptions` based constructor.
 
-- setErrorStatus: Control Span error status. Default is false - Span status is unchanged for hook error.
+- setErrorStatus: Control Span error status. Default is false - Span status is unchanged for flag evaluation error.

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHook.java
@@ -6,64 +6,80 @@ import dev.openfeature.sdk.HookContext;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 
 import java.util.Map;
 
 /**
- * The OpenTelemetry hook  provides a way to automatically add a feature flag evaluation to a span as a span event.
+ * The OpenTelemetry hook provides a way to automatically add a feature flag evaluation to a span as a span event.
  * Refer to <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/feature-flags.md">OpenTelemetry</a>
  */
 public class OpenTelemetryHook implements Hook {
 
     private static final String EVENT_NAME = "feature_flag";
 
+    private final boolean setErrorStatus;
+
     private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".flag_key");
-
     private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".provider_name");
-
     private final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".variant");
 
     /**
-     * Create a new OpenTelemetryHook instance.
+     * Create a new OpenTelemetryHook instance with default options.
      */
     public OpenTelemetryHook() {
+        this(OpenTelemetryHookOptions.builder().build());
     }
 
     /**
-     * Records the event in the current span after the successful flag evaluation.
+     * Create a new OpenTelemetryHook instance with options.
+     */
+    public OpenTelemetryHook(OpenTelemetryHookOptions options) {
+        setErrorStatus = options.isSetErrorStatus();
+    }
+
+    /**
+     * Records the event in the current span after the successful flag evaluation. Span is derived from the current
+     * context. Refer OpenTelemetry documentation on nested spans for more details -
+     * <a href="https://opentelemetry.io/docs/instrumentation/java/manual/#create-nested-spans">Nested Spans</a>
      *
      * @param ctx     Information about the particular flag evaluation
      * @param details Information about how the flag was resolved, including any resolved values.
      * @param hints   An immutable mapping of data for users to communicate to the hooks.
      */
-    @Override
-    public void after(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+    @Override public void after(HookContext ctx, FlagEvaluationDetails details, Map hints) {
         Span currentSpan = Span.current();
-        if (currentSpan != null) {
-            String variant = details.getVariant() != null ? details.getVariant() : String.valueOf(details.getValue());
-            Attributes attributes = Attributes.of(
-                    flagKeyAttributeKey, ctx.getFlagKey(),
-                    providerNameAttributeKey, ctx.getProviderMetadata().getName(),
-                    variantAttributeKey, variant);
-            currentSpan.addEvent(EVENT_NAME, attributes);
+        if (currentSpan == null) {
+            return;
         }
+
+        String variant = details.getVariant() != null ? details.getVariant() : String.valueOf(details.getValue());
+        Attributes attributes = Attributes.of(flagKeyAttributeKey, ctx.getFlagKey(), providerNameAttributeKey,
+                ctx.getProviderMetadata().getName(), variantAttributeKey, variant);
+        currentSpan.addEvent(EVENT_NAME, attributes);
     }
 
     /**
-     * Records the error details in the current span after the flag evaluation has processed abnormally.
+     * Records the error details in the current span after the flag evaluation has processed abnormally. Span is derived
+     * from the current context. Refer OpenTelemetry documentation on nested spans for more details -
+     * <a href="https://opentelemetry.io/docs/instrumentation/java/manual/#create-nested-spans">Nested Spans</a>
      *
      * @param ctx   Information about the particular flag evaluation
      * @param error The exception that was thrown.
      * @param hints An immutable mapping of data for users to communicate to the hooks.
      */
-    @Override
-    public void error(HookContext ctx, Exception error, Map hints) {
+    @Override public void error(HookContext ctx, Exception error, Map hints) {
         Span currentSpan = Span.current();
-        if (currentSpan != null) {
-            Attributes attributes = Attributes.of(
-                    flagKeyAttributeKey, ctx.getFlagKey(),
-                    providerNameAttributeKey, ctx.getProviderMetadata().getName());
-            currentSpan.recordException(error, attributes);
+        if (currentSpan == null) {
+            return;
         }
+
+        if (setErrorStatus) {
+            currentSpan.setStatus(StatusCode.ERROR);
+        }
+
+        Attributes attributes = Attributes.of(flagKeyAttributeKey, ctx.getFlagKey(), providerNameAttributeKey,
+                ctx.getProviderMetadata().getName());
+        currentSpan.recordException(error, attributes);
     }
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHook.java
@@ -18,7 +18,7 @@ public class OpenTelemetryHook implements Hook {
 
     private static final String EVENT_NAME = "feature_flag";
 
-    private final boolean setErrorStatus;
+    private final boolean setSpanErrorStatus;
 
     private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".flag_key");
     private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".provider_name");
@@ -35,7 +35,7 @@ public class OpenTelemetryHook implements Hook {
      * Create a new OpenTelemetryHook instance with options.
      */
     public OpenTelemetryHook(OpenTelemetryHookOptions options) {
-        setErrorStatus = options.isSetErrorStatus();
+        setSpanErrorStatus = options.isSetSpanErrorStatus();
     }
 
     /**
@@ -74,7 +74,7 @@ public class OpenTelemetryHook implements Hook {
             return;
         }
 
-        if (setErrorStatus) {
+        if (setSpanErrorStatus) {
             currentSpan.setStatus(StatusCode.ERROR);
         }
 

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
@@ -11,8 +11,8 @@ import lombok.Getter;
 public class OpenTelemetryHookOptions {
 
     /**
-     * Control Span error status. Default is true - Span status is set to Error if an error occurs.
+     * Control Span error status. Default is false - Span status is unchanged for hook error
      */
     @Builder.Default
-    private boolean setErrorStatus = true;
+    private boolean setErrorStatus = false;
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
@@ -14,5 +14,5 @@ public class OpenTelemetryHookOptions {
      * Control Span error status. Default is false - Span status is unchanged for hook error
      */
     @Builder.Default
-    private boolean setErrorStatus = false;
+    private boolean setSpanErrorStatus = false;
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookOptions.java
@@ -1,0 +1,18 @@
+package dev.openfeature.contrib.hooks.otel;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * OpenTelemetry hook options.
+ */
+@Builder
+@Getter
+public class OpenTelemetryHookOptions {
+
+    /**
+     * Control Span error status. Default is true - Span status is set to Error if an error occurs.
+     */
+    @Builder.Default
+    private boolean setErrorStatus = true;
+}

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
@@ -7,7 +7,6 @@ import dev.openfeature.sdk.MutableContext;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +17,6 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -126,6 +124,7 @@ class OpenTelemetryHookTest {
                 providerNameAttributeKey, "test provider");
 
         verify(span).recordException(runtimeException, expectedAttr);
+        verify(span, times(0)).setStatus(any());
     }
 
     @Test
@@ -137,7 +136,7 @@ class OpenTelemetryHookTest {
         OpenTelemetryHook openTelemetryHook =
                 new OpenTelemetryHook(OpenTelemetryHookOptions
                         .builder()
-                        .setErrorStatus(true)
+                        .setSpanErrorStatus(true)
                         .build());
         openTelemetryHook.error(hookContext, runtimeException, null);
 

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
@@ -7,6 +7,7 @@ import dev.openfeature.sdk.MutableContext;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -14,40 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.mockito.internal.matchers.Any;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class OpenTelemetryHookTest {
-
-    private OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
-
-    private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey("feature_flag.flag_key");
-
-    private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey("feature_flag.provider_name");
-
-    private final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey("feature_flag.variant");
-
     private static MockedStatic<Span> mockedSpan;
-
-    @Mock private Span span;
-
-    private HookContext<String> hookContext = HookContext.<String>builder()
-            .flagKey("test_key")
-            .type(FlagValueType.STRING)
-            .providerMetadata(() -> "test provider")
-            .ctx(new MutableContext())
-            .defaultValue("default")
-            .build();
 
     @BeforeAll
     public static void init() {
@@ -59,6 +38,21 @@ class OpenTelemetryHookTest {
         mockedSpan.close();
     }
 
+    private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey("feature_flag.flag_key");
+    private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey("feature_flag.provider_name");
+    private final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey("feature_flag.variant");
+
+    private final HookContext<String> hookContext = HookContext.<String>builder()
+            .flagKey("test_key")
+            .type(FlagValueType.STRING)
+            .providerMetadata(() -> "test provider")
+            .ctx(new MutableContext())
+            .defaultValue("default")
+            .build();
+
+    @Mock
+    private Span span;
+
     @Test
     @DisplayName("should add an event in span during after method execution")
     void should_add_event_in_span_during_after_method_execution() {
@@ -67,10 +61,14 @@ class OpenTelemetryHookTest {
                 .value("variant_value")
                 .build();
         mockedSpan.when(Span::current).thenReturn(span);
+
+        OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
         openTelemetryHook.after(hookContext, details, null);
+
         Attributes expectedAttr = Attributes.of(flagKeyAttributeKey, "test_key",
                 providerNameAttributeKey, "test provider",
                 variantAttributeKey, "test_variant");
+
         verify(span).addEvent("feature_flag", expectedAttr);
     }
 
@@ -81,10 +79,15 @@ class OpenTelemetryHookTest {
                 .value("variant_value")
                 .build();
         mockedSpan.when(Span::current).thenReturn(span);
+
+
+        OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
         openTelemetryHook.after(hookContext, details, null);
+
         Attributes expectedAttr = Attributes.of(flagKeyAttributeKey, "test_key",
                 providerNameAttributeKey, "test provider",
                 variantAttributeKey, "variant_value");
+
         verify(span).addEvent("feature_flag", expectedAttr);
     }
 
@@ -103,19 +106,47 @@ class OpenTelemetryHookTest {
                 .value("variant_value")
                 .build();
         mockedSpan.when(Span::current).thenReturn(null);
+
+        OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
         openTelemetryHook.after(hookContext, details, null);
+
         verifyNoInteractions(span);
     }
 
     @Test
-    @DisplayName("should record an exception in span during error method execution")
-    void should_record_exception_in_span_during_error_method_execution() {
+    @DisplayName("should record an exception and set error status in span during error method execution")
+    void should_record_exception_and_status_in_span_during_error_method_execution() {
         RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
         mockedSpan.when(Span::current).thenReturn(span);
+
+        OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
         openTelemetryHook.error(hookContext, runtimeException, null);
+
         Attributes expectedAttr = Attributes.of(flagKeyAttributeKey, "test_key",
                 providerNameAttributeKey, "test provider");
+
         verify(span).recordException(runtimeException, expectedAttr);
+        verify(span).setStatus(StatusCode.ERROR);
+    }
+
+    @Test
+    @DisplayName("span error status must not be set if overridden by option")
+    void should_record_exception_but_not_status_in_span_with_options() {
+        RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
+        mockedSpan.when(Span::current).thenReturn(span);
+
+        OpenTelemetryHook openTelemetryHook =
+                new OpenTelemetryHook(OpenTelemetryHookOptions
+                        .builder()
+                        .setErrorStatus(false)
+                        .build());
+        openTelemetryHook.error(hookContext, runtimeException, null);
+
+        Attributes expectedAttr = Attributes.of(flagKeyAttributeKey, "test_key",
+                providerNameAttributeKey, "test provider");
+
+        verify(span).recordException(runtimeException, expectedAttr);
+        verify(span, times(0)).setStatus(any());
     }
 
     @Test
@@ -123,7 +154,10 @@ class OpenTelemetryHookTest {
     void should_not_call_record_exception_when_no_active_span() {
         RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
         mockedSpan.when(Span::current).thenReturn(null);
+
+        OpenTelemetryHook openTelemetryHook = new OpenTelemetryHook();
         openTelemetryHook.error(hookContext, runtimeException, null);
+
         verifyNoInteractions(span);
     }
 

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/OpenTelemetryHookTest.java
@@ -114,7 +114,7 @@ class OpenTelemetryHookTest {
     }
 
     @Test
-    @DisplayName("should record an exception and set error status in span during error method execution")
+    @DisplayName("should record an exception and avoid status changes in span during error method execution")
     void should_record_exception_and_status_in_span_during_error_method_execution() {
         RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
         mockedSpan.when(Span::current).thenReturn(span);
@@ -126,11 +126,10 @@ class OpenTelemetryHookTest {
                 providerNameAttributeKey, "test provider");
 
         verify(span).recordException(runtimeException, expectedAttr);
-        verify(span).setStatus(StatusCode.ERROR);
     }
 
     @Test
-    @DisplayName("span error status must not be set if overridden by option")
+    @DisplayName("span error status must be set if overridden by option")
     void should_record_exception_but_not_status_in_span_with_options() {
         RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
         mockedSpan.when(Span::current).thenReturn(span);
@@ -138,7 +137,7 @@ class OpenTelemetryHookTest {
         OpenTelemetryHook openTelemetryHook =
                 new OpenTelemetryHook(OpenTelemetryHookOptions
                         .builder()
-                        .setErrorStatus(false)
+                        .setErrorStatus(true)
                         .build());
         openTelemetryHook.error(hookContext, runtimeException, null);
 
@@ -146,7 +145,7 @@ class OpenTelemetryHookTest {
                 providerNameAttributeKey, "test provider");
 
         verify(span).recordException(runtimeException, expectedAttr);
-        verify(span, times(0)).setStatus(any());
+        verify(span, times(1)).setStatus(any());
     }
 
     @Test


### PR DESCRIPTION
## This PR

Fixes #311 

Span error status is set based on configurations. Further, this can be overridden through `OpenTelemetryHookOptions`

Added tests to cover the new logic. Improved code level docs & README 