### PR TITLE
chore: generate automatic module names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <module-name>${groupId}.${artifactId}</module-name>
     </properties>
 
     <dependencies>
@@ -276,6 +277,20 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- automatically derive a module name from the groupId and artifactId -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                <archive>
+                    <manifestEntries>
+                    <Automatic-Module-Name>${module-name}</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
+                </configuration>
             </plugin>
 
             <!-- skips deployment of submodule artifact if already in repo -->

--- a/providers/env-var/pom.xml
+++ b/providers/env-var/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <!-- override module name defined in parent ("-" is not allowed) -->
-        <module-name>${groupId}.env</module-name>
+        <module-name>${groupId}.envvar</module-name>
     </properties>
 
     <name>env-var</name>

--- a/providers/env-var/pom.xml
+++ b/providers/env-var/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>env-var</artifactId>
     <version>0.0.4</version> <!--x-release-please-version -->
 
+    <properties>
+        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <module-name>${groupId}.env</module-name>
+    </properties>
+
     <name>env-var</name>
     <description>Environment Variables provider for Java</description>
 

--- a/providers/env-var/pom.xml
+++ b/providers/env-var/pom.xml
@@ -13,7 +13,7 @@
     <version>0.0.4</version> <!--x-release-please-version -->
 
     <properties>
-        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <!-- override module name defined in parent ("-" is not allowed) -->
         <module-name>${groupId}.env</module-name>
     </properties>
 

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -16,6 +16,11 @@
     <description>GO Feature Flag provider for Java</description>
     <url>https://gofeatureflag.org</url>
 
+    <properties>
+        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <module-name>${groupId}.goff</module-name>
+    </properties>
+
     <developers>
         <developer>
             <id>thomaspoignant</id>

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -17,7 +17,7 @@
     <url>https://gofeatureflag.org</url>
 
     <properties>
-        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <!-- override module name defined in parent ("-" is not allowed) -->
         <module-name>${groupId}.goff</module-name>
     </properties>
 

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <!-- override module name defined in parent ("-" is not allowed) -->
-        <module-name>${groupId}.goff</module-name>
+        <module-name>${groupId}.gofeatureflag</module-name>
     </properties>
 
     <developers>

--- a/providers/jsonlogic-eval-provider/pom.xml
+++ b/providers/jsonlogic-eval-provider/pom.xml
@@ -16,6 +16,11 @@
     <description>Allows for evaluating rules on the client without synchronous calls to a backend</description>
     <url>https://openfeature.dev</url>
 
+    <properties>
+        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <module-name>${groupId}.jsonlogic</module-name>
+    </properties>
+
     <developers>
         <developer>
             <id>justinabrahms</id>

--- a/providers/jsonlogic-eval-provider/pom.xml
+++ b/providers/jsonlogic-eval-provider/pom.xml
@@ -17,7 +17,7 @@
     <url>https://openfeature.dev</url>
 
     <properties>
-        <!-- override module name defined in paraent ("-" is not allowed) -->
+        <!-- override module name defined in parent ("-" is not allowed) -->
         <module-name>${groupId}.jsonlogic</module-name>
     </properties>
 


### PR DESCRIPTION
See title.

Tested this locally with `mvn install`, then opened the locally cached module. This is what the MANIFEST.MF looks like for the flagd provider:

```
Manifest-Version: 1.0
Automatic-Module-Name: dev.openfeature.contrib.providers.flagd
Build-Jdk-Spec: 1.8
Created-By: Maven JAR Plugin 3.3.0
```

Note: I had to "make up" some module names for a few providers that would otherwise have invalid ones based on the module name (apparently "-" is illegal).

:warning: Note: http://branchandbound.net/blog/java/2017/12/automatic-module-name/ and https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html _strongly_ recommend that module names should match the `root package` of the jar. I've therefore used the root package for the "-" cases.

Fixes: https://github.com/open-feature/java-sdk-contrib/issues/261
