### PR TITLE
feat!: use sdk-maintained state, require 1.12

### DIFF
--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -39,13 +39,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>dev.openfeature</groupId>
-            <artifactId>sdk</artifactId>
-            <version>[1.4,2.0)</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
             <version>1.30.1-alpha</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,11 @@
     <dependencies>
         <dependency>
             <!-- provided -->
+            <!-- this can be overriden in child POMs to support specific SDK requirements -->
             <groupId>dev.openfeature</groupId>
             <artifactId>sdk</artifactId>
-            <!-- 1.0 <= v < 2.0 -->
-            <version>[1.0,2.0)</version>
+            <!-- 1.12 <= v < 2.0 -->
+            <version>[1.12,2.0)</version>
             <!-- use the version provided at runtime -->
             <scope>provided</scope>
         </dependency>

--- a/providers/configcat/src/main/java/dev/openfeature/contrib/providers/configcat/ConfigCatProvider.java
+++ b/providers/configcat/src/main/java/dev/openfeature/contrib/providers/configcat/ConfigCatProvider.java
@@ -1,23 +1,22 @@
 package dev.openfeature.contrib.providers.configcat;
 
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.configcat.ConfigCatClient;
 import com.configcat.EvaluationDetails;
 import com.configcat.User;
+
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEventDetails;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provider implementation for ConfigCat.

