### PR TITLE
feat: flow instead of exceptions in resolver

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -19,7 +19,6 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.extern.slf4j.Slf4j;
@@ -165,7 +164,7 @@ public class InProcessResolver implements Resolver {
 
         // missing flag
         if (flag == null) {
-           return ProviderEvaluation.<T>builder()
+            return ProviderEvaluation.<T>builder()
                    .errorMessage("flag: " + key + " not found")
                    .errorCode(ErrorCode.FLAG_NOT_FOUND)
                    .build();

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -12,6 +12,7 @@ import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connecto
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc.GrpcStreamConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Operator;
 import dev.openfeature.contrib.providers.flagd.resolver.process.targeting.TargetingRuleException;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.ProviderEvaluation;
@@ -164,12 +165,18 @@ public class InProcessResolver implements Resolver {
 
         // missing flag
         if (flag == null) {
-            throw new FlagNotFoundError("flag: " + key + " not found");
+           return ProviderEvaluation.<T>builder()
+                   .errorMessage("flag: " + key + " not found")
+                   .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                   .build();
         }
 
         // state check
         if ("DISABLED".equals(flag.getState())) {
-            throw new FlagNotFoundError("flag: " + key + " is disabled");
+            return ProviderEvaluation.<T>builder()
+                    .errorMessage("flag: " + key + " is disabled")
+                    .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                    .build();
         }
 
         final String resolvedVariant;

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -8,6 +8,7 @@ import dev.openfeature.contrib.providers.flagd.resolver.process.storage.StorageS
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.StorageStateChange;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.file.FileConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc.GrpcStreamConnector;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.MutableContext;
@@ -239,10 +240,8 @@ class InProcessResolverTest {
                 });
 
         // when/then
-        assertThrows(FlagNotFoundError.class, () -> {
-            inProcessResolver.booleanEvaluation("missingFlag", false, new ImmutableContext());
-
-        });
+        ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false, new ImmutableContext());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
     }
 
     @Test
@@ -256,9 +255,8 @@ class InProcessResolverTest {
                 });
 
         // when/then
-        assertThrows(FlagNotFoundError.class, () -> {
-            inProcessResolver.booleanEvaluation("disabledFlag", false, new ImmutableContext());
-        });
+        ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false, new ImmutableContext());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
…g not found errors

Exceptions are expensive GOTO statements, and in a performance relevant system not the best to be used for control flow . A FlagNotFound-Error can be expected, but the performance draw backs of exception in this case not.

relates to: https://github.com/open-feature/java-sdk/pull/1095