### PR TITLE
chore: allow override of javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <module-name>${groupId}.${artifactId}</module-name>
+        <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>
@@ -342,7 +343,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
                 <configuration>
-                    <failOnWarnings>true</failOnWarnings>
+                    <failOnWarnings>${javadoc.failOnWarnings}</failOnWarnings>
                     <sourceFileExcludes>
                         <sourceFileExclude>**/GoFeatureFlagProviderOptions.java</sourceFileExclude>
                     </sourceFileExcludes>

--- a/providers/flipt/pom.xml
+++ b/providers/flipt/pom.xml
@@ -16,6 +16,10 @@
     <description>Flipt provider for Java</description>
     <url>https://www.flipt.io/</url>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.flipt</groupId>


### PR DESCRIPTION
Allows modules to override this prop, see: https://github.com/open-feature/java-sdk-contrib/pull/638

Don't merge this without approval from @markphelps 