### PR TITLE
feat: add JUnit Pioneer as testing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <!-- used so that lombok can generate suppressions for spotbugs. It needs to find it on the relevant classpath -->
             <groupId>com.github.spotbugs</groupId>
@@ -137,6 +137,13 @@
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
             <version>1.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>1.9.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -3,6 +3,7 @@ package dev.openfeature.contrib.providers.flagd;
 import io.opentelemetry.api.OpenTelemetry;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Mockito;
 
 import java.util.function.Function;
@@ -88,7 +89,7 @@ class FlagdOptionsTest {
     }
 
     @Test
-    @Disabled("Currently there is no defined way on how to set environment variables for tests")
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
     void testInProcessProviderFromEnv_noPortConfigured_defaultsToCorrectPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder().build();
 
@@ -107,7 +108,7 @@ class FlagdOptionsTest {
     }
 
     @Test
-    @Disabled("Currently there is no defined way on how to set environment variables for tests")
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
     void testInProcessProviderFromEnv_portConfigured_usesConfiguredPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder()
                 .port(1000)
@@ -118,7 +119,7 @@ class FlagdOptionsTest {
     }
 
     @Test
-    @Disabled("Currently there is no defined way on how to set environment variables for tests")
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_RPC)
     void testRpcProviderFromEnv_noPortConfigured_defaultsToCorrectPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder().build();
 
@@ -137,7 +138,7 @@ class FlagdOptionsTest {
     }
 
     @Test
-    @Disabled("Currently there is no defined way on how to set environment variables for tests")
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_RPC)
     void testRpcProviderFromEnv_portConfigured_usesConfiguredPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder()
                 .port(1534)


### PR DESCRIPTION
JUnit Pioneer offers a great set of additional utilities for JUnit tests, like setting env variables, setting system properties, default locales, etc. This could be a great extension of our testing capabilities without adding another dependency for our provided libraries.

closes: #818
