### PR TITLE
fix: ConcurrentModificationException on flag config change java 9

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParser.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParser.java
@@ -29,10 +29,7 @@ public class FlagParser {
     private static final String FLAG_KEY = "flags";
     private static final String EVALUATOR_KEY = "$evaluators";
     private static final String REPLACER_FORMAT = "\"\\$ref\":(\\s)*\"%s\"";
-
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final Map<String, Pattern> PATTERN_MAP = new HashMap<>();
-
     private static JsonSchema SCHEMA_VALIDATOR;
 
     private FlagParser() {
@@ -100,6 +97,7 @@ public class FlagParser {
 
     private static String transposeEvaluators(final String configuration) throws IOException {
         try (JsonParser parser = MAPPER.createParser(configuration)) {
+            final Map<String, Pattern> patternMap = new HashMap<>();
             final TreeNode treeNode = parser.readValueAsTree();
             final TreeNode evaluators = treeNode.get(EVALUATOR_KEY);
 
@@ -120,7 +118,7 @@ public class FlagParser {
 
                 // then derive pattern
                 final Pattern reg_replace =
-                        PATTERN_MAP.computeIfAbsent(replacePattern, s -> Pattern.compile(replacePattern));
+                        patternMap.computeIfAbsent(replacePattern, s -> Pattern.compile(replacePattern));
 
                 // finally replace all references
                 replacedConfigurations = reg_replace.matcher(replacedConfigurations).replaceAll(replacer);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -98,9 +99,9 @@ class FlagStoreTest {
         Map<String, FeatureFlag> expectedChangedFlags =
                 FlagParser.parseString(getFlagsFromResource(VALID_LONG),true);
         expectedChangedFlags.remove("myBoolFlag");
-        // flags changed from initial VALID_SIMPLE flag
-        Assert.assertEquals(expectedChangedFlags.keySet().stream().collect(Collectors.toList()),
-                storageStateDTOS.take().getChangedFlagsKeys());
+        // flags changed from initial VALID_SIMPLE flag, as a set because we don't care about order
+        Assert.assertEquals(expectedChangedFlags.keySet().stream().collect(Collectors.toSet()),
+        new HashSet<>(storageStateDTOS.take().getChangedFlagsKeys()));
     }
 
 }


### PR DESCRIPTION
We had a static hashmap that could possibly be modified by multiple threads since `computeIfAbsent` mutates the map.

This is specifically more visible in Java 9 due to some [new additional checks](https://stackoverflow.com/questions/56433061/computeifabsent-throwing-concurrentmodificationexception). This is easily solved by making this static member a local variable.