### PR TITLE
chore: add component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,0 +1,24 @@
+# Keep all in alphabetical order
+components:
+  hooks/open-telemetry:
+    - beeme1mr
+    - Kavindu-Dodan
+    - thiyagu06
+    - toddbaert
+  providers/env-var:
+    - madhead
+    - toddbaert
+  providers/flagd:
+    - beeme1mr
+    - Kavindu-Dodan
+    - toddbaert
+  providers/flagsmith:
+    - ajhelsby
+    - matthewelwell
+  providers/go-feature-flag:
+    - thomaspoignant
+  providers/jsonlogic-eval-provider:
+    - justinabrahms
+
+ignored-authors:
+  - renovate-bot

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,0 +1,18 @@
+name: 'Component Owners'
+on:
+  pull_request_target:
+
+permissions:
+  contents: read          # to read changed files
+  issues: write           # to read/write issue assignees
+  pull-requests: write    # to read/write PR reviewers
+
+jobs:
+  run_self:
+    runs-on: ubuntu-latest
+    name: Auto Assign Owners
+    steps:
+      - uses: dyladan/component-owners@95fcb98c201ff5a41f6b9df38caad4bf9bf4ef02
+        with:
+          config-file: .github/component_owners.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- adds component owners, which are added as assignees/reviewers when the file path in question is modified in a PR.