### PR TITLE
feat: support gRPC over proxy

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -112,6 +112,7 @@ Given below are the supported configurations:
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                      | 5         | rpc                 |
 | retryBackoffMs        | FLAGD_RETRY_BACKOFF_MS         | int                      | 1000      | rpc                 |
 | offlineFlagSourcePath | FLAGD_OFFLINE_FLAG_SOURCE_PATH | String                   | null      | in-process          |
+| authority             | FLAGD_AUTHORITY_OVERRIDE       | String                   | null      | rpc & in-process    |
 
 > [!NOTE]  
 > Some configurations are only applicable for RPC resolver.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -35,6 +35,7 @@ public final class Config {
     static final String OFFLINE_SOURCE_PATH = "FLAGD_OFFLINE_FLAG_SOURCE_PATH";
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME_OLD = "FLAGD_KEEP_ALIVE_TIME";
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE_TIME_MS";
+    static final String AUTHORITY_OVERRIDE = "FLAGD_AUTHORITY_OVERRIDE";
 
     static final String RESOLVER_RPC = "rpc";
     static final String RESOLVER_IN_PROCESS = "in-process";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -96,7 +96,7 @@ public class FlagdOptions {
     /**
      * gRPC client KeepAlive in milliseconds. Disabled with 0.
      * Defaults to 0 (disabled).
-     * 
+     *
      **/
     @Builder.Default
     private long keepAlive = fallBackToEnvOrDefault(Config.KEEP_ALIVE_MS_ENV_VAR_NAME,
@@ -108,6 +108,16 @@ public class FlagdOptions {
      */
     @Builder.Default
     private String offlineFlagSourcePath = fallBackToEnvOrDefault(Config.OFFLINE_SOURCE_PATH, null);
+
+
+    /**
+     * gRPC authority override.
+     * Setting this will allow user to override the system generated authority with
+     * user specified string. This is useful when running flagd gRPC sync service behind
+     * proxy e.g. envoy, istio etc.
+     */
+    @Builder.Default
+    private String authority = fallBackToEnvOrDefault(Config.AUTHORITY_OVERRIDE, null);
 
     /**
      * Inject a Custom Connector for fetching flags.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -53,6 +53,12 @@ public class ChannelBuilder {
             final NettyChannelBuilder builder = NettyChannelBuilder
                     .forAddress(options.getHost(), options.getPort())
                     .keepAliveTime(keepAliveMs, TimeUnit.MILLISECONDS);
+
+
+            if (options.getAuthority() != null) {
+                builder.overrideAuthority(options.getAuthority());
+            }
+
             if (options.isTls()) {
                 SslContextBuilder sslContext = GrpcSslContexts.forClient();
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -34,6 +34,7 @@ class FlagdOptionsTest {
         assertNull(builder.getOfflineFlagSourcePath());
         assertEquals(Resolver.RPC, builder.getResolverType());
         assertEquals(0, builder.getKeepAlive());
+        assertNull(builder.getAuthority());
     }
 
     @Test
@@ -55,6 +56,7 @@ class FlagdOptionsTest {
                 .customConnector(connector)
                 .resolverType(Resolver.IN_PROCESS)
                 .keepAlive(1000)
+                .authority("test.service")
                 .build();
 
         assertEquals("https://hosted-flagd", flagdOptions.getHost());
@@ -70,6 +72,7 @@ class FlagdOptionsTest {
         assertEquals(connector, flagdOptions.getCustomConnector());
         assertEquals(Resolver.IN_PROCESS, flagdOptions.getResolverType());
         assertEquals(1000, flagdOptions.getKeepAlive());
+        assertEquals("test.service", flagdOptions.getAuthority());
     }
 
 
@@ -186,5 +189,14 @@ class FlagdOptionsTest {
         assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.RPC);
         assertThat(flagdOptions.getPort()).isEqualTo(1534);
 
+    }
+
+
+    @Test
+    @SetEnvironmentVariable(key = AUTHORITY_OVERRIDE, value = "test.service")
+    void testAuthorityOverrideFromEnv() {
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getAuthority()).isEqualTo("test.service");
     }
 }


### PR DESCRIPTION
## This PR
Added a new config option `AUTHORITY_OVERRIDE` which will allow users to override system
generated `authority`. This will be useful when running gRPC sync service behind proxy e.g. envoy, istio etc

- support gRPC over proxy

### Related Issues
N/A

### Notes
grpcurl sample using envoy proxy

```
$ grpcurl -vv -plaintext -format=json  -authority flagd-sync.service 127.0.0.1:9211 list flagd.sync.v1.FlagSyncService
flagd.sync.v1.FlagSyncService.FetchAllFlags
flagd.sync.v1.FlagSyncService.GetMetadata
flagd.sync.v1.FlagSyncService.SyncFlags
```

Flagd  Provider Logs:
```
ERROR [2024-09-11 00:38:43,120] dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc.GrpcStreamConnector: Error from grpc connection, retrying in 2000ms
! io.grpc.StatusRuntimeException: UNKNOWN: service not registered for this consumer
! at io.grpc.Status.asRuntimeException(Status.java:537)
! at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:481)
! at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:489)
! at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:453)
! at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:486)
! at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:567)
! at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:71)
! at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:735)
! at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:716)
! at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
! at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
! at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
! at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
! at java.base/java.lang.Thread.run(Thread.java:1583)
WARN  [2024-09-11 00:38:43,125] dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc.GrpcStreamConnector: Stream failed, retrying in 2000ms
ERROR [2024-09-11 00:38:43,377] dev.openfeature.sdk.ProviderRepository: Exception when initializing feature provider dev.openfeature.contrib.providers.flagd.FlagdProvider

```


### Follow-up Tasks
N/A

### How to test
TBD
