### PR TITLE
chore: Create docker-compose.yml do match CONTRIBUTING.md

### DIFF
--- a/providers/flagd/CONTRIBUTING.md
+++ b/providers/flagd/CONTRIBUTING.md
@@ -23,7 +23,7 @@ In vscode for instance, the following settings are recommended:
 The continuous integration runs a set of [gherkin e2e tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
 
 ```
-docker-compose up
+docker compose up
 ```
 and then run 
 ```

--- a/providers/flagd/docker-compose.yml
+++ b/providers/flagd/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  flagd:
+    build:
+      context: ./test-harness
+      dockerfile: flagd/Dockerfile


### PR DESCRIPTION
CONTRIBUTING.md mentions to use docker compose to run flagd from the testbed, but there is no `docker-compose.yml` file present. This PR add it such that it uses the testbed flagd `DOCKERFILE`.