### PR TITLE
ISSUE-658 go-feature-flag sdk - add provider cache and publish data collector events

### DIFF
--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -23,6 +23,11 @@
             <organization>go-feature-flag</organization>
             <url>https://gofeatureflag.org</url>
         </developer>
+        <developer>
+            <id>liran2000</id>
+            <name>Liran Mendeovich</name>
+            <url>https://liran2000.github.io</url>
+        </developer>
     </developers>
 
     <dependencies>
@@ -49,6 +54,12 @@
             <artifactId>mockwebserver</artifactId>
             <version>4.11.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.1-jre</version>
         </dependency>
     </dependencies>
 </project>

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -23,11 +23,6 @@
             <organization>go-feature-flag</organization>
             <url>https://gofeatureflag.org</url>
         </developer>
-        <developer>
-            <id>liran2000</id>
-            <name>Liran Mendeovich</name>
-            <url>https://liran2000.github.io</url>
-        </developer>
     </developers>
 
     <dependencies>
@@ -61,5 +56,18 @@
             <artifactId>guava</artifactId>
             <version>32.1.1-jre</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -43,6 +43,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -58,9 +59,11 @@ public class GoFeatureFlagProvider implements FeatureProvider {
     private static final ObjectMapper requestMapper = new ObjectMapper();
     private static final ObjectMapper responseMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    public static final int DEFAULT_CONCURRENCY_LEVEL = 1;
-    public static final int DEFAULT_INITIAL_CAPACITY = 100;
-    public static final int DEFAULT_MAXIMUM_SIZE = 1000;
+
+    public static final int DEFAULT_CACHE_TTL_MINUTES = 10;
+    public static final int DEFAULT_CACHE_CONCURRENCY_LEVEL = 1;
+    public static final int DEFAULT_CACHE_INITIAL_CAPACITY = 100;
+    public static final int DEFAULT_CACHE_MAXIMUM_SIZE = 1000;
     protected static final String CACHED_REASON = Reason.CACHED.name();
     protected static final String REASON_SEPARATOR = ", ";
     private HttpUrl parsedEndpoint;
@@ -142,8 +145,9 @@ public class GoFeatureFlagProvider implements FeatureProvider {
 
     private Cache buildDefaultCache() {
         return CacheBuilder.newBuilder()
-            .concurrencyLevel(DEFAULT_CONCURRENCY_LEVEL)
-            .initialCapacity(DEFAULT_INITIAL_CAPACITY).maximumSize(DEFAULT_MAXIMUM_SIZE)
+            .concurrencyLevel(DEFAULT_CACHE_CONCURRENCY_LEVEL)
+            .initialCapacity(DEFAULT_CACHE_INITIAL_CAPACITY).maximumSize(DEFAULT_CACHE_MAXIMUM_SIZE)
+            .refreshAfterWrite(Duration.ofMinutes(DEFAULT_CACHE_TTL_MINUTES))
             .build();
     }
 

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -1,5 +1,7 @@
 package dev.openfeature.contrib.providers.gofeatureflag;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -48,4 +50,19 @@ public class GoFeatureFlagProviderOptions {
      */
     @Getter
     private String apiKey;
+
+    /**
+     *  (optional) If cache custom configuration is wanted, you should provide
+     *  a cache builder.
+     *  Default: null
+     */
+    @Getter
+    private CacheBuilder cacheBuilder;
+
+    /**
+     * (optional) enable cache value
+     * Default: true
+     */
+    @Getter
+    private Boolean enableCache;
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -9,13 +9,13 @@ import lombok.Getter;
  * GoFeatureFlagProviderOptions contains the options to initialise the provider.
  */
 @Builder
+@Getter
 public class GoFeatureFlagProviderOptions {
 
     /**
      * (mandatory) endpoint contains the DNS of your GO Feature Flag relay proxy
      * example: https://mydomain.com/gofeatureflagproxy/
      */
-    @Getter
     private String endpoint;
 
     /**
@@ -23,7 +23,6 @@ public class GoFeatureFlagProviderOptions {
      * go-feature-flag relay proxy API.
      * Default: 10000 ms
      */
-    @Getter
     private int timeout;
 
 
@@ -31,14 +30,12 @@ public class GoFeatureFlagProviderOptions {
      * (optional) maxIdleConnections is the maximum number of connexions in the connexion pool.
      * Default: 1000
      */
-    @Getter
     private int maxIdleConnections;
 
     /**
      * (optional) keepAliveDuration is the time in millisecond we keep the connexion open.
      * Default: 7200000 (2 hours)
      */
-    @Getter
     private Long keepAliveDuration;
 
     /**
@@ -48,7 +45,6 @@ public class GoFeatureFlagProviderOptions {
      *  (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
      *  Default: null
      */
-    @Getter
     private String apiKey;
 
     /**
@@ -56,13 +52,19 @@ public class GoFeatureFlagProviderOptions {
      *  a cache builder.
      *  Default: null
      */
-    @Getter
     private CacheBuilder cacheBuilder;
 
     /**
      * (optional) enable cache value
      * Default: true
      */
-    @Getter
     private Boolean enableCache;
+
+    /**
+     * (optional) interval time we publish statistics collection data to the proxy.
+     * 	The parameter is used only if the cache is enabled, otherwise the collection of the data is done directly
+     * 	when calling the evaluation API.
+     * 	default: 1 minute
+     */
+    private Long flushIntervalMinues;
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/bean/BeanUtils.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/bean/BeanUtils.java
@@ -1,0 +1,20 @@
+package dev.openfeature.contrib.providers.gofeatureflag.bean;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Bean utils.
+ */
+public class BeanUtils {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    private BeanUtils() {
+
+    }
+
+    public static String buildKey(GoFeatureFlagUser goFeatureFlagUser) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(goFeatureFlagUser);
+    }
+}

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/Event.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/Event.java
@@ -1,0 +1,22 @@
+package dev.openfeature.contrib.providers.gofeatureflag.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class Event {
+    private String contextKind;
+    private Long creationDate;
+
+    @JsonProperty("default")
+    private Object defaultValue;
+
+    private String key;
+    private String kind;
+    private String userKey;
+    private Object value;
+    private String variation;
+    private String version;
+}

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/Events.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/Events.java
@@ -1,0 +1,19 @@
+package dev.openfeature.contrib.providers.gofeatureflag.events;
+
+import lombok.Getter;
+
+import java.util.*;
+
+@Getter
+public class Events {
+    private List<Event> events = new LinkedList<>();
+    private static Map<String, String> meta = new HashMap<>();
+    static {
+        meta.put("provider", "java");
+        meta.put("openfeature", "true");
+    }
+
+    public Events(List<Event> events) {
+        this.events = events;
+    }
+}

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/EventsPublisher.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/events/EventsPublisher.java
@@ -1,0 +1,73 @@
+package dev.openfeature.contrib.providers.gofeatureflag.events;
+
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+/**
+ * Events publisher
+ * @param <T> event type
+ *
+ * @author Liran Mendelovich
+ */
+@Slf4j
+public class EventsPublisher<T> {
+
+    private List<T> eventsList;
+    private Consumer<List<T>> publisher;
+    private long flushIntervalMinues;
+
+    private ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private Lock readLock = readWriteLock.readLock();
+    private Lock writeLock = readWriteLock.writeLock();
+
+    private ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
+
+    public EventsPublisher(Consumer<List<T>> publisher, long flushIntervalMinues) {
+        eventsList = new CopyOnWriteArrayList<>();
+        this.publisher = publisher;
+        this.flushIntervalMinues = flushIntervalMinues;
+        log.debug("Scheduling events publishing at fixed rate of {} minutes", flushIntervalMinues);
+        scheduledExecutorService.scheduleAtFixedRate(this::publish, flushIntervalMinues, flushIntervalMinues, TimeUnit.MINUTES);
+    }
+
+    public void add(T event) {
+        readLock.lock();
+        try {
+            eventsList.add(event);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * publish events
+     * @return count of publish events
+     */
+    public int publish() {
+        int publishedEvents = 0;
+        writeLock.lock();
+        try {
+            if (eventsList.isEmpty()) {
+                log.info("Not publishing, no events");
+            } else {
+                log.info("publishing {} events", eventsList.size());
+                publishedEvents = eventsList.size();
+                publisher.accept(new ArrayList<>(eventsList));
+                eventsList = new CopyOnWriteArrayList<>();
+            }
+        } catch (Exception e) {
+            log.error("Error publishing events", e);
+        } finally {
+            writeLock.unlock();
+            return publishedEvents;
+        }
+    }
+}

--- a/providers/go-feature-flag/src/test/resources/log4j2-test.xml
+++ b/providers/go-feature-flag/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="consoleLogger" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="consoleLogger"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## This PR
Implementing [issue 658](https://github.com/thomaspoignant/go-feature-flag/issues/658): (feature) Implement open-feature provider cache for the Java provider.

### Related Issues
 [issue 658](https://github.com/thomaspoignant/go-feature-flag/issues/658)

### Notes
<!-- any additional notes for this PR -->

### How to test
- Run unit tests.
- Can test via go-feature-flag instance, while observing logs, and checking collect data API requests.
