### PR TITLE
fix: targeting key sometimes missing in rule context

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
@@ -161,7 +161,7 @@ public final class GrpcResolver implements Resolver {
         // build the gRPC request
         Message req = request.newBuilderForType()
                 .setField(getFieldDescriptor(request, FLAG_KEY_FIELD), key)
-                .setField(getFieldDescriptor(request, CONTEXT_FIELD), this.convertContext(ctx))
+                .setField(getFieldDescriptor(request, CONTEXT_FIELD), convertContext(ctx))
                 .build();
 
         final Message response;
@@ -216,7 +216,12 @@ public final class GrpcResolver implements Resolver {
      * Recursively convert the Evaluation context to a protobuf structure.
      */
     private static Struct convertContext(EvaluationContext ctx) {
-        return convertMap(ctx.asMap()).getStructValue();
+        Map<String, Value> ctxMap = ctx.asMap();
+        // asMap() does not provide explicitly set targeting key (ex:- new ImmutableContext("TargetingKey") ).
+        // Hence, we add this explicitly here for targeting rule processing.
+        ctxMap.put("targetingKey", new Value(ctx.getTargetingKey()));
+
+        return convertMap(ctxMap).getStructValue();
     }
 
     /**

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -34,6 +34,7 @@ import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.FLAG_WIH_IF_IN_TARGET;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.FLAG_WIH_INVALID_TARGET;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.FLAG_WIH_SHORTHAND_TARGETING;
+import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.FLAG_WITH_TARGETING_KEY;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.INT_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.OBJECT_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.VARIANT_MISMATCH_FLAG;
@@ -331,6 +332,25 @@ class InProcessResolverTest {
         assertEquals("loopAlg", providerEvaluation.getValue());
         assertEquals("loop", providerEvaluation.getVariant());
         assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap), providerState -> {
+        });
+
+        // when
+        ProviderEvaluation<String> providerEvaluation =
+                inProcessResolver.stringEvaluation("stringFlag", "loop", new MutableContext("xyz"));
+
+        // then
+        assertEquals("binetAlg", providerEvaluation.getValue());
+        assertEquals("binet", providerEvaluation.getVariant());
+        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
     }
 
     @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockFlags.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockFlags.java
@@ -73,6 +73,9 @@ public class MockFlags {
     static final FeatureFlag FLAG_WIH_IF_IN_TARGET = new FeatureFlag("ENABLED", "loop", stringVariants,
             "{\"if\":[{\"in\":[\"@faas.com\",{\"var\":[\"email\"]}]},\"binet\",null]}");
 
+    static final FeatureFlag FLAG_WITH_TARGETING_KEY = new FeatureFlag("ENABLED", "loop", stringVariants,
+            "{\"if\":[{\"==\":[{\"var\":\"targetingKey\"},\"xyz\"]},\"binet\",null]}");
+
     // flag with incorrect targeting rule
     static final FeatureFlag FLAG_WIH_INVALID_TARGET = new FeatureFlag("ENABLED", "loop", stringVariants,
             "{if this, then that}");

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/targeting/OperatorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/targeting/OperatorTest.java
@@ -1,5 +1,6 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.targeting;
 
+import static dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Operator.TARGET_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,6 +65,7 @@ class OperatorTest {
         flagdProperties.put(Operator.TIME_STAMP, 1634000000L);
 
         Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(TARGET_KEY, "myTargetingKey");
         dataMap.put(Operator.FLAGD_PROPS_KEY, flagdProperties);
 
         // When
@@ -71,6 +73,7 @@ class OperatorTest {
 
         // Then
         assertEquals("some-key", flagProperties.getFlagKey());
+        assertEquals("myTargetingKey", flagProperties.getTargetingKey());
         assertEquals(1634000000L, flagProperties.getTimestamp());
     }
 


### PR DESCRIPTION
## This PR

Fixes a bug that failed to extract the targeting key when set through the constructor. 

When set through the constructor, 

```Java
 var ctx = new ImmutableContext("TargetingKey")
 ```
 
exposed methods such as `ctc.asObjectMap()` or `ctx.asMap()` does not include the targeting key set at constructor. This PR fixes this by explicitly getting and adding the targeting key for downstream payloads. 