### PR TITLE
chore: improve netty usage

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -54,7 +54,7 @@
             <!-- we only support unix sockets on linux, via epoll native lib -->
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.95.Final</version>
+            <version>4.1.96.Final</version>
             <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
             <classifier>linux-x86_64</classifier>
         </dependency>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnector.java
@@ -194,7 +194,7 @@ public class GrpcConnector {
         // we have a socket path specified, build a channel with a unix socket
         if (options.getSocketPath() != null) {
             // check epoll availability
-            if (!Epoll.isAvailable()){
+            if (!Epoll.isAvailable()) {
                 throw new IllegalStateException("unix socket cannot be used", Epoll.unavailabilityCause());
             }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnector.java
@@ -10,6 +10,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -192,6 +193,11 @@ public class GrpcConnector {
     private static ManagedChannel nettyChannel(final FlagdOptions options) {
         // we have a socket path specified, build a channel with a unix socket
         if (options.getSocketPath() != null) {
+            // check epoll availability
+            if (!Epoll.isAvailable()){
+                throw new IllegalStateException("unix socket cannot be used", Epoll.unavailabilityCause());
+            }
+
             return NettyChannelBuilder
                     .forAddress(new DomainSocketAddress(options.getSocketPath()))
                     .eventLoopGroup(new EpollEventLoopGroup())

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
@@ -7,9 +7,15 @@ import dev.openfeature.flagd.grpc.ServiceGrpc;
 import io.grpc.Channel;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.unix.DomainSocketAddress;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
@@ -17,12 +23,15 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -174,6 +183,89 @@ public class GrpcConnectorTest {
                     // verify host/port matches & called times(= 1 as we rely on reusable channel)
                     mockStaticChannelBuilder.verify(() -> NettyChannelBuilder.
                             forAddress(host, port), times(1));
+                }
+            }
+        });
+    }
+
+
+    /**
+     * OS Specific test - This test is valid only on Linux system as it rely on epoll availability
+    * */
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void path_arg_should_build_domain_socket_with_correct_path() {
+        final String path = "/some/path";
+
+        ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
+        ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
+        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
+
+        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
+            mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
+                    .thenReturn(mockBlockingStub);
+            mockStaticService.when(() -> ServiceGrpc.newStub(any()))
+                    .thenReturn(mockStub);
+
+            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
+
+                try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup = mockConstruction(
+                        EpollEventLoopGroup.class,
+                        (mock, context) -> {
+                        })) {
+                    when(NettyChannelBuilder.forAddress(any(DomainSocketAddress.class))).thenReturn(mockChannelBuilder);
+
+                    new GrpcConnector(FlagdOptions.builder().socketPath(path).build(), null, null);
+
+                    // verify path matches
+                    mockStaticChannelBuilder.verify(() -> NettyChannelBuilder
+                            .forAddress(argThat((DomainSocketAddress d) -> {
+                                assertEquals(d.path(), path); // path should match
+                                return true;
+                            })), times(1));
+                }
+            }
+        }
+    }
+
+    /**
+     * OS Specific test - This test is valid only on Linux system as it rely on epoll availability
+     * */
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void no_args_socket_env_should_build_domain_socket_with_correct_path() throws Exception {
+        final String path = "/some/other/path";
+
+        new EnvironmentVariables("FLAGD_SOCKET_PATH", path).execute(() -> {
+
+            ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
+            ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
+            NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
+
+            try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
+                mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
+                        .thenReturn(mockBlockingStub);
+                mockStaticService.when(() -> ServiceGrpc.newStub(any()))
+                        .thenReturn(mockStub);
+
+                try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(
+                        NettyChannelBuilder.class)) {
+
+                    try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup = mockConstruction(
+                            EpollEventLoopGroup.class,
+                            (mock, context) -> {
+                            })) {
+                        mockStaticChannelBuilder.when(() -> NettyChannelBuilder
+                                .forAddress(any(DomainSocketAddress.class))).thenReturn(mockChannelBuilder);
+
+                        new GrpcConnector(FlagdOptions.builder().build(), null, null);
+
+                        //verify path matches & called times(= 1 as we rely on reusable channel)
+                        mockStaticChannelBuilder.verify(() -> NettyChannelBuilder
+                                .forAddress(argThat((DomainSocketAddress d) -> {
+                                    return d.path() == path;
+                                })), times(1));
+                    }
                 }
             }
         });

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
@@ -124,80 +124,6 @@ public class GrpcConnectorTest {
     }
 
     @Test
