### PR TITLE
fix!: Remove error message from dimension

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -97,7 +97,7 @@ Below are the metrics extracted by this hook and dimensions they carry:
 |----------------------------------------|---------------------------------|--------------|----------------------------------------------------------|
 | feature_flag.evaluation_requests_total | Number of evaluation requests   | {request}    | key & provider name                                      |
 | feature_flag.evaluation_success_total  | Flag evaluation successes       | {impression} | key, provider name, reason, variant & custom dimensions* |
-| feature_flag.evaluation_error_total    | Flag evaluation errors          | Counter      | key, provider name, exception                            |
+| feature_flag.evaluation_error_total    | Flag evaluation errors          | Counter      | key, provider name                                       |
 | feature_flag.evaluation_active_count   | Active flag evaluations counter | Counter      | key                                                      |
 
 Consider the following code example for usage,

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static dev.openfeature.contrib.hooks.otel.OTelCommons.ERROR_KEY;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.REASON_KEY;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.flagKeyAttributeKey;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.providerNameAttributeKey;
@@ -122,13 +121,8 @@ public class MetricsHook implements Hook {
     @Override
     public void error(HookContext ctx, Exception error, Map hints) {
         final AttributesBuilder attributesBuilder = Attributes.builder();
-
         attributesBuilder.put(flagKeyAttributeKey, ctx.getFlagKey());
         attributesBuilder.put(providerNameAttributeKey, ctx.getProviderMetadata().getName());
-
-        if (error.getMessage() != null) {
-            attributesBuilder.put(ERROR_KEY, error.getMessage());
-        }
 
         evaluationErrorCounter.add(+1, attributesBuilder.build());
     }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OTelCommons.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/OTelCommons.java
@@ -14,5 +14,4 @@ class OTelCommons {
 
     // Define non convention attribute keys
     static final String REASON_KEY = "reason";
-    static final String ERROR_KEY = "exception";
 }

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static dev.openfeature.contrib.hooks.otel.OTelCommons.ERROR_KEY;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.REASON_KEY;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.flagKeyAttributeKey;
 import static dev.openfeature.contrib.hooks.otel.OTelCommons.providerNameAttributeKey;
@@ -173,7 +172,6 @@ class MetricsHookTest {
 
         assertThat(attributes.get(flagKeyAttributeKey)).isEqualTo("key");
         assertThat(attributes.get(providerNameAttributeKey)).isEqualTo("UnitTest");
-        assertThat(attributes.get(AttributeKey.stringKey(ERROR_KEY))).isEqualTo("some_exception");
     }
 
 


### PR DESCRIPTION
## This PR

Removed `exception` attribute from `feature_flag.evaluation_error_total` metric. This is to prevent cardinality explosion/spikes which can cause unwanted loads and costs on the monitoring system. Implementation used`Thorowable.getMessage()` which is not ideal as a dimension. 