### PR TITLE
feat: add gRPC keepalive

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -105,6 +105,7 @@ Given below are the supported configurations:
 | socketPath            | FLAGD_SOCKET_PATH              | String                   | null      | rpc & in-process    |
 | certPath              | FLAGD_SERVER_CERT_PATH         | String                   | null      | rpc & in-process    |
 | deadline              | FLAGD_DEADLINE_MS              | int                      | 500       | rpc & in-process    |
+| keepAliveTime         | FLAGD_KEEP_ALIVE_TIME          | long                     | 0         | rpc & in-process    |
 | selector              | FLAGD_SOURCE_SELECTOR          | String                   | null      | in-process          |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled   | lru       | rpc                 |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                      | 1000      | rpc                 |

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -33,7 +33,7 @@ public final class Config {
     static final String DEADLINE_MS_ENV_VAR_NAME = "FLAGD_DEADLINE_MS";
     static final String SOURCE_SELECTOR_ENV_VAR_NAME = "FLAGD_SOURCE_SELECTOR";
     static final String OFFLINE_SOURCE_PATH = "FLAGD_OFFLINE_FLAG_SOURCE_PATH";
-    static final String KEEP_ALIVE_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE";
+    static final String KEEP_ALIVE_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE_TIME";
 
     static final String RESOLVER_RPC = "rpc";
     static final String RESOLVER_IN_PROCESS = "in-process";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -18,6 +18,7 @@ public final class Config {
 
     static final int DEFAULT_DEADLINE = 500;
     static final int DEFAULT_MAX_CACHE_SIZE = 1000;
+    static final long DEFAULT_KEEP_ALIVE = 0;
 
     static final String RESOLVER_ENV_VAR = "FLAGD_RESOLVER";
     static final String HOST_ENV_VAR_NAME = "FLAGD_HOST";
@@ -32,6 +33,7 @@ public final class Config {
     static final String DEADLINE_MS_ENV_VAR_NAME = "FLAGD_DEADLINE_MS";
     static final String SOURCE_SELECTOR_ENV_VAR_NAME = "FLAGD_SOURCE_SELECTOR";
     static final String OFFLINE_SOURCE_PATH = "FLAGD_OFFLINE_FLAG_SOURCE_PATH";
+    static final String KEEP_ALIVE_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE";
 
     static final String RESOLVER_RPC = "rpc";
     static final String RESOLVER_IN_PROCESS = "in-process";
@@ -59,6 +61,14 @@ public final class Config {
     static int fallBackToEnvOrDefault(String key, int defaultValue) {
         try {
             return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    static long fallBackToEnvOrDefault(String key, long defaultValue) {
+        try {
+            return System.getenv(key) != null ? Long.parseLong(System.getenv(key)) : defaultValue;
         } catch (Exception e) {
             return defaultValue;
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -94,6 +94,14 @@ public class FlagdOptions {
     private String selector = fallBackToEnvOrDefault(Config.SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
     /**
+     * gRPC client KeepAlive in milliseconds. Disabled with 0.
+     * Defaults to 0 (disabled).
+     * 
+     **/
+    @Builder.Default
+    private long keepAlive = fallBackToEnvOrDefault(Config.KEEP_ALIVE_ENV_VAR_NAME, Config.DEFAULT_KEEP_ALIVE);
+
+    /**
      * File source of flags to be used by offline mode.
      * Setting this enables the offline mode of the in-process provider.
      */

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -13,6 +13,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 /**
  * gRPC channel builder helper.
@@ -36,6 +37,8 @@ public class ChannelBuilder {
 
             return NettyChannelBuilder
                     .forAddress(new DomainSocketAddress(options.getSocketPath()))
+                    // keepAliveTime: Long.MAX_VALUE disables keepAlive; very small values are increased automatically
+                    .keepAliveTime(options.getKeepAlive() == 0 ? Long.MAX_VALUE : options.getKeepAlive(), TimeUnit.MILLISECONDS)
                     .eventLoopGroup(new EpollEventLoopGroup())
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -38,7 +38,8 @@ public class ChannelBuilder {
             return NettyChannelBuilder
                     .forAddress(new DomainSocketAddress(options.getSocketPath()))
                     // keepAliveTime: Long.MAX_VALUE disables keepAlive; very small values are increased automatically
-                    .keepAliveTime(options.getKeepAlive() == 0 ? Long.MAX_VALUE : options.getKeepAlive(), TimeUnit.MILLISECONDS)
+                    .keepAliveTime(options.getKeepAlive() == 0 ? Long.MAX_VALUE : options.getKeepAlive(),
+                            TimeUnit.MILLISECONDS)
                     .eventLoopGroup(new EpollEventLoopGroup())
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -3,7 +3,6 @@ package dev.openfeature.contrib.providers.flagd;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.MockConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
 import io.opentelemetry.api.OpenTelemetry;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Mockito;
@@ -33,6 +32,7 @@ class FlagdOptionsTest {
         assertNull(builder.getCustomConnector());
         assertNull(builder.getOfflineFlagSourcePath());
         assertEquals(Resolver.RPC, builder.getResolverType());
+        assertEquals(0, builder.getKeepAlive());
     }
 
     @Test
@@ -53,6 +53,7 @@ class FlagdOptionsTest {
                 .openTelemetry(openTelemetry)
                 .customConnector(connector)
                 .resolverType(Resolver.IN_PROCESS)
+                .keepAlive(1000)
                 .build();
 
         assertEquals("https://hosted-flagd", flagdOptions.getHost());
@@ -67,6 +68,7 @@ class FlagdOptionsTest {
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());
         assertEquals(connector, flagdOptions.getCustomConnector());
         assertEquals(Resolver.IN_PROCESS, flagdOptions.getResolverType());
+        assertEquals(1000, flagdOptions.getKeepAlive());
     }
 
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -277,6 +278,7 @@ public class GrpcConnectorTest {
         when(mockChannelBuilder.eventLoopGroup(any(EventLoopGroup.class))).thenReturn(mockChannelBuilder);
         when(mockChannelBuilder.channelType(any(Class.class))).thenReturn(mockChannelBuilder);
         when(mockChannelBuilder.usePlaintext()).thenReturn(mockChannelBuilder);
+        when(mockChannelBuilder.keepAliveTime(anyLong(), any())).thenReturn(mockChannelBuilder);
         when(mockChannelBuilder.build()).thenReturn(null);
         return mockChannelBuilder;
     }


### PR DESCRIPTION
Adds gRPC keepalive.

The according to in-line docs, the keepalive in the netty channel is disabled with Long.MAX_VALUE, so I've mapped that from 0.