### PR TITLE
feat: flagd in-process evalator improvements

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -61,13 +61,14 @@ variables.
 Given below are the supported configurations:
 
 | Option name           | Environment variable name      | Type & Values          | Default   | Compatible resolver |
-| --------------------- | ------------------------------ | ---------------------- | --------- | ------------------- |
+|-----------------------|--------------------------------|------------------------|-----------|---------------------|
 | host                  | FLAGD_HOST                     | String                 | localhost | RPC & in-process    |
 | port                  | FLAGD_PORT                     | int                    | 8013      | RPC & in-process    |
 | tls                   | FLAGD_TLS                      | boolean                | false     | RPC & in-process    |
 | socketPath            | FLAGD_SOCKET_PATH              | String                 | null      | RPC & in-process    |
 | certPath              | FLAGD_SERVER_CERT_PATH         | String                 | null      | RPC & in-process    |
 | deadline              | FLAGD_DEADLINE_MS              | int                    | 500       | RPC & in-process    |
+| selector              | FLAGD_SELECTOR                 | String                 | null      | in-process          |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled | lru       | RPC                 |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                    | 1000      | RPC                 |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                    | 5         | RPC                 |

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -68,7 +68,7 @@ Given below are the supported configurations:
 | socketPath            | FLAGD_SOCKET_PATH              | String                 | null      | RPC & in-process    |
 | certPath              | FLAGD_SERVER_CERT_PATH         | String                 | null      | RPC & in-process    |
 | deadline              | FLAGD_DEADLINE_MS              | int                    | 500       | RPC & in-process    |