--- a/providers/configcat/src/main/java/dev/openfeature/contrib/providers/configcat/ConfigCatProvider.java
+++ b/providers/configcat/src/main/java/dev/openfeature/contrib/providers/configcat/ConfigCatProvider.java
@@ -36,9 +36,6 @@ public class ConfigCatProvider extends EventProvider {
     @Getter
     private ConfigCatClient configCatClient;
 
-    @Getter
-    private ProviderState state = ProviderState.NOT_READY;
-
     private AtomicBoolean isInitialized = new AtomicBoolean(false);
 
     /**
@@ -64,8 +61,7 @@ public class ConfigCatProvider extends EventProvider {
         configCatClient = ConfigCatClient.get(configCatProviderConfig.getSdkKey(),
             configCatProviderConfig.getOptions());
         configCatProviderConfig.postInit();
-        state = ProviderState.READY;
-        log.info("finished initializing provider, state: {}", state);
+        log.info("finished initializing provider");
 
         configCatClient.getHooks().addOnClientReady(() -> {
             ProviderEventDetails providerEventDetails = ProviderEventDetails.builder()
@@ -123,12 +119,6 @@ public class ConfigCatProvider extends EventProvider {
 
     private <T> ProviderEvaluation<T> getEvaluation(Class<T> classOfT, String key, T defaultValue,
            EvaluationContext ctx) {
-        if (!ProviderState.READY.equals(state)) {
-            if (ProviderState.NOT_READY.equals(state)) {
-                throw new ProviderNotReadyError(PROVIDER_NOT_YET_INITIALIZED);
-            }
-            throw new GeneralError(UNKNOWN_ERROR);
-        }
         User user = ctx == null ? null : ContextTransformer.transform(ctx);
         EvaluationDetails<T> evaluationDetails;
         T evaluatedValue;
@@ -157,6 +147,5 @@ public class ConfigCatProvider extends EventProvider {
         if (configCatClient != null) {
             configCatClient.close();
         }
-        state = ProviderState.NOT_READY;
     }
 }

--- a/providers/configcat/src/test/java/dev/openfeature/contrib/providers/configcat/ConfigCatProviderTest.java
+++ b/providers/configcat/src/test/java/dev/openfeature/contrib/providers/configcat/ConfigCatProviderTest.java
@@ -181,27 +181,6 @@ class ConfigCatProviderTest {
         assertEquals("fallback", client.getStringValue(USERS_FLAG_NAME + "Str", "111", evaluationContext));
     }
 
-    @SneakyThrows
-    @Test
-    void shouldThrowIfNotInitialized() {
-        ConfigCatProviderConfig configCatProviderConfig = ConfigCatProviderConfig.builder().sdkKey("configcat-sdk-1/TEST_KEY-0123456789012/1234567890123456789012").build();
-        ConfigCatProvider tempConfigCatProvider = new ConfigCatProvider(configCatProviderConfig);
-
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
-
-        OpenFeatureAPI.getInstance().setProviderAndWait("tempConfigCatProvider", tempConfigCatProvider);
-
-        assertThrows(GeneralError.class, ()-> tempConfigCatProvider.initialize(null));
-
-        tempConfigCatProvider.shutdown();
-
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getDoubleEvaluation("fail_not_initialized", 0.1, new ImmutableContext()));
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getIntegerEvaluation("fail_not_initialized", 3, new ImmutableContext()));
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getObjectEvaluation("fail_not_initialized", null, new ImmutableContext()));
-        assertThrows(ProviderNotReadyError.class, ()-> tempConfigCatProvider.getStringEvaluation("fail_not_initialized", "", new ImmutableContext()));
-    }
-
     @Test
     void eventsTest() {
         configCatProvider.emitProviderReady(ProviderEventDetails.builder().build());

--- a/providers/configcat/src/test/java/dev/openfeature/contrib/providers/configcat/ConfigCatProviderTest.java
+++ b/providers/configcat/src/test/java/dev/openfeature/contrib/providers/configcat/ConfigCatProviderTest.java
@@ -1,27 +1,26 @@
 package dev.openfeature.contrib.providers.configcat;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import com.configcat.OverrideBehaviour;
 import com.configcat.OverrideDataSourceBuilder;
 import com.configcat.User;
+
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * ConfigCatProvider test, based on local config file evaluation.

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -32,16 +32,7 @@
     </developers>
 
     <dependencies>
-
         <!-- we inherent dev.openfeature.javasdk and the test dependencies from the parent pom -->
-        <!-- override parent definition -->
-        <dependency>
-            <groupId>dev.openfeature</groupId>
-            <artifactId>sdk</artifactId>
-            <version>[1.4,2.0)</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -1,5 +1,7 @@
 package dev.openfeature.contrib.providers.flagd;
 
+import java.util.List;
+
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
@@ -9,20 +11,14 @@ import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEventDetails;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * OpenFeature provider for flagd.
  */
 @Slf4j
-@SuppressWarnings({"PMD.TooManyStaticImports", "checkstyle:NoFinalizer"})
+@SuppressWarnings({ "PMD.TooManyStaticImports", "checkstyle:NoFinalizer" })
 public class FlagdProvider extends EventProvider {
     private static final String FLAGD_PROVIDER = "flagD Provider";
     private final Resolver flagResolver;
@@ -50,14 +46,14 @@ public class FlagdProvider extends EventProvider {
     public FlagdProvider(final FlagdOptions options) {
         switch (options.getResolverType().asString()) {
             case Config.RESOLVER_IN_PROCESS:
-                this.flagResolver = new InProcessResolver(options, this::isConnected, this::onResolverConnectionChanged);
+                this.flagResolver = new InProcessResolver(options, this::isConnected,
+                        this::onResolverConnectionChanged);
                 break;
             case Config.RESOLVER_RPC:
-                this.flagResolver =
-                        new GrpcResolver(options,
-                                new Cache(options.getCacheType(), options.getMaxCacheSize()),
-                                this::isConnected,
-                                this::onResolverConnectionChanged);
+                this.flagResolver = new GrpcResolver(options,
+                        new Cache(options.getCacheType(), options.getMaxCacheSize()),
+                        this::isConnected,
+                        this::onResolverConnectionChanged);
                 break;
             default:
                 throw new IllegalStateException(

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
@@ -1,6 +1,5 @@
 package dev.openfeature.contrib.providers.flagd.resolver.common;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import dev.openfeature.sdk.exceptions.GeneralError;
@@ -15,17 +14,20 @@ public class Util {
 
     /**
      * A helper to block the caller for given conditions.
-     * @param deadline number of milliseconds to block
+     * 
+     * @param deadline          number of milliseconds to block
      * @param connectedSupplier func to check for status true
-     * @throws InterruptedException
+     * @throws InterruptedException if interrupted
      */
-    public static void busyWaitAndCheck(final Long deadline, final Supplier<Boolean> connectedSupplier) throws InterruptedException {
+    public static void busyWaitAndCheck(final Long deadline, final Supplier<Boolean> connectedSupplier)
+            throws InterruptedException {
         long start = System.currentTimeMillis();
 
         do {
             if (deadline <= System.currentTimeMillis() - start) {
                 throw new GeneralError(
-                    String.format("Deadline exceeded. Condition did not complete within the %d deadline", deadline));
+                        String.format("Deadline exceeded. Condition did not complete within the %d deadline",
+                                deadline));
             }
 
             Thread.sleep(50L);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.flagd.resolver.common;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import dev.openfeature.sdk.exceptions.GeneralError;
 
@@ -14,11 +15,11 @@ public class Util {
 
     /**
      * A helper to block the caller for given conditions.
-     *
      * @param deadline number of milliseconds to block
-     * @param check    {@link AtomicBoolean} to check for status true
+     * @param connectedSupplier func to check for status true
+     * @throws InterruptedException
      */
-    public static void busyWaitAndCheck(final Long deadline, final AtomicBoolean check) throws InterruptedException {
+    public static void busyWaitAndCheck(final Long deadline, final Supplier<Boolean> connectedSupplier) throws InterruptedException {
         long start = System.currentTimeMillis();
 
         do {
@@ -28,6 +29,6 @@ public class Util {
             }
 
             Thread.sleep(50L);
-        } while (!check.get());
+        } while (!connectedSupplier.get());
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -1,18 +1,18 @@
 package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
-import com.google.protobuf.Value;
-import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
-import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
-import dev.openfeature.sdk.ProviderState;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.grpc.stub.StreamObserver;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+
+import com.google.protobuf.Value;
+
+import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
+import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * EventStreamObserver handles events emitted by flagd.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -20,7 +20,7 @@ import java.util.function.BiConsumer;
 @Slf4j
 @SuppressFBWarnings(justification = "cache needs to be read and write by multiple objects")
 class EventStreamObserver implements StreamObserver<EventStreamResponse> {
-    private final BiConsumer<ProviderState, List<String>> stateConsumer;
+    private final BiConsumer<Boolean, List<String>> stateConsumer;
     private final Object sync;
     private final Cache cache;
 
@@ -35,7 +35,7 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
      * @param cache         cache to update
      * @param stateConsumer lambda to call for setting the state
      */
-    EventStreamObserver(Object sync, Cache cache, BiConsumer<ProviderState, List<String>> stateConsumer) {
+    EventStreamObserver(Object sync, Cache cache, BiConsumer<Boolean, List<String>> stateConsumer) {
         this.sync = sync;
         this.cache = cache;
         this.stateConsumer = stateConsumer;
@@ -61,7 +61,7 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
         if (this.cache.getEnabled()) {
             this.cache.clear();
         }
-        this.stateConsumer.accept(ProviderState.ERROR, Collections.emptyList());
+        this.stateConsumer.accept(false, Collections.emptyList());
 
         // handle last call of this stream
         handleEndOfStream();
@@ -72,7 +72,7 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
         if (this.cache.getEnabled()) {
             this.cache.clear();
         }
-        this.stateConsumer.accept(ProviderState.ERROR, Collections.emptyList());
+        this.stateConsumer.accept(false, Collections.emptyList());
 
         // handle last call of this stream
         handleEndOfStream();
@@ -99,11 +99,11 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
             }
         }
 
-        this.stateConsumer.accept(ProviderState.READY, changedFlags);
+        this.stateConsumer.accept(true, changedFlags);
     }
 
     private void handleProviderReadyEvent() {
-        this.stateConsumer.accept(ProviderState.READY, Collections.emptyList());
+        this.stateConsumer.accept(true, Collections.emptyList());
         if (this.cache.getEnabled()) {
             this.cache.clear();
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -4,8 +4,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
 import dev.openfeature.contrib.providers.flagd.resolver.common.Util;
@@ -13,7 +14,6 @@ import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamRequest;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
-import dev.openfeature.sdk.ProviderState;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 @SuppressFBWarnings(justification = "cache needs to be read and write by multiple objects")
 public class GrpcConnector {
     private final Object sync = new Object();
-    private final AtomicBoolean connected = new AtomicBoolean(false);
     private final Random random = new Random();
 
     private final ServiceGrpc.ServiceBlockingStub serviceBlockingStub;
@@ -38,7 +37,8 @@ public class GrpcConnector {
     private final long deadline;
 
     private final Cache cache;
-    private final BiConsumer<ProviderState, List<String>> stateConsumer;
+    private final BiConsumer<Boolean, List<String>> stateConsumer;
+    private final Supplier<Boolean> connectedSupplier;
 
     private int eventStreamAttempt = 1;
     private int eventStreamRetryBackoff;
@@ -53,8 +53,8 @@ public class GrpcConnector {
      * @param cache         cache to use.
      * @param stateConsumer lambda to call for setting the state.
      */
-    public GrpcConnector(final FlagdOptions options, final Cache cache,
-            BiConsumer<ProviderState, List<String>> stateConsumer) {
+    public GrpcConnector(final FlagdOptions options, final Cache cache, final Supplier<Boolean> connectedSupplier,
+            BiConsumer<Boolean, List<String>> stateConsumer) {
         this.channel = ChannelBuilder.nettyChannel(options);
         this.serviceStub = ServiceGrpc.newStub(channel);
         this.serviceBlockingStub = ServiceGrpc.newBlockingStub(channel);
@@ -65,6 +65,7 @@ public class GrpcConnector {
         this.deadline = options.getDeadline();
         this.cache = cache;
         this.stateConsumer = stateConsumer;
+        this.connectedSupplier = connectedSupplier;
     }
 
     /**
@@ -76,7 +77,7 @@ public class GrpcConnector {
         eventObserverThread.start();
 
         // block till ready
-        Util.busyWaitAndCheck(this.deadline, this.connected);
+        Util.busyWaitAndCheck(this.deadline, this.connectedSupplier);
     }
 
     /**
@@ -103,7 +104,7 @@ public class GrpcConnector {
                 this.channel.awaitTermination(this.deadline, TimeUnit.MILLISECONDS);
                 log.warn(String.format("Unable to shut down channel by %d deadline", this.deadline));
             }
-            this.stateConsumer.accept(ProviderState.NOT_READY, Collections.emptyList());
+            this.stateConsumer.accept(false, Collections.emptyList());
         }
     }
 
@@ -154,21 +155,16 @@ public class GrpcConnector {
         }
 
         log.error("failed to connect to event stream, exhausted retries");
-        this.grpcStateConsumer(ProviderState.ERROR, null);
+        this.grpcStateConsumer(false, null);
     }
 
-    private void grpcStateConsumer(final ProviderState state, final List<String> changedFlags) {
-        // check for readiness
-        if (ProviderState.READY.equals(state)) {
+    private void grpcStateConsumer(final boolean connected, final List<String> changedFlags) {
+        // reset reconnection states
+        if (connected) {
             this.eventStreamAttempt = 1;
             this.eventStreamRetryBackoff = this.startEventStreamRetryBackoff;
-            this.connected.set(true);
-        } else if (ProviderState.ERROR.equals(state)) {
-            // reset connection status
-            this.connected.set(false);
         }
-
         // chain to initiator
-        this.stateConsumer.accept(state, changedFlags);
+        this.stateConsumer.accept(connected, changedFlags);
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -44,8 +44,12 @@ public class InProcessResolver implements Resolver {
 
     /**
      * Initialize an in-process resolver.
+     * @param options flagd options
+     * @param connectedSupplier supplier for connection state
+     * @param onResolverConnectionChanged handler for connection change
      */
-    public InProcessResolver(FlagdOptions options, final Supplier<Boolean> connectedSupplier, BiConsumer<Boolean, List<String>> onResolverConnectionChanged) {
+    public InProcessResolver(FlagdOptions options, final Supplier<Boolean> connectedSupplier,
+            BiConsumer<Boolean, List<String>> onResolverConnectionChanged) {
         this.flagStore = new FlagStore(getConnector(options));
         this.deadline = options.getDeadline();
         this.onResolverConnectionChanged = onResolverConnectionChanged;
@@ -160,9 +164,9 @@ public class InProcessResolver implements Resolver {
         // missing flag
         if (flag == null) {
             return ProviderEvaluation.<T>builder()
-                   .errorMessage("flag: " + key + " not found")
-                   .errorCode(ErrorCode.FLAG_NOT_FOUND)
-                   .build();
+                    .errorMessage("flag: " + key + " not found")
+                    .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                    .build();
         }
 
         // state check

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -1,5 +1,11 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process;
 
+import static dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag.EMPTY_TARGETING_STRING;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.common.Util;
@@ -16,18 +22,11 @@ import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-
-import static dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag.EMPTY_TARGETING_STRING;
 
 /**
  * flagd in-process resolver. Resolves feature flags in-process. Flags are
@@ -37,20 +36,21 @@ import static dev.openfeature.contrib.providers.flagd.resolver.process.model.Fea
 @Slf4j
 public class InProcessResolver implements Resolver {
     private final Storage flagStore;
-    private final BiConsumer<ProviderState, List<String>> stateConsumer;
+    private final BiConsumer<Boolean, List<String>> onResolverConnectionChanged;
     private final Operator operator;
     private final long deadline;
     private final ImmutableMetadata metadata;
-    private final AtomicBoolean connected = new AtomicBoolean(false);
+    private final Supplier<Boolean> connectedSupplier;
 
     /**
      * Initialize an in-process resolver.
      */
-    public InProcessResolver(FlagdOptions options, BiConsumer<ProviderState, List<String>> stateConsumer) {
+    public InProcessResolver(FlagdOptions options, final Supplier<Boolean> connectedSupplier, BiConsumer<Boolean, List<String>> onResolverConnectionChanged) {
         this.flagStore = new FlagStore(getConnector(options));
         this.deadline = options.getDeadline();
-        this.stateConsumer = stateConsumer;
+        this.onResolverConnectionChanged = onResolverConnectionChanged;
         this.operator = new Operator();
+        this.connectedSupplier = connectedSupplier;
         this.metadata = options.getSelector() == null ? null
                 : ImmutableMetadata.builder()
                         .addString("scope", options.getSelector())
@@ -68,15 +68,11 @@ public class InProcessResolver implements Resolver {
                     final StorageStateChange storageStateChange = flagStore.getStateQueue().take();
                     switch (storageStateChange.getStorageState()) {
                         case OK:
-                            stateConsumer.accept(ProviderState.READY, storageStateChange.getChangedFlagsKeys());
-                            this.connected.set(true);
+                            onResolverConnectionChanged.accept(true, storageStateChange.getChangedFlagsKeys());
                             break;
                         case ERROR:
-                            stateConsumer.accept(ProviderState.ERROR, null);
-                            this.connected.set(false);
+                            onResolverConnectionChanged.accept(false, null);
                             break;
-                        case STALE:
-                            // todo set stale state
                         default:
                             log.info(String.format("Storage emitted unhandled status: %s",
                                     storageStateChange.getStorageState()));
@@ -91,7 +87,7 @@ public class InProcessResolver implements Resolver {
         stateWatcher.start();
 
         // block till ready
-        Util.busyWaitAndCheck(this.deadline, this.connected);
+        Util.busyWaitAndCheck(this.deadline, this.connectedSupplier);
     }
 
     /**
@@ -101,8 +97,7 @@ public class InProcessResolver implements Resolver {
      */
     public void shutdown() throws InterruptedException {
         flagStore.shutdown();
-        this.connected.set(false);
-        stateConsumer.accept(ProviderState.NOT_READY, null);
+        onResolverConnectionChanged.accept(false, null);
     }
 
     /**

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -51,388 +51,397 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class InProcessResolverTest {
 
-    @Test
-    public void connectorSetup() {
-        // given
-        FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS).host("localhost")
-                .port(8080).build();
-        FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                .offlineFlagSourcePath("path").build();
-        FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                .customConnector(new MockConnector(null)).build();
+        @Test
+        public void connectorSetup() {
+                // given
+                FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .host("localhost")
+                                .port(8080).build();
+                FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .offlineFlagSourcePath("path").build();
+                FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .customConnector(new MockConnector(null)).build();
 
-        // then
-        assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
-        assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
-        assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
-    }
-
-    @Test
-    public void eventHandling() throws Throwable {
-        // given
-        // note - queues with adequate capacity
-        final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
-        final BlockingQueue<ProviderState> receiver = new LinkedBlockingQueue<>(5);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
-                (providerState, changedFlagKeys) -> receiver.offer(providerState));
-
-        // when - init and emit events
-        Thread initThread = new Thread(() -> {
-            try {
-                inProcessResolver.init();
-            } catch (Exception e) {
-            }
-        });
-        initThread.start();
-        if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.EMPTY_LIST), 100, TimeUnit.MILLISECONDS)) {
-            Assertions.fail("failed to send the event");
-        }
-        if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
-            Assertions.fail("failed to send the event");
+                // then
+                assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
+                assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
+                assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
         }
 
-        // then - receive events in order
-        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-            Assertions.assertEquals(ProviderState.READY, receiver.take());
-        });
+        @Test
+        public void eventHandling() throws Throwable {
+                // given
+                // note - queues with adequate capacity
+                final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
+                final BlockingQueue<Boolean> receiver = new LinkedBlockingQueue<>(5);
 
-        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-            Assertions.assertEquals(ProviderState.ERROR, receiver.take());
-        });
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
+                                (connectedState, changedFlagKeys) -> receiver.offer(connectedState));
 
-    @Test
-    public void simpleBooleanResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("booleanFlag", BOOLEAN_FLAG);
+                // when - init and emit events
+                Thread initThread = new Thread(() -> {
+                        try {
+                                inProcessResolver.init();
+                        } catch (Exception e) {
+                        }
+                });
+                initThread.start();
+                if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.EMPTY_LIST), 100,
+                                TimeUnit.MILLISECONDS)) {
+                        Assertions.fail("failed to send the event");
+                }
+                if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
+                        Assertions.fail("failed to send the event");
+                }
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
+                // then - receive events in order
+                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+                        Assertions.assertTrue(receiver.take());
                 });
 
-        // when
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag", false,
-                new ImmutableContext());
-
-        // then
-        assertEquals(true, providerEvaluation.getValue());
-        assertEquals("on", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void simpleDoubleResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("doubleFlag", DOUBLE_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
+                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+                        Assertions.assertFalse(receiver.take());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
-                new ImmutableContext());
+        @Test
+        public void simpleBooleanResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("booleanFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(3.141d, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
 
-    @Test
-    public void fetchIntegerAsDouble() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("doubleFlag", DOUBLE_FLAG);
+                // when
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                                false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
+                // then
+                assertEquals(true, providerEvaluation.getValue());
+                assertEquals("on", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleDoubleResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(3.141d, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void fetchIntegerAsDouble() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(3, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void fetchDoubleAsInt() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("integerFlag", INT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(1d, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleIntResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("integerFlag", INT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(1, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleObjectResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("objectFlag", OBJECT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                Map<String, Object> typeDefault = new HashMap<>();
+                typeDefault.put("key", "0164");
+                typeDefault.put("date", "01.01.1990");
+
+                // when
+                ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
+                                Value.objectToValue(typeDefault), new ImmutableContext());
+
+                // then
+                Value value = providerEvaluation.getValue();
+                Map<String, Value> valueMap = value.asStructure().asMap();
+
+                assertEquals("0165", valueMap.get("key").asString());
+                assertEquals("01.01.2000", valueMap.get("date").asString());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+                assertEquals("typeA", providerEvaluation.getVariant());
+        }
+
+        @Test
+        public void missingFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when/then
+                ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false,
+                                new ImmutableContext());
+                assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
+        }
+
+        @Test
+        public void disabledFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("disabledFlag", DISABLED_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when/then
+                ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false,
+                                new ImmutableContext());
+                assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
+        }
+
+        @Test
+        public void variantMismatchFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when/then
+                assertThrows(TypeMismatchError.class, () -> {
+                        inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
-                new ImmutableContext());
+        @Test
+        public void typeMismatchEvaluation() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(3, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
 
-    @Test
-    public void fetchDoubleAsInt() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("integerFlag", INT_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
+                // when/then
+                assertThrows(TypeMismatchError.class, () -> {
+                        inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
-                new ImmutableContext());
+        @Test
+        public void booleanShorthandEvaluation() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
 
-        // then
-        assertEquals(1d, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
 
-    @Test
-    public void simpleIntResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("integerFlag", INT_FLAG);
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
+                // then
+                assertEquals(true, providerEvaluation.getValue());
+                assertEquals("true", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingMatchedEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                                "loopAlg",
+                                new MutableContext().add("email", "abc@faas.com"));
+
+                // then
+                assertEquals("binetAlg", providerEvaluation.getValue());
+                assertEquals("binet", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingUnmatchedEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                                "loopAlg",
+                                new MutableContext().add("email", "abc@abc.com"));
+
+                // then
+                assertEquals("loopAlg", providerEvaluation.getValue());
+                assertEquals("loop", providerEvaluation.getVariant());
+                assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
+                                new MutableContext("xyz"));
+
+                // then
+                assertEquals("binetAlg", providerEvaluation.getValue());
+                assertEquals("binet", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingErrorEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (providerState, changedFlagKeys) -> {
+                                });
+
+                // when/then
+                assertThrows(ParseError.class, () -> {
+                        inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
-                new ImmutableContext());
+        @Test
+        public void validateMetadataInEvaluationResult() throws Exception {
+                // given
+                final String scope = "appName=myApp";
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("booleanFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(1, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(
+                                FlagdOptions.builder().selector(scope).build(),
+                                new MockStorage(flagMap));
 
-    @Test
-    public void simpleObjectResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("objectFlag", OBJECT_FLAG);
+                // when
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                                false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
+                // then
+                final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
+                assertNotNull(metadata);
+                assertEquals(scope, metadata.getString("scope"));
+        }
 
-        Map<String, Object> typeDefault = new HashMap<>();
-        typeDefault.put("key", "0164");
-        typeDefault.put("date", "01.01.1990");
+        private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        // when
-        ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
-                Value.objectToValue(typeDefault), new ImmutableContext());
+                final InProcessResolver resolver = new InProcessResolver(options, () -> true,
+                                (providerState, changedFlagKeys) -> {
+                                });
+                return injectFlagStore(resolver, storage);
+        }
 
-        // then
-        Value value = providerEvaluation.getValue();
-        Map<String, Value> valueMap = value.asStructure().asMap();
+        private InProcessResolver getInProcessResolverWth(final MockStorage storage,
+                        final BiConsumer<Boolean, List<String>> stateConsumer)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        assertEquals("0165", valueMap.get("key").asString());
-        assertEquals("01.01.2000", valueMap.get("date").asString());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        assertEquals("typeA", providerEvaluation.getVariant());
-    }
+                final InProcessResolver resolver = new InProcessResolver(
+                                FlagdOptions.builder().deadline(1000).build(), () -> true, stateConsumer);
+                return injectFlagStore(resolver, storage);
+        }
 
-    @Test
-    public void missingFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        // helper to inject flagStore override
+        private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
+                final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
+                flagStore.setAccessible(true);
+                flagStore.set(resolver, storage);
 
-        // when/then
-        ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false, new ImmutableContext());
-        assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
-    }
-
-    @Test
-    public void disabledFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("disabledFlag", DISABLED_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when/then
-        ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false, new ImmutableContext());
-        assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
-    }
-
-    @Test
-    public void variantMismatchFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when/then
-        assertThrows(TypeMismatchError.class, () -> {
-            inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void typeMismatchEvaluation() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", BOOLEAN_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when/then
-        assertThrows(TypeMismatchError.class, () -> {
-            inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void booleanShorthandEvaluation() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
-                new ImmutableContext());
-
-        // then
-        assertEquals(true, providerEvaluation.getValue());
-        assertEquals("true", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingMatchedEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loopAlg",
-                new MutableContext().add("email", "abc@faas.com"));
-
-        // then
-        assertEquals("binetAlg", providerEvaluation.getValue());
-        assertEquals("binet", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingUnmatchedEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loopAlg",
-                new MutableContext().add("email", "abc@abc.com"));
-
-        // then
-        assertEquals("loopAlg", providerEvaluation.getValue());
-        assertEquals("loop", providerEvaluation.getVariant());
-        assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
-                new MutableContext("xyz"));
-
-        // then
-        assertEquals("binetAlg", providerEvaluation.getValue());
-        assertEquals("binet", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingErrorEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys) -> {
-                });
-
-        // when/then
-        assertThrows(ParseError.class, () -> {
-            inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void validateMetadataInEvaluationResult() throws Exception {
-        // given
-        final String scope = "appName=myApp";
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("booleanFlag", BOOLEAN_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(
-                FlagdOptions.builder().selector(scope).build(),
-                new MockStorage(flagMap));
-
-        // when
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag", false,
-                new ImmutableContext());
-
-        // then
-        final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
-        assertNotNull(metadata);
-        assertEquals(scope, metadata.getString("scope"));
-    }
-
-    private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final InProcessResolver resolver = new InProcessResolver(options, (providerState, changedFlagKeys) -> {
-        });
-        return injectFlagStore(resolver, storage);
-    }
-
-    private InProcessResolver getInProcessResolverWth(final MockStorage storage,
-            final BiConsumer<ProviderState, List<String>> stateConsumer)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final InProcessResolver resolver = new InProcessResolver(
-                FlagdOptions.builder().deadline(1000).build(), stateConsumer);
-        return injectFlagStore(resolver, storage);
-    }
-
-    // helper to inject flagStore override
-    private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
-        flagStore.setAccessible(true);
-        flagStore.set(resolver, storage);
-
-        return resolver;
-    }
+                return resolver;
+        }
 
 }

--- a/providers/flipt/src/main/java/dev/openfeature/contrib/providers/flipt/FliptProvider.java
+++ b/providers/flipt/src/main/java/dev/openfeature/contrib/providers/flipt/FliptProvider.java
@@ -1,15 +1,18 @@
 package dev.openfeature.contrib.providers.flipt;
 
+import static dev.openfeature.sdk.Reason.DEFAULT;
+import static dev.openfeature.sdk.Reason.TARGETING_MATCH;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.ProviderEventDetails;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import io.flipt.api.FliptClient;
 import io.flipt.api.evaluation.models.BooleanEvaluationResponse;
 import io.flipt.api.evaluation.models.EvaluationRequest;
@@ -18,12 +21,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static dev.openfeature.sdk.Reason.DEFAULT;
-import static dev.openfeature.sdk.Reason.TARGETING_MATCH;
 
 /**
  * Provider implementation for Flipt.
@@ -75,16 +72,6 @@ public class FliptProvider extends EventProvider {
     @Override
     public Metadata getMetadata() {
         return () -> NAME;
-    }
-
-    @Override
-    public void emitProviderReady(ProviderEventDetails details) {
-        super.emitProviderReady(details);
-    }
-
-    @Override
-    public void emitProviderError(ProviderEventDetails details) {
-        super.emitProviderError(details);
     }
 
     @Override

--- a/providers/flipt/src/test/java/dev/openfeature/contrib/providers/flipt/FliptProviderTest.java
+++ b/providers/flipt/src/test/java/dev/openfeature/contrib/providers/flipt/FliptProviderTest.java
@@ -173,40 +173,4 @@ class FliptProviderTest {
                 evaluationContext);
         assertEquals(null, nonExistingFlagEvaluation.getFlagMetadata().getBoolean("variant-attachment"));
     }
-
-    @SneakyThrows
-    @Test
-    void shouldThrowIfNotInitialized() {
-        FliptProvider asyncInitfliptProvider = buildFliptProvider();
-        assertEquals(ProviderState.NOT_READY, asyncInitfliptProvider.getState());
-
-        // ErrorCode.PROVIDER_NOT_READY should be returned when evaluated via the client
-        assertThrows(ProviderNotReadyError.class, () -> asyncInitfliptProvider
-                .getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
-        assertThrows(ProviderNotReadyError.class,
-                () -> asyncInitfliptProvider.getStringEvaluation("fail_not_initialized", "", new ImmutableContext()));
-
-        asyncInitfliptProvider.initialize(null);
-        assertThrows(GeneralError.class, () -> asyncInitfliptProvider.initialize(null));
-
-        asyncInitfliptProvider.shutdown();
-    }
-
-    @SneakyThrows
-    @Test
-    void shouldThrowIfErrorEvent() {
-        FliptProvider asyncInitfliptProvider = buildFliptProvider();
-        asyncInitfliptProvider.initialize(new ImmutableContext());
-
-        asyncInitfliptProvider.emitProviderError(ProviderEventDetails.builder().build());
-
-        // ErrorCode.PROVIDER_NOT_READY should be returned when evaluated via the client
-        assertThrows(GeneralError.class,
-                () -> asyncInitfliptProvider.getBooleanEvaluation("fail", false, new ImmutableContext()));
-        assertThrows(GeneralError.class,
-                () -> asyncInitfliptProvider.getStringEvaluation("fail", "", new ImmutableContext()));
-
-        asyncInitfliptProvider.shutdown();
-    }
-
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProvider.java
@@ -1,6 +1,13 @@
 package dev.openfeature.contrib.providers.gofeatureflag;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+
 import dev.openfeature.contrib.providers.gofeatureflag.bean.ConfigurationChange;
 import dev.openfeature.contrib.providers.gofeatureflag.controller.CacheController;
 import dev.openfeature.contrib.providers.gofeatureflag.controller.GoFeatureFlagController;
@@ -16,22 +23,14 @@ import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEventDetails;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.PublishSubject;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * GoFeatureFlagProvider is the JAVA provider implementation for the feature flag solution GO Feature Flag.

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -182,33 +182,6 @@ class GoFeatureFlagProviderTest {
 
     @SneakyThrows
     @Test
-    void should_return_not_ready_if_not_initialized() {
-        GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build()) {
-            @Override
-            public void initialize(EvaluationContext evaluationContext) throws Exception {
-
-                // make the provider not initialized for this test
-                Thread.sleep(3000);
-            }
-        };
-
-        /*
-         ErrorCode.PROVIDER_NOT_READY and default value should be returned when evaluated via the client,
-         see next step in this test.
-         */
-        assertThrows(ProviderNotReadyError.class, () -> g.getBooleanEvaluation("bool_targeting_match", false, this.evaluationContext));
-
-        String providerName = "shouldReturnNotReadyIfNotInitialized";
-        OpenFeatureAPI.getInstance().setProviderAndWait(providerName, g);
-        assertThat(OpenFeatureAPI.getInstance().getProvider(providerName).getState()).isEqualTo(ProviderState.NOT_READY);
-        Client client = OpenFeatureAPI.getInstance().getClient(providerName);
-        FlagEvaluationDetails<Boolean> booleanFlagEvaluationDetails = client.getBooleanDetails("return_error_when_not_initialized", false, new ImmutableContext("targetingKey"));
-        assertEquals(ErrorCode.PROVIDER_NOT_READY, booleanFlagEvaluationDetails.getErrorCode());
-        assertEquals(Boolean.FALSE, booleanFlagEvaluationDetails.getValue());
-    }
-
-    @SneakyThrows
-    @Test
     void client_test() {
         GoFeatureFlagProvider g = new GoFeatureFlagProvider(GoFeatureFlagProviderOptions.builder().endpoint(this.baseUrl.toString()).timeout(1000).build());
         String providerName = "clientTest";

--- a/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProvider.java
+++ b/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProvider.java
@@ -3,7 +3,6 @@ package dev.openfeature.contrib.providers.statsig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProvider.java
+++ b/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/StatsigProvider.java
@@ -1,32 +1,31 @@
 package dev.openfeature.contrib.providers.statsig;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.statsig.sdk.APIFeatureGate;
 import com.statsig.sdk.DynamicConfig;
 import com.statsig.sdk.EvaluationReason;
 import com.statsig.sdk.Layer;
 import com.statsig.sdk.Statsig;
 import com.statsig.sdk.StatsigUser;
+
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provider implementation for Statsig.
@@ -36,17 +35,8 @@ public class StatsigProvider extends EventProvider {
 
     @Getter
     private static final String NAME = "Statsig";
-
-    private static final String PROVIDER_NOT_YET_INITIALIZED = "provider not yet initialized";
-    private static final String UNKNOWN_ERROR = "unknown error";
     private static final String FEATURE_CONFIG_KEY = "feature_config";
-
     private final StatsigProviderConfig statsigProviderConfig;
-
-    @Getter
-    private ProviderState state = ProviderState.NOT_READY;
-
-    private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
     /**
      * Constructor.
@@ -63,19 +53,12 @@ public class StatsigProvider extends EventProvider {
      */
     @Override
     public void initialize(EvaluationContext evaluationContext) throws Exception {
-        boolean initialized = isInitialized.getAndSet(true);
-        if (initialized && ProviderState.READY.equals(state)) {
-            log.debug("already initialized");
-            return;
-        }
-
         Future<Void> initFuture = Statsig.initializeAsync(statsigProviderConfig.getSdkKey(),
             statsigProviderConfig.getOptions());
         initFuture.get();
 
         statsigProviderConfig.postInit();
-        state = ProviderState.READY;
-        log.info("finished initializing provider, state: {}", state);
+        log.info("finished initializing provider");
     }
 
     @Override
@@ -87,7 +70,6 @@ public class StatsigProvider extends EventProvider {
     @Override
     @SuppressFBWarnings(value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "reason can be null")
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
-        verifyEvaluation();
         StatsigUser user = ContextTransformer.transform(ctx);
         Boolean evaluatedValue = defaultValue;
         Value featureConfigValue = ctx.getValue(FEATURE_CONFIG_KEY);
@@ -136,7 +118,6 @@ public class StatsigProvider extends EventProvider {
 
     @Override
     public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
-        verifyEvaluation();
         StatsigUser user = ContextTransformer.transform(ctx);
         FeatureConfig featureConfig = parseFeatureConfig(ctx);
         String evaluatedValue = defaultValue;
@@ -159,7 +140,6 @@ public class StatsigProvider extends EventProvider {
 
     @Override
     public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
-        verifyEvaluation();
         StatsigUser user = ContextTransformer.transform(ctx);
         FeatureConfig featureConfig = parseFeatureConfig(ctx);
         Integer evaluatedValue = defaultValue;
@@ -182,7 +162,6 @@ public class StatsigProvider extends EventProvider {
 
     @Override
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
-        verifyEvaluation();
         StatsigUser user = ContextTransformer.transform(ctx);
         FeatureConfig featureConfig = parseFeatureConfig(ctx);
         Double evaluatedValue = defaultValue;
@@ -206,7 +185,6 @@ public class StatsigProvider extends EventProvider {
     @SneakyThrows
     @Override
     public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
-        verifyEvaluation();
         StatsigUser user = ContextTransformer.transform(ctx);
         FeatureConfig featureConfig = parseFeatureConfig(ctx);
         Value evaluatedValue = defaultValue;
@@ -293,27 +271,11 @@ public class StatsigProvider extends EventProvider {
         return new FeatureConfig(type, name);
     }
 
-    private void verifyEvaluation() throws ProviderNotReadyError, GeneralError {
-        if (!ProviderState.READY.equals(state)) {
-
-            /*
-            According to spec Requirement 2.4.5:
-            "The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready."
-            https://github.com/open-feature/spec/blob/main/specification/sections/02-providers.md#requirement-245
-             */
-            if (ProviderState.NOT_READY.equals(state)) {
-                throw new ProviderNotReadyError(PROVIDER_NOT_YET_INITIALIZED);
-            }
-            throw new GeneralError(UNKNOWN_ERROR);
-        }
-    }
-
     @SneakyThrows
     @Override
     public void shutdown() {
         log.info("shutdown");
         Statsig.shutdown();
-        state = ProviderState.NOT_READY;
     }
 
     /**

--- a/providers/statsig/src/test/java/dev/openfeature/contrib/providers/statsig/StatsigProviderTest.java
+++ b/providers/statsig/src/test/java/dev/openfeature/contrib/providers/statsig/StatsigProviderTest.java
@@ -300,19 +300,7 @@ class StatsigProviderTest {
         assertEquals(false, statsigProvider.getBooleanEvaluation(PROPERTIES_FLAG_NAME, false,
             evaluationContext).getValue());
     }
-
-    @SneakyThrows
-    @Test
-    void shouldThrowIfNotInitialized() {
-        StatsigProviderConfig statsigProviderConfig = StatsigProviderConfig.builder().sdkKey("test").build();
-        StatsigProvider tempstatsigProvider = new StatsigProvider(statsigProviderConfig);
-
-        assertThrows(ProviderNotReadyError.class, ()-> tempstatsigProvider.getBooleanEvaluation(
-        "fail_not_initialized", false, new ImmutableContext()));
-
-        OpenFeatureAPI.getInstance().setProviderAndWait("tempstatsigProvider", tempstatsigProvider);
-    }
-
+    
     @SneakyThrows
     @Test
     void contextTransformTest() {

--- a/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
+++ b/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
@@ -1,15 +1,17 @@
 package dev.openfeature.contrib.providers.unleash;
 
+import static io.getunleash.Variant.DISABLED_VARIANT;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEventDetails;
-import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import io.getunleash.DefaultUnleash;
 import io.getunleash.Unleash;
 import io.getunleash.UnleashContext;
@@ -19,10 +21,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static io.getunleash.Variant.DISABLED_VARIANT;
 
 /**
  * Provider implementation for Unleash.
@@ -44,10 +42,6 @@ public class UnleashProvider extends EventProvider {
     @Setter(AccessLevel.PROTECTED)
     @Getter
     private Unleash unleash;
-
-    @Setter(AccessLevel.PROTECTED)
-    @Getter
-    private ProviderState state = ProviderState.NOT_READY;
 
     private AtomicBoolean isInitialized = new AtomicBoolean(false);
 
@@ -78,8 +72,7 @@ public class UnleashProvider extends EventProvider {
         unleash = new DefaultUnleash(unleashConfig);
 
         // Unleash is per definition ready after it is initialized.
-        state = ProviderState.READY;
-        log.info("finished initializing provider, state: {}", state);
+        log.info("finished initializing provider");
     }
 
     @Override
@@ -90,23 +83,15 @@ public class UnleashProvider extends EventProvider {
     @Override
     public void emitProviderReady(ProviderEventDetails details) {
         super.emitProviderReady(details);
-        state = ProviderState.READY;
     }
 
     @Override
     public void emitProviderError(ProviderEventDetails details) {
         super.emitProviderError(details);
-        state = ProviderState.ERROR;
     }
 
     @Override
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
-        if (!ProviderState.READY.equals(state)) {
-            if (ProviderState.NOT_READY.equals(state)) {
-                throw new ProviderNotReadyError(PROVIDER_NOT_YET_INITIALIZED);
-            }
-            throw new GeneralError(UNKNOWN_ERROR);
-        }
         UnleashContext context = ctx == null ? UnleashContext.builder().build() : ContextTransformer.transform(ctx);
         boolean featureBooleanValue = unleash.isEnabled(key, context, defaultValue);
         return ProviderEvaluation.<Boolean>builder()
@@ -172,12 +157,6 @@ public class UnleashProvider extends EventProvider {
 
     @Override
     public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
-        if (!ProviderState.READY.equals(state)) {
-            if (ProviderState.NOT_READY.equals(state)) {
-                throw new ProviderNotReadyError(PROVIDER_NOT_YET_INITIALIZED);
-            }
-            throw new GeneralError(UNKNOWN_ERROR);
-        }
         UnleashContext context = ctx == null ? UnleashContext.builder().build() : ContextTransformer.transform(ctx);
         Variant evaluatedVariant = unleash.getVariant(key, context);
         String variantName;
@@ -209,6 +188,5 @@ public class UnleashProvider extends EventProvider {
         if (unleash != null) {
             unleash.shutdown();
         }
-        state = ProviderState.NOT_READY;
     }
 }

--- a/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
+++ b/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
@@ -9,7 +9,6 @@ import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import io.getunleash.DefaultUnleash;
@@ -80,16 +79,7 @@ public class UnleashProvider extends EventProvider {
         return () -> NAME;
     }
 
-    @Override
-    public void emitProviderReady(ProviderEventDetails details) {
-        super.emitProviderReady(details);
-    }
-
-    @Override
-    public void emitProviderError(ProviderEventDetails details) {
-        super.emitProviderError(details);
-    }
-
+    
     @Override
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
         UnleashContext context = ctx == null ? UnleashContext.builder().build() : ContextTransformer.transform(ctx);

--- a/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashSubscriberWrapper.java
+++ b/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashSubscriberWrapper.java
@@ -1,8 +1,11 @@
 package dev.openfeature.contrib.providers.unleash;
 
+import javax.annotation.Nullable;
+
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.ProviderEventDetails;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.getunleash.UnleashException;
 import io.getunleash.event.ImpressionEvent;
 import io.getunleash.event.ToggleEvaluated;
@@ -17,8 +20,6 @@ import io.getunleash.repository.ToggleCollection;
 import lombok.Generated;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
-
 /**
  * UnleashSubscriber wrapper for emitting event provider events.
  */
@@ -31,9 +32,11 @@ public class UnleashSubscriberWrapper implements UnleashSubscriber {
 
     /**
      * Constructor.
+     * 
      * @param unleashSubscriber subscriber
-     * @param eventProvider events provider for emitting events.
+     * @param eventProvider     events provider for emitting events.
      */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" })
     public UnleashSubscriberWrapper(@Nullable UnleashSubscriber unleashSubscriber, EventProvider eventProvider) {
         this.unleashSubscriber = unleashSubscriber;
         this.eventProvider = eventProvider;

--- a/tools/junit-openfeature/pom.xml
+++ b/tools/junit-openfeature/pom.xml
@@ -27,13 +27,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>dev.openfeature</groupId>
-            <artifactId>sdk</artifactId>
-            <version>[1.4,2.0)</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.17.0</version>


### PR DESCRIPTION
This PR:

- removes all `ProviderState` from providers - the SDK now keeps track of this so providers do not have to
- updates and remove associated tests
- updates minimum SDK version to 1.12 which has this feature

Nothing here is breaking for consumers, it's a transparent change with the exception they will have to update their SDK version.

see: https://github.com/open-feature/java-sdk/pull/1096