### PR TITLE
feat: introduce Resolver as a drop in replacement for Evaluator

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -41,7 +41,7 @@ Consider the following example to create a `FlagdProvider` with in-process evalu
 ```java
 FlagdProvider flagdProvider = new FlagdProvider(
         FlagdOptions.builder()
-                .resolverType(Config.Evaluator.IN_PROCESS)
+                .resolverType(Config.Resolver.IN_PROCESS)
                 .build());
 ```
 
@@ -55,7 +55,7 @@ To enable this mode, you should provide a valid flag configuration file with the
 ```java
 FlagdProvider flagdProvider = new FlagdProvider(
         FlagdOptions.builder()
-                .resolverType(Config.Evaluator.IN_PROCESS)
+                .resolverType(Config.Resolver.IN_PROCESS)
                 .offlineFlagSourcePath("PATH")
                 .build());
 ```

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -87,7 +87,6 @@ public final class Config {
 
     /**
      * flagd evaluator type.
-     * <p>
      * Deprecated : Please use {@code Config.Resolver}, which is a drop-in replacement of this.
      */
     @Deprecated

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -40,7 +40,7 @@ public class FlagdOptions {
      * flagd resolving type.
      */
     @Builder.Default
-    private Config.Evaluator resolverType = fromValueProvider(System::getenv);
+    private Config.EvaluatorType resolverType = fromValueProvider(System::getenv);
 
     /**
      * flagd connection host.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -50,11 +50,11 @@ public class FlagdProvider extends EventProvider implements FeatureProvider {
      * @param options {@link FlagdOptions} with
      */
     public FlagdProvider(final FlagdOptions options) {
-        switch (options.getResolverType()) {
-            case IN_PROCESS:
+        switch (options.getResolverType().asString()) {
+            case Config.RESOLVER_IN_PROCESS:
                 this.flagResolver = new InProcessResolver(options, this::setState);
                 break;
-            case RPC:
+            case Config.RESOLVER_RPC:
                 this.flagResolver =
                         new GrpcResolver(options,
                                 new Cache(options.getCacheType(), options.getMaxCacheSize()),

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -33,7 +33,7 @@ public class FlagdOptionsTest {
         assertNull(builder.getSelector());
         assertNull(builder.getOpenTelemetry());
         assertNull(builder.getOfflineFlagSourcePath());
-        assertEquals(Config.Evaluator.RPC, builder.getResolverType());
+        assertEquals(Config.Resolver.RPC, builder.getResolverType());
     }
 
     @Test
@@ -51,7 +51,7 @@ public class FlagdOptionsTest {
                 .selector("app=weatherApp")
                 .offlineFlagSourcePath("some-path")
                 .openTelemetry(openTelemetry)
-                .resolverType(Config.Evaluator.IN_PROCESS)
+                .resolverType(Config.Resolver.IN_PROCESS)
                 .build();
 
         assertEquals("https://hosted-flagd", flagdOptions.getHost());
@@ -64,23 +64,23 @@ public class FlagdOptionsTest {
         assertEquals("app=weatherApp", flagdOptions.getSelector());
         assertEquals("some-path", flagdOptions.getOfflineFlagSourcePath());
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());
-        assertEquals(Config.Evaluator.IN_PROCESS, flagdOptions.getResolverType());
+        assertEquals(Config.Resolver.IN_PROCESS, flagdOptions.getResolverType());
     }
 
 
     @Test
     public void testValueProviderForEdgeCase_valid() {
         Function<String, String> valueProvider = s -> "in-process";
-        assertEquals(Config.Evaluator.IN_PROCESS, Config.fromValueProvider(valueProvider));
+        assertEquals(Config.Resolver.IN_PROCESS, Config.fromValueProvider(valueProvider));
 
         valueProvider = s -> "IN-PROCESS";
-        assertEquals(Config.Evaluator.IN_PROCESS, Config.fromValueProvider(valueProvider));
+        assertEquals(Config.Resolver.IN_PROCESS, Config.fromValueProvider(valueProvider));
 
         valueProvider = s -> "rpc";
-        assertEquals(Config.Evaluator.RPC, Config.fromValueProvider(valueProvider));
+        assertEquals(Config.Resolver.RPC, Config.fromValueProvider(valueProvider));
 
         valueProvider = s -> "RPC";
-        assertEquals(Config.Evaluator.RPC, Config.fromValueProvider(valueProvider));
+        assertEquals(Config.Resolver.RPC, Config.fromValueProvider(valueProvider));
     }
 
     @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/process/FlagdInProcessSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/process/FlagdInProcessSetup.java
@@ -19,7 +19,7 @@ public class FlagdInProcessSetup {
     @BeforeAll()
     public static void setup() throws InterruptedException {
         FlagdInProcessSetup.provider = new FlagdProvider(FlagdOptions.builder()
-        .resolverType(Config.Evaluator.IN_PROCESS)
+        .resolverType(Config.Resolver.IN_PROCESS)
         .deadline(3000)
         .port(9090)
         .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
@@ -17,14 +17,14 @@ public class FlagdInProcessSetup {
     @BeforeAll()
     public static void setup() throws InterruptedException {
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
-        .resolverType(Config.Evaluator.IN_PROCESS)
+        .resolverType(Config.Resolver.IN_PROCESS)
         .deadline(3000)
         .port(9091)
         .build());
         StepDefinitions.setUnstableProvider(workingProvider);
 
         FeatureProvider unavailableProvider = new FlagdProvider(FlagdOptions.builder()
-        .resolverType(Config.Evaluator.IN_PROCESS)
+        .resolverType(Config.Resolver.IN_PROCESS)
         .deadline(100)
         .port(9092) // this port isn't serving anything, error expected
         .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
@@ -18,7 +18,7 @@ public class FlagdRpcSetup {
     @BeforeAll()
     public static void setup() throws InterruptedException {
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
-                .resolverType(Config.Evaluator.RPC)
+                .resolverType(Config.Resolver.RPC)
                 .port(8014)
                 // set a generous deadline, to prevent timeouts in actions
                 .deadline(3000)
@@ -27,7 +27,7 @@ public class FlagdRpcSetup {
         StepDefinitions.setUnstableProvider(workingProvider);
 
         FeatureProvider unavailableProvider = new FlagdProvider(FlagdOptions.builder()
-                .resolverType(Config.Evaluator.RPC)
+                .resolverType(Config.Resolver.RPC)
                 .port(8015) // this port isn't serving anything, error expected
                 // set a generous deadline, to prevent timeouts in actions
                 .deadline(100)

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/rpc/FlagdRpcSetup.java
@@ -20,7 +20,7 @@ public class FlagdRpcSetup {
     @BeforeAll()
     public static void setup() {
         FlagdRpcSetup.provider = new FlagdProvider(FlagdOptions.builder()
-                .resolverType(Config.Evaluator.RPC)
+                .resolverType(Config.Resolver.RPC)
                 // set a generous deadline, to prevent timeouts in actions
                 .deadline(3000)
                 .cacheType(CacheType.DISABLED.getValue())

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -50,9 +50,9 @@ class InProcessResolverTest {
     public void connectorSetup(){
         // given
         FlagdOptions forGrpcOptions =
-                 FlagdOptions.builder().resolverType(Config.Evaluator.IN_PROCESS).host("localhost").port(8080).build();
+                 FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS).host("localhost").port(8080).build();
         FlagdOptions forOfflineOptions =
-                FlagdOptions.builder().resolverType(Config.Evaluator.IN_PROCESS).offlineFlagSourcePath("path").build();
+                FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS).offlineFlagSourcePath("path").build();
 
         // then
         assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));


### PR DESCRIPTION
## This PR

To have consistent naming, I have introduced `Config.Resolver` as a drop-in replacement of `Config.Evaluator`. No breaking change as internal handling is done through a common interface. 

Old

```java
FlagdProvider flagdProvider = new FlagdProvider(
        FlagdOptions.builder()
                .resolverType(Config.Evaluator.IN_PROCESS)
                .build());
```

New

```java
FlagdProvider flagdProvider = new FlagdProvider(
        FlagdOptions.builder()
                .resolverType(Config.Resolver.IN_PROCESS)
                .build());
```

`Config.Evaluator` is deprecated and will be removed in a future release.