### PR TITLE
fix: null exception when no options used

### DIFF
--- a/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProviderConfig.java
+++ b/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProviderConfig.java
@@ -12,7 +12,8 @@ import lombok.Getter;
 @Builder
 public class StatsigProviderConfig {
 
-    private StatsigOptions options;
+    @Builder.Default
+    private StatsigOptions options = new StatsigOptions();
 
     // Only holding temporary for initialization
     private String sdkKey;


### PR DESCRIPTION
## This PR

Noticed several pipeline failures and seems this is due to the tests fixing in the PR.

@toddbaert  identified this to be an issue with default value of `StatsigOptions`