### PR TITLE
feat: avoid star imports via checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -51,7 +51,7 @@
     <module name="TreeWalker">
         <!-- needed for SuppressWarningsFilter -->
         <module name="SuppressWarningsHolder" />
-        
+
         <module name="SuppressWarnings">
             <property name="id" value="checkstyle:suppresswarnings"/>
         </module>
@@ -62,7 +62,11 @@
                         default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
         </module>
-    
+
+
+        <module name="AvoidStarImport">
+        </module>
+
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -64,8 +64,7 @@
         </module>
 
 
-        <module name="AvoidStarImport">
-        </module>
+        <module name="AvoidStarImport" />
 
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvVarProvider.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvVarProvider.java
@@ -1,6 +1,11 @@
 package dev.openfeature.contrib.providers.envvar;
 
-import dev.openfeature.sdk.*;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Reason;
+import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.ValueNotConvertableError;

--- a/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentKeyTransformer.java
+++ b/providers/env-var/src/main/java/dev/openfeature/contrib/providers/envvar/EnvironmentKeyTransformer.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.envvar;
 
-import java.util.function.*;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;

--- a/providers/jsonlogic-eval-provider/src/main/java/dev/openfeature/contrib/providers/jsonlogic/JsonlogicProvider.java
+++ b/providers/jsonlogic-eval-provider/src/main/java/dev/openfeature/contrib/providers/jsonlogic/JsonlogicProvider.java
@@ -1,6 +1,11 @@
 package dev.openfeature.contrib.providers.jsonlogic;
 
-import dev.openfeature.sdk.*;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Reason;
+import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.ParseError;
 import io.github.jamsesso.jsonlogic.JsonLogic;
 import io.github.jamsesso.jsonlogic.JsonLogicException;


### PR DESCRIPTION
Star imports are seen as a bad practice within Java, as they can lead to too tight coupling with packages and the introduction of name clashes. Hence, we should avoid them.

closes: #816

