### PR TITLE
fix: [go-feature-flag] Fix NullPointerException on checking anonymous user

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/bean/GoFeatureFlagUser.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/bean/GoFeatureFlagUser.java
@@ -28,18 +28,25 @@ public class GoFeatureFlagUser {
      */
     public static GoFeatureFlagUser fromEvaluationContext(EvaluationContext ctx) {
         String key = ctx.getTargetingKey();
-        if (key == null || "".equals(key)) {
+        if (key == null || key.isEmpty()) {
             throw new TargetingKeyMissingError();
         }
-        Value anonymousValue = ctx.getValue(anonymousFieldName);
-        if (anonymousValue == null) {
-            anonymousValue = new Value(Boolean.FALSE);
-        }
-        boolean anonymous = anonymousValue.asBoolean();
+        boolean anonymous = isAnonymousUser(ctx);
         Map<String, Object> custom = new HashMap<>(ctx.asObjectMap());
         if (ctx.getValue(anonymousFieldName) != null) {
             custom.remove(anonymousFieldName);
         }
         return GoFeatureFlagUser.builder().anonymous(anonymous).key(key).custom(custom).build();
+    }
+
+    /**
+     * isAnonymousUser is checking if the user in the evaluationContext is anonymous.
+     *
+     * @param ctx - EvaluationContext from open-feature
+     * @return true if the user is anonymous, false otherwise
+     */
+    public static boolean isAnonymousUser(EvaluationContext ctx) {
+        Value value = ctx.getValue(anonymousFieldName);
+        return value != null && value.asBoolean();
     }
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/DataCollectorHook.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/DataCollectorHook.java
@@ -2,6 +2,7 @@ package dev.openfeature.contrib.providers.gofeatureflag.hook;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.openfeature.contrib.providers.gofeatureflag.GoFeatureFlagProvider;
+import dev.openfeature.contrib.providers.gofeatureflag.bean.GoFeatureFlagUser;
 import dev.openfeature.contrib.providers.gofeatureflag.exception.InvalidOptions;
 import dev.openfeature.contrib.providers.gofeatureflag.hook.events.Event;
 import dev.openfeature.contrib.providers.gofeatureflag.hook.events.Events;
@@ -73,7 +74,7 @@ public class DataCollectorHook implements Hook {
         Event event = Event.builder()
                 .key(ctx.getFlagKey())
                 .kind("feature")
-                .contextKind(ctx.getCtx().getValue("anonymous").asBoolean() ? "anonymousUser" : "user")
+                .contextKind(GoFeatureFlagUser.isAnonymousUser(ctx.getCtx()) ? "anonymousUser" : "user")
                 .defaultValue(false)
                 .variation(details.getVariant())
                 .value(details.getValue())
@@ -88,7 +89,7 @@ public class DataCollectorHook implements Hook {
         Event event = Event.builder()
                 .key(ctx.getFlagKey())
                 .kind("feature")
-                .contextKind(ctx.getCtx().getValue("anonymous").asBoolean() ? "anonymousUser" : "user")
+                .contextKind(GoFeatureFlagUser.isAnonymousUser(ctx.getCtx()) ? "anonymousUser" : "user")
                 .creationDate(System.currentTimeMillis())
                 .defaultValue(true)
                 .variation("SdkDefault")


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes `java.lang.NullPointerException` error on checking anonymous user in `DataCollectorHook`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

~~Fixes #~~ No issues.

We're facing Null pointer exception on enabling the cache feature.
```
2023-12-25T06:29:07.141Z Unable to correctly evaluate flag with key 'feature-test' java.lang.NullPointerException: Cannot invoke "dev.openfeature.sdk.Value.asBoolean()" because the return value of "dev.openfeature.sdk.EvaluationContext.getValue(String)" is null
        at dev.openfeature.contrib.providers.gofeatureflag.hook.DataCollectorHook.after(DataCollectorHook.java:76)
        at dev.openfeature.sdk.HookSupport.lambda$afterHooks$2(HookSupport.java:32)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at dev.openfeature.sdk.HookSupport.executeHooksUnchecked(HookSupport.java:54)
        at dev.openfeature.sdk.HookSupport.afterHooks(HookSupport.java:32)
        at dev.openfeature.sdk.OpenFeatureClient.evaluateFlag(OpenFeatureClient.java:138)
        at dev.openfeature.sdk.OpenFeatureClient.getBooleanDetails(OpenFeatureClient.java:211)
        at dev.openfeature.sdk.OpenFeatureClient.getBooleanDetails(OpenFeatureClient.java:205)
        at dev.openfeature.sdk.OpenFeatureClient.getBooleanValue(OpenFeatureClient.java:189)
```

We firstly could not find what's happening, but noticed that the evaluation context needs to include the `"anonymous"` boolean field. But I think this field should be optional.

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

