### PR TITLE
fix: broken netty transport

### DIFF
--- a/providers/flagd/CONTRIBUTING.md
+++ b/providers/flagd/CONTRIBUTING.md
@@ -23,7 +23,7 @@ In vscode for instance, the following settings are recommended:
 The continuous integration runs a set of [gherkin e2e tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
 
 ```
-docker-compose up -d
+docker-compose up
 ```
 and then run 
 ```

--- a/providers/flagd/docker-compose.yaml
+++ b/providers/flagd/docker-compose.yaml
@@ -1,25 +1,17 @@
 services:
   flagd:
-    build:
-      context: test-harness
-      dockerfile: flagd/Dockerfile
+    image: ghcr.io/open-feature/flagd-testbed:v0.5.4
     ports:
       - 8013:8013
   flagd-unstable:
-    build:
-      context: test-harness
-      dockerfile: flagd/Dockerfile.unstable
+    image: ghcr.io/open-feature/flagd-testbed-unstable:v0.5.4
     ports:
       - 8014:8013
   flagd-sync:
-    build:
-      context: test-harness
-      dockerfile: sync/Dockerfile
+    image: ghcr.io/open-feature/sync-testbed:v0.5.4
     ports:
       - 9090:9090
   flagd-sync-unstable:
-    build:
-      context: test-harness
-      dockerfile: sync/Dockerfile.unstable
+    image: ghcr.io/open-feature/sync-testbed-unstable:v0.5.4
     ports:
       - 9091:9090

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -64,7 +64,7 @@
             <!-- we only support unix sockets on linux, via epoll native lib -->
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.111.Final</version>
+            <version>4.1.110.Final</version>
             <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
             <classifier>linux-x86_64</classifier>
         </dependency>


### PR DESCRIPTION
The latest netty epoll version seems to be broken and is causing inconsistent test failures impacting `main` and other PRs. This reverts it.

Also makes some improvements to our docker-compose for local e2e.

See: https://github.com/open-feature/java-sdk-contrib/pull/819