### PR TITLE
chore: fix failing tests

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -41,14 +41,14 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>1.57.0</version>
+            <version>1.57.1</version>
         </dependency>
 
         <dependency>
             <!-- we only support unix sockets on linux, via epoll native lib -->
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.96.Final</version>
+            <version>4.1.95.Final</version>
             <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
             <classifier>linux-x86_64</classifier>
         </dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>1.57.0</version>
+            <version>1.57.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## This PR

Noticed flagd class loading issues in tests after updating `netty-transport-native-epoll` to version `4.1.96.Final` [^1]

This PR downgrade the version to `4.1.95.Final` and update some of the dependencies.

Addendum 

The root cause was a change introduced with 4.1.96.Final release. Opened an issue to discuss with netty community on a possible fix - https://github.com/netty/netty/issues/13523 


[^1]: https://github.com/open-feature/java-sdk-contrib/pull/372