-| selector              | FLAGD_SELECTOR                 | String                 | null      | in-process          |
+| selector              | FLAGD_SOURCE_SELECTOR          | String                 | null      | in-process          |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled | lru       | RPC                 |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                    | 1000      | RPC                 |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                    | 5         | RPC                 |

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -22,6 +22,7 @@ public final class Config {
     static final String MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME = "FLAGD_MAX_EVENT_STREAM_RETRIES";
     static final String BASE_EVENT_STREAM_RETRY_BACKOFF_MS_ENV_VAR_NAME = "FLAGD_RETRY_BACKOFF_MS";
     static final String DEADLINE_MS_ENV_VAR_NAME = "FLAGD_DEADLINE_MS";
+    static final String SELECTOR_ENV_VAR_NAME = "FLAGD_SELECTOR";
 
     public static final String STATIC_REASON = "STATIC";
     public static final String CACHED_REASON = "CACHED";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -22,7 +22,7 @@ public final class Config {
     static final String MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME = "FLAGD_MAX_EVENT_STREAM_RETRIES";
     static final String BASE_EVENT_STREAM_RETRY_BACKOFF_MS_ENV_VAR_NAME = "FLAGD_RETRY_BACKOFF_MS";
     static final String DEADLINE_MS_ENV_VAR_NAME = "FLAGD_DEADLINE_MS";
-    static final String SELECTOR_ENV_VAR_NAME = "FLAGD_SELECTOR";
+    static final String SOURCE_SELECTOR_ENV_VAR_NAME = "FLAGD_SOURCE_SELECTOR";
 
     public static final String STATIC_REASON = "STATIC";
     public static final String CACHED_REASON = "CACHED";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -20,6 +20,7 @@ import static dev.openfeature.contrib.providers.flagd.Config.HOST_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.MAX_CACHE_SIZE_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.PORT_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SELECTOR_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.SERVER_CERT_PATH_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.SOCKET_PATH_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.TLS_ENV_VAR_NAME;
@@ -97,11 +98,19 @@ public class FlagdOptions {
 
 
     /**
-     * Deadline to connect to flagD in milliseconds.
+     * Connection deadline in milliseconds.
+     *
+     * For RPC resolving, this is the deadline to connect to flagd for flag evaluation.
+     * For in-process resolving, this is the deadline for sync stream termination.
      * */
     @Builder.Default
-    private int deadline =
-            fallBackToEnvOrDefault(DEADLINE_MS_ENV_VAR_NAME, DEFAULT_DEADLINE);
+    private int deadline = fallBackToEnvOrDefault(DEADLINE_MS_ENV_VAR_NAME, DEFAULT_DEADLINE);
+
+    /**
+     * Selector to be used with flag sync gRPC contract.
+     **/
+    @Builder.Default
+    private String selector = fallBackToEnvOrDefault(SELECTOR_ENV_VAR_NAME, null);
 
     /**
      * Inject OpenTelemetry for the library runtime. Providing sdk will initiate distributed tracing for flagd grpc

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -99,7 +99,6 @@ public class FlagdOptions {
 
     /**
      * Connection deadline in milliseconds.
-     *
      * For RPC resolving, this is the deadline to connect to flagd for flag evaluation.
      * For in-process resolving, this is the deadline for sync stream termination.
      * */

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -20,7 +20,7 @@ import static dev.openfeature.contrib.providers.flagd.Config.HOST_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.MAX_CACHE_SIZE_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.PORT_ENV_VAR_NAME;
-import static dev.openfeature.contrib.providers.flagd.Config.SELECTOR_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SOURCE_SELECTOR_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.SERVER_CERT_PATH_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.SOCKET_PATH_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.TLS_ENV_VAR_NAME;
@@ -109,7 +109,7 @@ public class FlagdOptions {
      * Selector to be used with flag sync gRPC contract.
      **/
     @Builder.Default
-    private String selector = fallBackToEnvOrDefault(SELECTOR_ENV_VAR_NAME, null);
+    private String selector = fallBackToEnvOrDefault(SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
     /**
      * Inject OpenTelemetry for the library runtime. Providing sdk will initiate distributed tracing for flagd grpc

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FeatureFlag.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FeatureFlag.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -14,6 +15,7 @@ import java.util.Map;
 @Getter
 @SuppressFBWarnings(value = {"EI_EXPOSE_REP"},
         justification = "Feature flag comes as a Json configuration, hence they must be parsed and exposed")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FeatureFlag {
     public static final String EMPTY_TARGETING_STRING = "{}";
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FeatureFlagProviderBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FeatureFlagProviderBuilderTest.java
@@ -28,6 +28,7 @@ public class FeatureFlagProviderBuilderTest {
         assertEquals(builder.getCacheType(), DEFAULT_CACHE);
         assertEquals(builder.getMaxCacheSize(), DEFAULT_MAX_CACHE_SIZE);
         assertEquals(builder.getMaxEventStreamRetries(), DEFAULT_MAX_EVENT_STREAM_RETRIES);
+        assertNull(builder.getSelector());
         assertNull(builder.getOpenTelemetry());
     }
 
@@ -43,6 +44,7 @@ public class FeatureFlagProviderBuilderTest {
                 .cacheType("lru")
                 .maxCacheSize(100)
                 .maxEventStreamRetries(1)
+                .selector("app=weatherApp")
                 .openTelemetry(openTelemetry)
                 .build();
 
@@ -53,6 +55,7 @@ public class FeatureFlagProviderBuilderTest {
         assertEquals(flagdOptions.getCacheType(), "lru");
         assertEquals(flagdOptions.getMaxCacheSize(), 100);
         assertEquals(flagdOptions.getMaxEventStreamRetries(), 1);
+        assertEquals(flagdOptions.getSelector(), "app=weatherApp");
         assertEquals(flagdOptions.getOpenTelemetry(), openTelemetry);
     }
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/TestUtils.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/TestUtils.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 
 public class TestUtils {
     public static final String VALID_SIMPLE = "flagConfigurations/valid-simple.json";
+    public static final String VALID_SIMPLE_EXTRA_FIELD = "flagConfigurations/valid-simple-with-extra-fields.json";
     public static final String VALID_LONG = "flagConfigurations/valid-long.json";
     public static final String INVALID_FLAG = "flagConfigurations/invalid-flag.json";
     public static final String INVALID_CFG = "flagConfigurations/invalid-configuration.json";

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParserTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParserTest.java
@@ -9,6 +9,7 @@ import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_LONG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_SIMPLE;
+import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_SIMPLE_EXTRA_FIELD;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.getFlagsFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,6 +19,21 @@ class FlagParserTest {
     @Test
     public void validJsonConfigurationParsing() throws IOException {
         Map<String, FeatureFlag> flagMap = FlagParser.parseString(getFlagsFromResource(VALID_SIMPLE));
+        FeatureFlag boolFlag = flagMap.get("myBoolFlag");
+
+        assertNotNull(boolFlag);
+        assertEquals("ENABLED", boolFlag.getState());
+        assertEquals("on", boolFlag.getDefaultVariant());
+
+        Map<String, Object> variants = boolFlag.getVariants();
+
+        assertEquals(true, variants.get("on"));
+        assertEquals(false, variants.get("off"));
+    }
+
+    @Test
+    public void validJsonConfigurationWithExtraFieldsParsing() throws IOException {
+        Map<String, FeatureFlag> flagMap = FlagParser.parseString(getFlagsFromResource(VALID_SIMPLE_EXTRA_FIELD));
         FeatureFlag boolFlag = flagMap.get("myBoolFlag");
 
         assertNotNull(boolFlag);

--- a/providers/flagd/src/test/resources/flagConfigurations/valid-simple-with-extra-fields.json
+++ b/providers/flagd/src/test/resources/flagConfigurations/valid-simple-with-extra-fields.json
@@ -1,0 +1,13 @@
+{
+  "flags": {
+    "myBoolFlag": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on",
+      "someNewFieldInFlagd": "value"
+    }
+  }
+}


### PR DESCRIPTION
## This PR

Improves in-process evaluator with,

- Adding `selector` field for gRPC sync connection [^1]
- Allow unknown fields in flagd flag structure: future-proofing when flag sources change


[^1]: https://github.com/open-feature/schemas/blob/main/protobuf/sync/v1/sync_service.proto#L24



