### PR TITLE
feat: hook builder options for dimension extraction

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -111,7 +111,7 @@ OpenFeatureAPI api = OpenFeatureAPI.getInstance();
 api.addHooks(new MetricsHook(openTelemetry, customDimensions));
 ```
 
-Alternatively, you can wrtie your own extraction logic against [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by providing a callback to `TracesHookOptions.dimensionExtractor`.
+Alternatively, you can wrtie your own extraction logic against [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by providing a callback to `TracesHookOptions.attributeSetter`.
 
 ```java
 final OpenTelemetry openTelemetry = ... // OpenTelemetry API instance

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -33,7 +33,22 @@ The hook implementation is attached to `after`and `error` [hook stages](https://
 Both successful and failed flag evaluations will add a span event named `feature_flag` with evaluation details such as flag key, provider name and variant.
 Failed evaluations can be allowed to set span status to `ERROR`. You can configure this behavior through`TracesHookOptions`.
 
-Consider the following code example for usage,
+Further, you can write your own logic to extract custom dimensions from [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by setting a callback to `TracesHookOptions.dimensionExtractor`.
+Extracted dimensions will be added to successful falg evaluation spans.
+
+```java
+ TracesHookOptions options = TracesHookOptions.builder()
+             // configure a callback
+            .dimensionExtractor(metadata -> Attributes.builder()
+                    .put("boolean", metadata.getBoolean("boolean"))
+                    .put("integer", metadata.getInteger("integer"))
+                    .build()
+            ).build();
+
+    TracesHook tracesHook = new TracesHook(options);
+```
+
+Consider the following code example for a complete usage,
 
 ```java
 final Tracer tracer=... // derive Tracer from OpenTelemetry
@@ -94,4 +109,20 @@ OpenFeatureAPI api = OpenFeatureAPI.getInstance();
 
 // Register MetricsHook with custom dimensions
 api.addHooks(new MetricsHook(openTelemetry, customDimensions));
+```
+
+Alternatively, you can wrtie your own extraction logic against [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by providing a callback to `TracesHookOptions.dimensionExtractor`.
+
+```java
+final OpenTelemetry openTelemetry = ... // OpenTelemetry API instance
+
+MetricHookOptions hookOptions = MetricHookOptions.builder()
+        // configure a callback
+        .attributeSetter(metadata -> Attributes.builder()
+            .put("boolean", metadata.getBoolean("boolean"))
+            .put("integer", metadata.getInteger("integer"))
+            .build())
+        .build();
+
+final MetricsHook metricHook = new MetricsHook(openTelemetry, hookOptions);
 ```

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -17,12 +17,13 @@ import java.util.function.Function;
 public class MetricHookOptions {
 
     /**
-     * Custom handler to derive {@link Attributes} from flag evaluation metadata represented with {@link ImmutableMetadata}
+     * Custom handler to derive {@link Attributes} from flag evaluation metadata represented with
+     * {@link ImmutableMetadata}.
      */
     private Function<ImmutableMetadata, Attributes> attributeSetter;
 
     /**
-     * List of {@link DimensionDescription} to be extracted from flag evaluation metadata
+     * List of {@link DimensionDescription} to be extracted from flag evaluation metadata.
      */
     @Builder.Default
     private final List<DimensionDescription> setDimensions = Collections.emptyList();

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.hooks.otel;
 
 import dev.openfeature.sdk.ImmutableMetadata;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentelemetry.api.common.Attributes;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,8 @@ import java.util.function.Function;
  */
 @Builder
 @Getter
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP"}, justification = "Dimension list can be mutable")
+
 public class MetricHookOptions {
 
     /**

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -1,4 +1,29 @@
 package dev.openfeature.contrib.hooks.otel;
 
-public class MertricHookOptions {
+import dev.openfeature.sdk.ImmutableMetadata;
+import io.opentelemetry.api.common.Attributes;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * OpenTelemetry hook options.
+ */
+@Builder
+@Getter
+public class MetricHookOptions {
+
+    /**
+     * Custom handler to derive {@link Attributes} from flag evaluation metadata represented with {@link ImmutableMetadata}
+     */
+    private Function<ImmutableMetadata, Attributes> attributeSetter;
+
+    /**
+     * List of {@link DimensionDescription} to be extracted from flag evaluation metadata
+     */
+    @Builder.Default
+    private final List<DimensionDescription> setDimensions = Collections.emptyList();
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -1,0 +1,4 @@
+package dev.openfeature.contrib.hooks.otel;
+
+public class MertricHookOptions {
+}

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
@@ -56,7 +56,10 @@ public class MetricsHook implements Hook {
      * Construct a metric hook with {@link OpenTelemetry} instance and a list of {@link DimensionDescription}.
      * Provided dimensions are attempted to be extracted from ImmutableMetadata attached to
      * {@link FlagEvaluationDetails}.
+     *
+     * @deprecated - This constructor is deprecated. Please use {@link MetricHookOptions} based options
      */
+    @Deprecated
     public MetricsHook(final OpenTelemetry openTelemetry, final List<DimensionDescription> dimensions) {
         this(openTelemetry, MetricHookOptions.builder().setDimensions(dimensions).build());
     }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
@@ -21,7 +21,7 @@ public class TracesHookOptions {
 
     /**
      * Custom callback to derive {@link Attributes} from flag evaluation metadata represented with
-     * {@link ImmutableMetadata}
+     * {@link ImmutableMetadata}.
      */
     private Function<ImmutableMetadata, Attributes> dimensionExtractor;
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
@@ -1,10 +1,14 @@
 package dev.openfeature.contrib.hooks.otel;
 
+import dev.openfeature.sdk.ImmutableMetadata;
+import io.opentelemetry.api.common.Attributes;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.function.Function;
+
 /**
- * OpenTelemetry hook options.
+ * OpenTelemetry {@link TracesHook} options.
  */
 @Builder
 @Getter
@@ -14,4 +18,10 @@ public class TracesHookOptions {
      */
     @Builder.Default
     private boolean setSpanErrorStatus = false;
+
+    /**
+     * Custom callback to derive {@link Attributes} from flag evaluation metadata represented with
+     * {@link ImmutableMetadata}
+     */
+    private Function<ImmutableMetadata, Attributes> dimensionExtractor;
 }


### PR DESCRIPTION
## This PR

Fixes https://github.com/open-feature/java-sdk-contrib/issues/381 

Adds callback option to extract custom dimensions from flag evaluation metadata. 

This is similar to what we do in JS SDK - https://github.com/open-feature/js-sdk-contrib/pull/520 

```Java
MetricHookOptions hookOptions = MetricHookOptions.builder()
        //Configure a callback which accepts ImmutableMetadata
        .attributeSetter(metadata -> Attributes.builder()
            .put("boolean", metadata.getBoolean("boolean"))
            .put("integer", metadata.getInteger("integer"))
            .build())
        .build();
```

This change is backward compatible and does not change the current beavhior.
