### PR TITLE
chore: add build support for newer JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <module-name>${groupId}.${artifactId}</module-name>
         <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
+        <!--  This is required for later correct replacement of surefireArgLine -->
+        <!-- see surefire-java8 and surefire-java9+ profiles -->
+        <surefireArgLine/>
     </properties>
 
     <dependencies>
@@ -91,6 +94,24 @@
             <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Start mockito workaround -->
+        <!-- https://github.com/mockito/mockito/issues/3121 -->
+        <!-- These are transitive dependencies of mockito we are forcing -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.15.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.15.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- End mockito workaround-->
 
         <dependency>
             <groupId>uk.org.lidalia</groupId>
@@ -204,19 +225,6 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.0</version>
-                <configuration>
-                    <excludes>
-                        <!-- tests to exclude -->
-                        <exclude>${testExclusions}</exclude>
-                    </excludes>
-                    <argLine>${surefireArgLine}</argLine>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -432,6 +440,60 @@
             <!-- End publish to maven central -->
         </plugins>
     </build>
+
+    <profiles>
+        <!-- profile for running tests under java 8 (used mostly in CI) -->
+        <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
+        <profile>
+            <id>surefire-java8</id>
+            <activation>
+                <!-- JDK 1.8 -->
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <configuration>
+                            <excludes>
+                                <!-- tests to exclude -->
+                                <exclude>${testExclusions}</exclude>
+                            </excludes>
+                            <argLine>@{surefireArgLine}</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- profile for running tests under java 9+ (used for dev environments where people don't want to be locked to Java 8) -->
+        <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
+        <profile>
+            <id>surefire-java9+</id>
+            <activation>
+                <!-- JDK 1.9+ -->
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <configuration>
+                            <excludes>
+                                <!-- tests to exclude -->
+                                <exclude>${testExclusions}</exclude>
+                            </excludes>
+                            <argLine>@{surefireArgLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
This PR adds the ability to build the contribs in the newest versions of Java, but still supports Java 8 which we want in CI for maximum compatibility.

To do this I had to:

- use auto-detection of the JDK version to run the maven-surefire plugin differentially
- add the bytebuddy workarounds as we have in the java-sdk