### PR TITLE
chore: fix dependencies for flagd and OTel hook

### DIFF
--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -48,8 +48,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>1.28.0-alpha</version>
-            <scope>provided</scope>
+            <version>1.30.1-alpha</version>
         </dependency>
 
         <dependency>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -128,6 +128,12 @@
             <version>5.2.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.16.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
While running FF eval in a Spring Boot app using the Flagd provider, I encountered some runtime problems due to dependencies. 

1. Missing MurmurHash3 in fractional eval:

```
java.lang.NoClassDefFoundError: org/apache/commons/codec/digest/MurmurHash3
	at dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Fractional.distributeValue(Fractional.java:79)
	at dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Fractional.evaluate(Fractional.java:73)
	at io.github.jamsesso.jsonlogic.evaluator.expressions.PreEvaluatedArgumentsExpression.evaluate(PreEvaluatedArgumentsExpression.java:23)
	at io.github.jamsesso.jsonlogic.evaluator.JsonLogicEvaluator.evaluate(JsonLogicEvaluator.java:132)
	at io.github.jamsesso.jsonlogic.evaluator.JsonLogicEvaluator.evaluate(JsonLogicEvaluator.java:22)
	at io.github.jamsesso.jsonlogic.JsonLogic.apply(JsonLogic.java:90)
	at dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Operator.apply(Operator.java:41)
```
We didn't encountered the problem because looking at the dep tree, `commons-codec:commons-codec:jar:1.15` is a transitive dependency of `com.github.spotbugs:spotbugs:jar:4.7.3`

```
[INFO] --- dependency:3.6.0:tree (default-cli) @ parent ---
[INFO] dev.openfeature.contrib:parent:pom:0.1.0
[INFO] +- dev.openfeature:sdk:jar:1.6.1:provided
[INFO] |  \- org.slf4j:slf4j-api:jar:2.0.9:provided
[INFO] +- org.projectlombok:lombok:jar:1.18.30:provided
[INFO] +- com.github.spotbugs:spotbugs:jar:4.7.3:provided
[INFO] |  +- org.ow2.asm:asm:jar:9.4:provided
[INFO] |  +- org.ow2.asm:asm-analysis:jar:9.4:provided
[INFO] |  +- org.ow2.asm:asm-commons:jar:9.4:provided
[INFO] |  +- org.ow2.asm:asm-tree:jar:9.4:provided
[INFO] |  +- org.ow2.asm:asm-util:jar:9.4:provided
[INFO] |  +- org.apache.bcel:bcel:jar:6.5.0:provided
[INFO] |  +- net.jcip:jcip-annotations:jar:1.0:provided
[INFO] |  +- org.dom4j:dom4j:jar:2.1.3:provided
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:provided
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:provided
[INFO] |  +- com.github.spotbugs:spotbugs-annotations:jar:4.7.3:provided
[INFO] |  |  \- com.google.code.findbugs:jsr305:jar:3.0.2:provided
[INFO] |  +- com.google.code.gson:gson:jar:2.9.1:provided
[INFO] |  +- jaxen:jaxen:jar:1.2.0:provided
[INFO] |  +- net.sf.saxon:Saxon-HE:jar:11.4:provided
[INFO] |  |  +- org.xmlresolver:xmlresolver:jar:4.4.3:provided
[INFO] |  |  |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.1.3:provided
[INFO] |  |  |  |  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.1.3:provided
[INFO] |  |  |  |  \- commons-codec:commons-codec:jar:1.15:provided
```

2. opentelemetry-semconv missing with agent instrumentation

I had my app failing because `io.opentelemetry.semconv.trace.attributes.SemanticAttributes` cannot be found. Furthermore, I bumped the version to 1.30.1-alpha which is the one supporting OTel API v1.30.1 (see [POM dependencies](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-semconv))
