### PR TITLE
fix: otel hook attribute naming correction

### DIFF
--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -47,6 +47,13 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.28.0-alpha</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
         <dependency>

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OTelCommons.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OTelCommons.java
@@ -1,14 +1,16 @@
 package dev.openfeature.contrib.hooks.otel;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 class OTelCommons {
     // Define semantic conventions
     // Refer - https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/
     static final String EVENT_NAME = "feature_flag";
-    static final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".flag_key");
-    static final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".provider_name");
-    static final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey(EVENT_NAME + ".variant");
+
+    static final AttributeKey<String> flagKeyAttributeKey = SemanticAttributes.FEATURE_FLAG_KEY;
+    static final AttributeKey<String> providerNameAttributeKey = SemanticAttributes.FEATURE_FLAG_PROVIDER_NAME;
+    static final AttributeKey<String> variantAttributeKey = SemanticAttributes.FEATURE_FLAG_VARIANT;
 
     // Define non convention attribute keys
     static final String REASON_KEY = "reason";

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
@@ -36,7 +36,7 @@ class TracesHookTest {
         mockedSpan.close();
     }
 
-    private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey("feature_flag.flag_key");
+    private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey("feature_flag.key");
     private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey("feature_flag.provider_name");
     private final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey("feature_flag.variant");
 


### PR DESCRIPTION
## This PR

Corrects telemetry attribute key from `feature_flag.flag_key` to `feature_flag.key`. This is to match the naming with OTel semconv for feature falgs [1]


[1] - https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/ 