### PR TITLE
feat: extra dimensions to error

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -51,7 +51,7 @@ TracesHook tracesHook = new TracesHook(options);
 ```
 
 Alternatively, you can add dimensions at hook construction time using builder option `extraAttributes`.
-These extracted dimensions will be added to successful falg evaluation spans as well as flag evaluation error spans.
+These extracted dimensions will be added to successful flag evaluation spans as well as flag evaluation error spans.
 
 ```java
 TracesHookOptions options = TracesHookOptions.builder()

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -36,7 +36,7 @@ Failed evaluations can be allowed to set span status to `ERROR`. You can configu
 #### Custom dimensions (attributes)
 
 You can write your own logic to extract custom dimensions from [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by setting a callback to `dimensionExtractor`.
-These extracted dimensions will be added to successful falg evaluation spans.
+These extracted dimensions will be added to successful flag evaluation spans.
 
 ```java
  TracesHookOptions options = TracesHookOptions.builder()

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -36,7 +36,7 @@ Failed evaluations can be allowed to set span status to `ERROR`. You can configu
 #### Custom dimensions (attributes)
 
 You can write your own logic to extract custom dimensions from [flag evaluation metadata](https://github.com/open-feature/spec/blob/main/specification/types.md#flag-metadata) by setting a callback to `dimensionExtractor`.
-Extracted dimensions will be added to successful falg evaluation spans.
+These extracted dimensions will be added to successful falg evaluation spans.
 
 ```java
  TracesHookOptions options = TracesHookOptions.builder()
@@ -50,7 +50,8 @@ Extracted dimensions will be added to successful falg evaluation spans.
 TracesHook tracesHook = new TracesHook(options);
 ```
 
-Alternatively, you can add dimensions at hook construction time using builder option `extraAttributes`,
+Alternatively, you can add dimensions at hook construction time using builder option `extraAttributes`.
+These extracted dimensions will be added to successful falg evaluation spans as well as flag evaluation error spans.
 
 ```java
 TracesHookOptions options = TracesHookOptions.builder()
@@ -143,7 +144,8 @@ MetricHookOptions hookOptions = MetricHookOptions.builder()
 
 final MetricsHook metricHook = new MetricsHook(openTelemetry, hookOptions);
 ```
-Alternatively, you can add dimensions at hook construction time using builder option `extraAttributes`,
+Alternatively, you can add dimensions at hook construction time using builder option `extraAttributes`.
+Dimensions added through `extraAttributes` option will be included in both flag evaluation success and evaluation error metrics.
 
 ```java
 MetricHookOptions hookOptions = MetricHookOptions.builder()

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
@@ -123,6 +123,7 @@ public class MetricsHook implements Hook {
         final AttributesBuilder attributesBuilder = Attributes.builder();
         attributesBuilder.put(flagKeyAttributeKey, ctx.getFlagKey());
         attributesBuilder.put(providerNameAttributeKey, ctx.getProviderMetadata().getName());
+        attributesBuilder.putAll(extraDimensions);
 
         evaluationErrorCounter.add(+1, attributesBuilder.build());
     }

--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHook.java
@@ -51,7 +51,8 @@ public class TracesHook implements Hook {
      * @param details Information about how the flag was resolved, including any resolved values.
      * @param hints   An immutable mapping of data for users to communicate to the hooks.
      */
-    @Override public void after(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+    @Override
+    public void after(HookContext ctx, FlagEvaluationDetails details, Map hints) {
         Span currentSpan = Span.current();
         if (currentSpan == null) {
             return;
@@ -82,7 +83,8 @@ public class TracesHook implements Hook {
      * @param error The exception that was thrown.
      * @param hints An immutable mapping of data for users to communicate to the hooks.
      */
-    @Override public void error(HookContext ctx, Exception error, Map hints) {
+    @Override
+    public void error(HookContext ctx, Exception error, Map hints) {
         Span currentSpan = Span.current();
         if (currentSpan == null) {
             return;
@@ -92,8 +94,12 @@ public class TracesHook implements Hook {
             currentSpan.setStatus(StatusCode.ERROR);
         }
 
-        Attributes attributes = Attributes.of(flagKeyAttributeKey, ctx.getFlagKey(), providerNameAttributeKey,
-                ctx.getProviderMetadata().getName());
+        Attributes attributes = Attributes.builder()
+                .put(flagKeyAttributeKey, ctx.getFlagKey())
+                .put(providerNameAttributeKey, ctx.getProviderMetadata().getName())
+                .putAll(extraAttributes)
+                .build();
+
         currentSpan.recordException(error, attributes);
     }
 }

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
@@ -149,7 +149,13 @@ class MetricsHookTest {
     @Test
     public void error_stage_validation() {
         // given
-        final MetricsHook metricHook = new MetricsHook(telemetryExtension.getOpenTelemetry());
+        final MetricsHook metricHook =
+                new MetricsHook(telemetryExtension.getOpenTelemetry(),
+                        MetricHookOptions.builder()
+                                .extraAttributes(Attributes.builder()
+                                        .put("scope", "app-a")
+                                        .build())
+                                .build());
 
         final Exception exception = new Exception("some_exception");
 
@@ -172,6 +178,7 @@ class MetricsHookTest {
 
         assertThat(attributes.get(flagKeyAttributeKey)).isEqualTo("key");
         assertThat(attributes.get(providerNameAttributeKey)).isEqualTo("UnitTest");
+        assertThat(attributes.get(AttributeKey.stringKey("scope"))).isEqualTo("app-a");
     }
 
 

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
@@ -119,11 +119,20 @@ class TracesHookTest {
         RuntimeException runtimeException = new RuntimeException("could not resolve the flag");
         mockedSpan.when(Span::current).thenReturn(span);
 
-        TracesHook tracesHook = new TracesHook();
+        final TracesHook tracesHook = new TracesHook(
+                TracesHookOptions.builder()
+                        .extraAttributes(Attributes.builder()
+                                .put("scope", "app-a")
+                                .build())
+                        .build());
+
         tracesHook.error(hookContext, runtimeException, null);
 
-        Attributes expectedAttr = Attributes.of(flagKeyAttributeKey, "test_key",
-                providerNameAttributeKey, "test provider");
+        final Attributes expectedAttr = Attributes.builder()
+                .put(flagKeyAttributeKey, "test_key")
+                .put(providerNameAttributeKey, "test provider")
+                .put("scope", "app-a")
+                .build();
 
         verify(span).recordException(runtimeException, expectedAttr);
         verify(span, times(0)).setStatus(any());


### PR DESCRIPTION
## This PR

Improves `extraAttributes` option for both metrics and traces hook by including extra attributes (dimensions) to error traces/metrics.



