### PR TITLE
feat!: remove deprecated constructor and option to define construction time attributes

### DIFF
--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -3,6 +3,7 @@ package dev.openfeature.contrib.hooks.otel;
 import dev.openfeature.sdk.ImmutableMetadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,4 +31,10 @@ public class MetricHookOptions {
      */
     @Builder.Default
     private final List<DimensionDescription> setDimensions = Collections.emptyList();
+
+    /**
+     * Extra attributes added at hook constructor time.
+     */
+    @Builder.Default
+    private Attributes extraAttributes = Attributes.empty();
 }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java
@@ -3,7 +3,6 @@ package dev.openfeature.contrib.hooks.otel;
 import dev.openfeature.sdk.ImmutableMetadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHook.java
@@ -24,6 +24,7 @@ import static dev.openfeature.contrib.hooks.otel.OTelCommons.variantAttributeKey
 public class TracesHook implements Hook {
     private final boolean setSpanErrorStatus;
     private final Function<ImmutableMetadata, Attributes> extractor;
+    private final Attributes extraAttributes;
 
     /**
      * Create a new OpenTelemetryHook instance with default options.
@@ -38,6 +39,7 @@ public class TracesHook implements Hook {
     public TracesHook(TracesHookOptions options) {
         setSpanErrorStatus = options.isSetSpanErrorStatus();
         extractor = options.getDimensionExtractor();
+        extraAttributes = options.getExtraAttributes();
     }
 
     /**
@@ -62,6 +64,7 @@ public class TracesHook implements Hook {
         attributesBuilder.put(flagKeyAttributeKey, ctx.getFlagKey());
         attributesBuilder.put(providerNameAttributeKey, ctx.getProviderMetadata().getName());
         attributesBuilder.put(variantAttributeKey, variant);
+        attributesBuilder.putAll(extraAttributes);
 
         if (extractor != null) {
             attributesBuilder.putAll(extractor.apply(details.getFlagMetadata()));

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java
@@ -24,4 +24,9 @@ public class TracesHookOptions {
      * {@link ImmutableMetadata}.
      */
     private Function<ImmutableMetadata, Attributes> dimensionExtractor;
+
+    /**
+     * Extra attributes added at hook constructor time.
+     */
+    private Attributes extraAttributes;
 }

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
@@ -105,7 +105,8 @@ class MetricsHookTest {
         dimensionList.add(new DimensionDescription("double", Double.class));
         dimensionList.add(new DimensionDescription("string", String.class));
 
-        final MetricsHook metricHook = new MetricsHook(telemetryExtension.getOpenTelemetry(), dimensionList);
+        final MetricsHook metricHook = new MetricsHook(telemetryExtension.getOpenTelemetry(),
+                MetricHookOptions.builder().setDimensions(dimensionList).build());
 
         final ImmutableMetadata metadata = ImmutableMetadata.builder()
                 .addBoolean("boolean", true)
@@ -213,6 +214,10 @@ class MetricsHookTest {
                         .put("double", metadata.getDouble("double"))
                         .put("string", metadata.getString("string"))
                         .build())
+                .extraAttributes(
+                        Attributes.builder()
+                                .put("scope", "value")
+                                .build())
                 .build();
 
         final MetricsHook metricHook = new MetricsHook(telemetryExtension.getOpenTelemetry(), hookOptions);
@@ -254,5 +259,6 @@ class MetricsHookTest {
         assertThat(attributes.get(AttributeKey.longKey("long"))).isEqualTo(1L);
         assertThat(attributes.get(AttributeKey.longKey("integer"))).isEqualTo(1);
         assertThat(attributes.get(AttributeKey.booleanKey("boolean"))).isEqualTo(true);
+        assertThat(attributes.get(AttributeKey.stringKey("scope"))).isEqualTo("value");
     }
 }

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
@@ -187,7 +187,9 @@ class TracesHookTest {
                         .put("double", metadata.getDouble("double"))
                         .put("string", metadata.getString("string"))
                         .build()
-                ).build();
+                )
+                .extraAttributes(Attributes.builder().put("scope", "value").build())
+                .build();
 
         TracesHook tracesHook = new TracesHook(options);
         tracesHook.after(hookContext, details, null);
@@ -202,8 +204,9 @@ class TracesHookTest {
         attributesBuilder.put("float", 1.0F);
         attributesBuilder.put("double", 1.0D);
         attributesBuilder.put("string", "string");
+        attributesBuilder.put("scope", "value");
 
-
+        // verify span built with given attributes
         verify(span).addEvent("feature_flag", attributesBuilder.build());
     }
 


### PR DESCRIPTION
## This PR

Expose options from both metrics and traces hooks to define constructor time attributes.

Further, it cleans up a deprecated constructor. 

