### PR TITLE
chore: flagd change log level from error to warn

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -54,7 +54,7 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
 
     @Override
     public void onError(Throwable t) {
-        log.error("event stream", t);
+        log.warn("event stream", t);
         if (this.cache.getEnabled()) {
             this.cache.clear();
         }


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Adapts the log level in case of network error

Network errors can occur and would trigger this error log. Since we have a retry strategy in place, I believe a warning level is more appropriate.