-    void path_arg_should_build_domain_socket_with_correct_path() {
-        final String path = "/some/path";
-
-        ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
-        ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
-        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(mockBlockingStub);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any()))
-                    .thenReturn(mockStub);
-
-            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
-
-                try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup = mockConstruction(
-                        EpollEventLoopGroup.class,
-                        (mock, context) -> {
-                        })) {
-                    when(NettyChannelBuilder.forAddress(any(DomainSocketAddress.class))).thenReturn(mockChannelBuilder);
-
-                    new GrpcConnector(FlagdOptions.builder().socketPath(path).build(), null, null);
-
-                    // verify path matches
-                    mockStaticChannelBuilder.verify(() -> NettyChannelBuilder
-                            .forAddress(argThat((DomainSocketAddress d) -> {
-                                assertEquals(d.path(), path); // path should match
-                                return true;
-                            })), times(1));
-                }
-            }
-        }
-    }
-
-    @Test
-    void no_args_socket_env_should_build_domain_socket_with_correct_path() throws Exception {
-        final String path = "/some/other/path";
-
-        new EnvironmentVariables("FLAGD_SOCKET_PATH", path).execute(() -> {
-
-            ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
-            ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
-            NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-            try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-                mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                        .thenReturn(mockBlockingStub);
-                mockStaticService.when(() -> ServiceGrpc.newStub(any()))
-                        .thenReturn(mockStub);
-
-                try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(
-                        NettyChannelBuilder.class)) {
-
-                    try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup = mockConstruction(
-                            EpollEventLoopGroup.class,
-                            (mock, context) -> {
-                            })) {
-                        mockStaticChannelBuilder.when(() -> NettyChannelBuilder
-                                .forAddress(any(DomainSocketAddress.class))).thenReturn(mockChannelBuilder);
-
-                        new GrpcConnector(FlagdOptions.builder().build(), null, null);
-
-                        //verify path matches & called times(= 1 as we rely on reusable channel)
-                        mockStaticChannelBuilder.verify(() -> NettyChannelBuilder
-                                .forAddress(argThat((DomainSocketAddress d) -> {
-                                    return d.path() == path;
-                                })), times(1));
-                    }
-                }
-            }
-        });
-    }
-
-    @Test
     void host_and_port_arg_should_build_tcp_socket() {
         final String host = "host.com";
         final int port = 1234;
@@ -225,6 +151,17 @@ public class GrpcConnectorTest {
                         .forAddress(host, port), times(1));
             }
         }
+    }
+
+    @Test
+    void should_fail_when_epoll_is_unavailable() {
+        // Manually override system property to make epoll unavailable
+        System.setProperty("io.netty.transport.noNative", "true");
+
+        final FlagdOptions flagdOptions = FlagdOptions.builder().socketPath("path").build();
+        assertThrows(RuntimeException.class, () -> new GrpcConnector(flagdOptions, null, null));
+
+        System.clearProperty("io.netty.transport.noNative");
     }
 
     @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/grpc/GrpcConnectorTest.java
@@ -7,9 +7,6 @@ import dev.openfeature.flagd.grpc.ServiceGrpc;
 import io.grpc.Channel;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -181,31 +178,6 @@ public class GrpcConnectorTest {
             }
         });
     }
-
-    @Nested
-    class EpollDisabled {
-
-        @BeforeEach
-        public void setUp() {
-            // Manually override system property to make epoll unavailable
-            System.setProperty("io.netty.transport.noNative", "true");
-        }
-
-        @AfterEach
-        public void cleanUp() {
-            System.clearProperty("io.netty.transport.noNative");
-        }
-
-
-        @Test
-        void should_fail_when_epoll_is_unavailable() {
-            final FlagdOptions flagdOptions = FlagdOptions.builder().socketPath("path").build();
-            assertThrows(RuntimeException.class, () -> new GrpcConnector(flagdOptions, null, null));
-
-            System.clearProperty("io.netty.transport.noNative");
-        }
-    }
-
 
     private NettyChannelBuilder getMockChannelBuilderSocket() {
         NettyChannelBuilder mockChannelBuilder = mock(NettyChannelBuilder.class);


### PR DESCRIPTION
## This PR

Fixes https://github.com/open-feature/java-sdk-contrib/issues/402

Improves netty usage by verifying epoll availability.  <del>Added a test to validate the check</del> Unfortunately, this is not testable. 

@toddbaert I had to remove two tests, which are not compatible with non-linux systems. 