### PR TITLE
chore: bundle flagd new proto schems

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -200,7 +200,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>copy-new-schema-definition</id>
+                        <id>copy-evaluation.proto</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>exec</goal>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -215,7 +215,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>copy-new-sync-definition</id>
+                        <id>copy-sync.proto</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>exec</goal>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -200,6 +200,36 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>copy-new-schema-definition</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <!-- run: cp schemas/protobuf/flagd/evaluation/v1/evaluation.proto src/main/proto/ -->
+                            <executable>cp</executable>
+                            <arguments>
+                                <argument>schemas/protobuf/flagd/evaluation/v1/evaluation.proto</argument>
+                                <argument>src/main/proto/</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-new-sync-definition</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <!-- run: cp schemas/protobuf/flagd/sync/v1/sync.proto src/main/proto/ -->
+                            <executable>cp</executable>
+                            <arguments>
+                                <argument>schemas/protobuf/flagd/sync/v1/sync.proto</argument>
+                                <argument>src/main/proto/</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-schema-json</id>
                         <phase>validate</phase>
                         <goals>

--- a/providers/flagd/src/main/proto/.gitignore
+++ b/providers/flagd/src/main/proto/.gitignore
@@ -1,4 +1,1 @@
-evaluation.proto
-schema.proto
-sync.proto
-sync_service.proto
+*.proto

--- a/providers/flagd/src/main/proto/.gitignore
+++ b/providers/flagd/src/main/proto/.gitignore
@@ -1,2 +1,4 @@
+evaluation.proto
 schema.proto
+sync.proto
 sync_service.proto

--- a/spotbugs-exclusions.xml
+++ b/spotbugs-exclusions.xml
@@ -3,12 +3,12 @@
 
     <!-- Ignore generated dev.openfeature.flagd.grpc schemas -->
     <Match>
-        <Package name="~dev\.openfeature\.flagd\.grpc\.*" />
+        <Package name="~dev.openfeature.flagd.grpc.*" />
     </Match>
 
     <!-- Ignore generated dev.openfeature.flagd.sync schemas -->
     <Match>
-        <Package name="~dev\.openfeature\.flagd\.sync\.*" />
+        <Package name="dev.openfeature.flagd.sync.*" />
     </Match>
 
     <!-- All bugs in test classes, except for JUnit-specific bugs -->


### PR DESCRIPTION
## This PR

Adds support to bundle new grpc proto schemas of flagd. This is one of several steps to push flagd to use new schemas released with https://github.com/open-feature/flagd-schemas/releases/tag/protobuf-v0.5.3 