### PR TITLE
fix: Double value for a flag converted to integer

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -428,6 +428,9 @@ public class GoFeatureFlagProvider implements FeatureProvider {
                 || expectedType == Double.class;
 
         if (isPrimitive) {
+            if (value.getClass() == Integer.class && expectedType == Double.class) {
+                return (T) Double.valueOf((Integer) value);
+            }
             return (T) value;
         }
         return (T) objectToValue(value);

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -575,6 +575,24 @@ class GoFeatureFlagProviderTest {
 
     @SneakyThrows
     @Test
+    void should_resolve_a_valid_double_flag_with_TARGETING_MATCH_reason_if_value_point_zero() {
+        GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
+        String providerName = this.testName;
+        OpenFeatureAPI.getInstance().setProviderAndWait(providerName, g);
+        Client client = OpenFeatureAPI.getInstance().getClient(providerName);
+        FlagEvaluationDetails<Double> got = client.getDoubleDetails("double_point_zero_key", 200.20, this.evaluationContext);
+        FlagEvaluationDetails<Double> want = FlagEvaluationDetails.<Double>builder()
+                .value(100.0)
+                .reason(Reason.TARGETING_MATCH.name())
+                .variant("True")
+                .flagMetadata(defaultMetadata)
+                .flagKey("double_point_zero_key")
+                .build();
+        assertEquals(want, got);
+    }
+
+    @SneakyThrows
+    @Test
     void should_use_double_default_value_if_the_flag_is_disabled() {
         GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
         String providerName = this.testName;

--- a/providers/go-feature-flag/src/test/resources/mock_responses/double_point_zero_key.json
+++ b/providers/go-feature-flag/src/test/resources/mock_responses/double_point_zero_key.json
@@ -1,0 +1,13 @@
+{
+  "trackEvents": true,
+  "variationType": "True",
+  "failed": false,
+  "version": 0,
+  "reason": "TARGETING_MATCH",
+  "errorCode": "",
+  "value": 100 ,
+  "metadata": {
+    "pr_link": "https://github.com/thomaspoignant/go-feature-flag/pull/916",
+    "version": 1
+  }
+}


### PR DESCRIPTION
## This PR
GO Feature Flag marshal double as `int` in the `JSON` response (because this is how GO is doing it).
This PR ensures that if we are expecting a double, the value is converted to `Double` and is not raising a type mismatch error.

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/1092
