### PR TITLE
fix: [go-feature-flag] Make flag metadata optional

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -395,6 +395,9 @@ public class GoFeatureFlagProvider implements FeatureProvider {
      */
     private ImmutableMetadata convertFlagMetadata(Map<String, Object> flagMetadata) {
         ImmutableMetadata.ImmutableMetadataBuilder builder = ImmutableMetadata.builder();
+        if (flagMetadata == null) {
+            return builder.build();
+        }
         flagMetadata.forEach((k, v) -> {
             if (v instanceof Long) {
                 builder.addLong(k, (Long) v);

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -703,6 +703,23 @@ class GoFeatureFlagProviderTest {
 
     @SneakyThrows
     @Test
+    void should_not_fail_if_no_metadata_in_response() {
+        GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
+        String providerName = this.testName;
+        OpenFeatureAPI.getInstance().setProviderAndWait(providerName, g);
+        Client client = OpenFeatureAPI.getInstance().getClient(providerName);
+        FlagEvaluationDetails<Boolean> got = client.getBooleanDetails("no_metadata",false, this.evaluationContext);
+        FlagEvaluationDetails<Boolean> want = FlagEvaluationDetails.<Boolean>builder()
+                .value(true)
+                .variant("True")
+                .flagKey("no_metadata")
+                .reason(Reason.TARGETING_MATCH.name())
+                .build();
+        assertEquals(want, got);
+    }
+
+    @SneakyThrows
+    @Test
     void should_publish_events() {
         GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder()
                 .endpoint(this.baseUrl.toString())

--- a/providers/go-feature-flag/src/test/resources/mock_responses/no_metadata.json
+++ b/providers/go-feature-flag/src/test/resources/mock_responses/no_metadata.json
@@ -1,0 +1,9 @@
+{
+  "trackEvents": true,
+  "variationType": "True",
+  "failed": false,
+  "version": 0,
+  "reason": "TARGETING_MATCH",
+  "errorCode": "",
+  "value": true
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes a `NullPointerException` when receive data without flag metadata from go-feature-flag.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/open-feature/java-sdk-contrib/pull/367#discussion_r1377197199.

### Notes
<!-- any additional notes for this PR -->
The metadata in the flag configuration is an optional field.
> metadata
> (optional)	
> This field allows adding a wealth of information about a particular feature flag, such as a configuration URL or the originating Jira issue.
> https://gofeatureflag.org/docs/configure_flag/flag_format

Also see the following `omitempty` tag which means that the field is not included in the response JSON if empty.
> 	Metadata      map[string]interface{} `json:"metadata,omitempty"`
> https://github.com/thomaspoignant/go-feature-flag/blob/ba95173c873f0bc49cabfe2911f04289d154a04b/internal/flagstate/flag_state.go#L16
### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

