### PR TITLE
feat: force update gson depdency

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -83,6 +83,13 @@
             <version>1.0.7</version>
         </dependency>
 
+        <!-- Override gson usage of json-logic-java-->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>


### PR DESCRIPTION
## This PR

Flagd use Json logic Java and the latest version of this contain a depdency on gson which has a vulnerability [^1]

This PR fixes this by forcing the latest version of gson library on flagd 

[^1]: - https://mvnrepository.com/artifact/io.github.jamsesso/json-logic-java/1.0.7 