### PR TITLE
test: fix broken test caused by change in OkHhttp MockWebServer default behaviour

### DIFF
--- a/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
+++ b/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
@@ -67,6 +67,14 @@ public class FlagsmithProviderTest {
         }
     };
 
+    final QueueDispatcher errorDispatcher = new QueueDispatcher() {
+        @SneakyThrows
+        @Override
+        public MockResponse dispatch(RecordedRequest request) {
+            return new MockResponse().setResponseCode(500);
+        }
+    };
+
     private static Stream<Arguments> provideKeysForFlagResolution() {
         return Stream.of(
             Arguments.of("true_key", "getBooleanEvaluation", Boolean.class, "true"),
@@ -132,8 +140,8 @@ public class FlagsmithProviderTest {
         // Error server will always result in FlagsmithApiError's used for
         // tests that need to handle this type of error
         mockFlagsmithErrorServer = new MockWebServer();
+        mockFlagsmithErrorServer.setDispatcher(this.errorDispatcher);
         mockFlagsmithErrorServer.start();
-
 
         FlagsmithProviderOptions options = FlagsmithProviderOptions.builder()
                                                                    .apiKey("API_KEY")


### PR DESCRIPTION
## This PR

Fixes broken test in the [existing renovate PR](https://github.com/open-feature/java-sdk-contrib/pull/734) caused by a (suspected) change in the OkHttp MockWebServer class's default behaviour. 

This PR explicitly updates the mock error server to respond with a 500 error for all requests. 

### Related Issues

N/a

### Notes

N/a

### Follow-up Tasks

N/a

### How to test

`mvn test`

