### PR TITLE
fix(gofeatureflag): fix java.lang.NoClassDefFoundError

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static dev.openfeature.sdk.Value.objectToValue;
-import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
+
 
 /**
  * GoFeatureFlagController is the layer to contact the APIs and get the data
@@ -54,6 +54,7 @@ import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
 @Slf4j
 @SuppressWarnings({"checkstyle:NoFinalizer"})
 public class GoFeatureFlagController {
+    public static final String APPLICATION_JSON = "application/json";
     public static final ObjectMapper requestMapper = new ObjectMapper();
     private static final ObjectMapper responseMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -136,7 +137,7 @@ public class GoFeatureFlagController {
 
             Request.Builder reqBuilder = new Request.Builder()
                     .url(url)
-                    .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON.getMimeType())
+                    .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
                     .post(RequestBody.create(
                             requestMapper.writeValueAsBytes(goffRequest),
                             MediaType.get("application/json; charset=utf-8")));
@@ -215,7 +216,7 @@ public class GoFeatureFlagController {
 
             Request.Builder reqBuilder = new Request.Builder()
                     .url(url)
-                    .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON.getMimeType())
+                    .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
                     .post(RequestBody.create(
                             requestMapper.writeValueAsBytes(events),
                             MediaType.get("application/json; charset=utf-8")));
@@ -258,7 +259,7 @@ public class GoFeatureFlagController {
 
         Request.Builder reqBuilder = new Request.Builder()
                 .url(url)
-                .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON.getMimeType())
+                .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
                 .get();
 
         if (this.etag != null && !this.etag.isEmpty()) {


### PR DESCRIPTION
## This PR
Not sure why, but the import `org/apache/hc/core5/http/ContentType` was working fine in the contrib repo BUT the dependency is not working on the built version.

Removing the link to this lib to be sure that we have no more `NoClassDefFoundError` errors.

```
org.gofeatureflag.integrationtests.ProviderTests.authenticatedRelayProxyInvalidToken -- Time elapsed: 0.004 s <<< ERROR!
java.lang.NoClassDefFoundError: org/apache/hc/core5/http/ContentType
	at dev.openfeature.contrib.providers.gofeatureflag.controller.GoFeatureFlagController.evaluateFlag(GoFeatureFlagController.java:138)
	at dev.openfeature.contrib.providers.gofeatureflag.GoFeatureFlagProvider.getEvaluation(GoFeatureFlagProvider.java:218)
	at dev.openfeature.contrib.providers.gofeatureflag.GoFeatureFlagProvider.getBooleanEvaluation(GoFeatureFlagProvider.java:80)
	at dev.openfeature.sdk.OpenFeatureClient.createProviderEvaluation(OpenFeatureClient.java:180)
	at dev.openfeature.sdk.OpenFeatureClient.evaluateFlag(OpenFeatureClient.java:123)
	at dev.openfeature.sdk.OpenFeatureClient.getBooleanDetails(OpenFeatureClient.java:223)
	at dev.openfeature.sdk.OpenFeatureClient.getBooleanDetails(OpenFeatureClient.java:217)
	at org.gofeatureflag.integrationtests.ProviderTests.authenticatedRelayProxyInvalidToken(ProviderTests.java:394)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.ClassNotFoundException: org.apache.hc.core5.http.ContentType
	... 11 more
```