### PR TITLE
feat: Add support for http protocols option with flagsmith client

### DIFF
--- a/providers/flagsmith/pom.xml
+++ b/providers/flagsmith/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.flagsmith</groupId>
             <artifactId>flagsmith-java-client</artifactId>
-            <version>7.4.1</version>
+            <version>7.4.2</version>
         </dependency>
 
         <dependency>

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
@@ -2,6 +2,7 @@ package dev.openfeature.contrib.providers.flagsmith;
 
 import com.flagsmith.FlagsmithClient;
 import com.flagsmith.config.FlagsmithCacheConfig;
+import com.flagsmith.config.FlagsmithConfig;
 import com.flagsmith.config.Retry;
 import dev.openfeature.contrib.providers.flagsmith.exceptions.InvalidCacheOptionsException;
 import dev.openfeature.contrib.providers.flagsmith.exceptions.InvalidOptionsException;
@@ -88,10 +89,8 @@ public class FlagsmithClientConfigurer {
      * @param options The options used to create the provider
      * @return a FlagsmithConfig object with the FlagsmithClient settings
      */
-    private static com.flagsmith.config.FlagsmithConfig initializeConfig(
-        FlagsmithProviderOptions options) {
-        com.flagsmith.config.FlagsmithConfig.Builder flagsmithConfig = com.flagsmith.config.FlagsmithConfig
-            .newBuilder();
+    private static FlagsmithConfig initializeConfig(FlagsmithProviderOptions options) {
+        FlagsmithConfig.Builder flagsmithConfig = FlagsmithConfig.newBuilder();
 
         // Set client level configuration settings
         if (options.getBaseUri() != null) {
@@ -134,6 +133,10 @@ public class FlagsmithClientConfigurer {
 
         if (options.isEnableAnalytics()) {
             flagsmithConfig.withEnableAnalytics(options.isEnableAnalytics());
+        }
+
+        if (options.getSupportedProtocols() != null && !options.getSupportedProtocols().isEmpty()) {
+            flagsmithConfig.withSupportedProtocols(options.getSupportedProtocols());
         }
 
         return flagsmithConfig.build();

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
@@ -36,7 +36,7 @@ public class FlagsmithClientConfigurer {
             flagsmithBuilder.withCache(flagsmithCacheConfig);
         }
 
-        com.flagsmith.config.FlagsmithConfig flagsmithConfig = initializeConfig(options);
+        final FlagsmithConfig flagsmithConfig = initializeConfig(options);
         flagsmithBuilder.withConfiguration(flagsmithConfig);
 
         return flagsmithBuilder.build();

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
@@ -2,8 +2,13 @@ package dev.openfeature.contrib.providers.flagsmith;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import com.flagsmith.config.FlagsmithConfig.Protocol;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import lombok.Builder;
 import lombok.Getter;
 import javax.net.ssl.SSLSocketFactory;
@@ -183,4 +188,12 @@ public class FlagsmithProviderOptions {
      */
     @Builder.Default
     private boolean usingBooleanConfigValue = false;
+
+    /**
+     * Set the list of supported protocols that should be used.
+     * Optional.
+     * Default: All the enum protocols from FlagsmithConfig.
+     */
+    @Builder.Default
+    private List<Protocol> supportedProtocols = Arrays.stream(Protocol.values()).collect(Collectors.toList());
 }

--- a/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
+++ b/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
@@ -2,6 +2,7 @@ package dev.openfeature.contrib.providers.flagsmith;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flagsmith.config.FlagsmithConfig;
 import dev.openfeature.contrib.providers.flagsmith.exceptions.InvalidCacheOptionsException;
 import dev.openfeature.contrib.providers.flagsmith.exceptions.InvalidOptionsException;
 import dev.openfeature.sdk.EvaluationContext;
@@ -16,6 +17,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -191,6 +194,7 @@ public class FlagsmithProviderTest {
                                     .environmentRefreshIntervalSeconds(1)
                                     .enableAnalytics(true)
                                     .usingBooleanConfigValue(false)
+                                    .supportedProtocols(Collections.singletonList(FlagsmithConfig.Protocol.HTTP_1_1))
                                     .build();
         assertDoesNotThrow(() -> new FlagsmithProvider(options));
     }


### PR DESCRIPTION
## This PR
There has been new developments in FlagsmithClient library, which allow specification of supported HTTP protocols.

Add support for this new feature of HTTP supported protocols

