### PR TITLE
feat: [flagd] Default port to 8015 if in-process resolver is used.

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -11,7 +11,13 @@ import java.util.function.Function;
 @Slf4j
 public final class Config {
     static final Resolver DEFAULT_RESOLVER_TYPE = Resolver.RPC;
-    static final String DEFAULT_PORT = "8013";
+    static final String DEFAULT_RPC_PORT = "8013";
+    /**
+     * @deprecated Use {@link Config#DEFAULT_RPC_PORT} or {@link Config#DEFAULT_IN_PROCESS_PORT}
+     */
+    @Deprecated
+    static final String DEFAULT_PORT = DEFAULT_RPC_PORT;
+    static final String DEFAULT_IN_PROCESS_PORT = "8015";
     static final String DEFAULT_TLS = "false";
     static final String DEFAULT_HOST = "localhost";
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -12,11 +12,6 @@ import java.util.function.Function;
 public final class Config {
     static final Resolver DEFAULT_RESOLVER_TYPE = Resolver.RPC;
     static final String DEFAULT_RPC_PORT = "8013";
-    /**
-     * @deprecated Use {@link Config#DEFAULT_RPC_PORT} or {@link Config#DEFAULT_IN_PROCESS_PORT}
-     */
-    @Deprecated
-    static final String DEFAULT_PORT = DEFAULT_RPC_PORT;
     static final String DEFAULT_IN_PROCESS_PORT = "8015";
     static final String DEFAULT_TLS = "false";
     static final String DEFAULT_HOST = "localhost";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -5,8 +5,27 @@ import io.opentelemetry.api.OpenTelemetry;
 import lombok.Builder;
 import lombok.Getter;
 
-import static dev.openfeature.contrib.providers.flagd.Config.*;
+import static dev.openfeature.contrib.providers.flagd.Config.BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
+import static dev.openfeature.contrib.providers.flagd.Config.BASE_EVENT_STREAM_RETRY_BACKOFF_MS_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.CACHE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.DEADLINE_MS_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_CACHE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_DEADLINE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_HOST;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_CACHE_SIZE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_EVENT_STREAM_RETRIES;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_TLS;
+import static dev.openfeature.contrib.providers.flagd.Config.HOST_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_CACHE_SIZE_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.OFFLINE_SOURCE_PATH;
+import static dev.openfeature.contrib.providers.flagd.Config.PORT_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SERVER_CERT_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SOCKET_PATH_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.SOURCE_SELECTOR_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.TLS_ENV_VAR_NAME;
 import static dev.openfeature.contrib.providers.flagd.Config.fallBackToEnvOrDefault;
+import static dev.openfeature.contrib.providers.flagd.Config.fromValueProvider;
 
 /**
  * FlagdOptions is a builder to build flagd provider options.
@@ -105,6 +124,11 @@ public class FlagdOptions {
     private OpenTelemetry openTelemetry;
 
 
+    /**
+     * Builder overwrite in order to customize the "build" method.
+     *
+     * @return the flagd options builder
+     */
     public static FlagdOptionsBuilder builder() {
         return new FlagdOptionsBuilder() {
             @Override


### PR DESCRIPTION
closes: #809

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
The flagd provider defaults to RPC mode and the corresponding port (8013) using the [evaluation proto](https://buf.build/open-feature/flagd/docs/main:flagd.evaluation.v1). If the in-process resolver is selected, it operates in in-process mode using the [sync proto](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1), but still uses port 8013, instead of defaulting to the correct port (8015, for the sync proto).

We improve the configuration by defaulting to port 8015 if the in-process resolver is selected.

### Related Issues

Fixes #809
