### PR TITLE
feat: expose sync-metadata, call RPC with (re)connect

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -47,6 +47,13 @@ FlagdProvider flagdProvider = new FlagdProvider(
 
 In the above example, in-process handlers attempt to connect to a sync service on address `localhost:8013` to obtain [flag definitions](https://github.com/open-feature/schemas/blob/main/json/flags.json).
 
+#### Sync-metadata
+
+To support the injection of contextual data configured in flagd for in-process evaluation, the provider exposes a `getSyncMetadata` accessor which provides the most recent value returned by the [GetMetadata RPC](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata).
+The value is updated with every (re)connection to the sync implementation.
+This can be used to enrich evaluations with such data.
+If the `in-process` mode is not used, and before the provider is ready, the `getSyncMetadata` returns an empty map.
+
 #### Offline mode
 
 In-process resolvers can also work in an offline mode.

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -19,7 +19,7 @@
     </properties>
 
     <name>flagd</name>
-    <description>FlagD provider for Java</description>
+    <description>flagd provider for Java</description>
     <url>https://openfeature.dev</url>
 
     <developers>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -1,10 +1,10 @@
 package dev.openfeature.contrib.providers.flagd;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.contrib.providers.flagd.resolver.process.InProcessResolver;
@@ -145,17 +145,16 @@ public class FlagdProvider extends EventProvider {
         return this.connected;
     }
 
-    private void onConnectionEvent(boolean newConnectedState, List<String> changedFlagKeys,
-            Map<String, Object> syncMetadata) {
+    private void onConnectionEvent(ConnectionEvent connectionEvent) {
         boolean previous = connected;
-        boolean current = newConnectedState;
-        this.connected = newConnectedState;
-        this.syncMetadata = syncMetadata;
+        boolean current = connected = connectionEvent.isConnected();
+        syncMetadata = connectionEvent.getSyncMetadata();
 
         // configuration changed
         if (initialized && previous && current) {
             log.debug("Configuration changed");
-            ProviderEventDetails details = ProviderEventDetails.builder().flagsChanged(changedFlagKeys)
+            ProviderEventDetails details = ProviderEventDetails.builder()
+                    .flagsChanged(connectionEvent.getFlagsChanged())
                     .message("configuration changed").build();
             this.emitProviderConfigurationChanged(details);
             return;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SuppressWarnings({ "PMD.TooManyStaticImports", "checkstyle:NoFinalizer" })
 public class FlagdProvider extends EventProvider {
-    private static final String FLAGD_PROVIDER = "flagd Provider";
+    private static final String FLAGD_PROVIDER = "flagd";
     private final Resolver flagResolver;
     private volatile boolean initialized = false;
     private volatile boolean connected = false;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SuppressWarnings({ "PMD.TooManyStaticImports", "checkstyle:NoFinalizer" })
 public class FlagdProvider extends EventProvider {
-    private static final String FLAGD_PROVIDER = "flagD Provider";
+    private static final String FLAGD_PROVIDER = "flagd Provider";
     private final Resolver flagResolver;
     private volatile boolean initialized = false;
     private volatile boolean connected = false;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -1,6 +1,8 @@
 package dev.openfeature.contrib.providers.flagd;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcResolver;
@@ -24,6 +26,7 @@ public class FlagdProvider extends EventProvider {
     private final Resolver flagResolver;
     private volatile boolean initialized = false;
     private volatile boolean connected = false;
+    private volatile Map<String, Object> syncMetadata = Collections.emptyMap();
 
     private EvaluationContext evaluationContext;
 
@@ -47,13 +50,13 @@ public class FlagdProvider extends EventProvider {
         switch (options.getResolverType().asString()) {
             case Config.RESOLVER_IN_PROCESS:
                 this.flagResolver = new InProcessResolver(options, this::isConnected,
-                        this::onResolverConnectionChanged);
+                        this::onConnectionEvent);
                 break;
             case Config.RESOLVER_RPC:
                 this.flagResolver = new GrpcResolver(options,
                         new Cache(options.getCacheType(), options.getMaxCacheSize()),
                         this::isConnected,
-                        this::onResolverConnectionChanged);
+                        this::onConnectionEvent);
                 break;
             default:
                 throw new IllegalStateException(
@@ -117,6 +120,19 @@ public class FlagdProvider extends EventProvider {
         return this.flagResolver.objectEvaluation(key, defaultValue, mergeContext(ctx));
     }
 
+    /**
+     * An unmodifiable view of an object map representing the latest result of the
+     * SyncMetadata.
+     * Set on initial connection and updated with every reconnection.
+     * see:
+     * https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata
+     * 
+     * @return Object map representing sync metadata
+     */
+    protected Map<String, Object> getSyncMetadata() {
+        return Collections.unmodifiableMap(syncMetadata);
+    }
+
     private EvaluationContext mergeContext(final EvaluationContext clientCallCtx) {
         if (this.evaluationContext != null) {
             return evaluationContext.merge(clientCallCtx);
@@ -129,10 +145,12 @@ public class FlagdProvider extends EventProvider {
         return this.connected;
     }
 
-    private void onResolverConnectionChanged(boolean newConnectedState, List<String> changedFlagKeys) {
+    private void onConnectionEvent(boolean newConnectedState, List<String> changedFlagKeys,
+            Map<String, Object> syncMetadata) {
         boolean previous = connected;
         boolean current = newConnectedState;
         this.connected = newConnectedState;
+        this.syncMetadata = syncMetadata;
 
         // configuration changed
         if (initialized && previous && current) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/Resolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/Resolver.java
@@ -5,7 +5,7 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
 
 /**
- * A generic flag resolving contract for flagd.
+ * Abstraction that resolves flag values in from some source. 
  */
 public interface Resolver {
     void init() throws Exception;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionEvent.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionEvent.java
@@ -1,0 +1,68 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event payload for a
+ * {@link dev.openfeature.contrib.providers.flagd.resolver.Resolver} connection
+ * state change event.
+ */
+@AllArgsConstructor
+public class ConnectionEvent {
+    @Getter
+    private final boolean connected;
+    private final List<String> flagsChanged;
+    private final Map<String, Object> syncMetadata;
+
+    /**
+     * Construct a new ConnectionEvent.
+     * 
+     * @param connected status of the connection
+     */
+    public ConnectionEvent(boolean connected) {
+        this(connected, Collections.emptyList(), Collections.emptyMap());
+    }
+
+    /**
+     * Construct a new ConnectionEvent.
+     * 
+     * @param connected    status of the connection
+     * @param flagsChanged list of flags changed
+     */
+    public ConnectionEvent(boolean connected, List<String> flagsChanged) {
+        this(connected, flagsChanged, Collections.emptyMap());
+    }
+
+    /**
+     * Construct a new ConnectionEvent.
+     * 
+     * @param connected    status of the connection
+     * @param syncMetadata sync.getMetadata
+     */
+    public ConnectionEvent(boolean connected, Map<String, Object> syncMetadata) {
+        this(connected, Collections.emptyList(), syncMetadata);
+    }
+
+    /**
+     * Get changed flags.
+     * 
+     * @return an unmodifiable view of the changed flags
+     */
+    public List<String> getFlagsChanged() {
+        return Collections.unmodifiableList(flagsChanged);
+    }
+
+    /**
+     * Get changed sync metadata.
+     * 
+     * @return an unmodifiable view of the sync metadata
+     */
+    public Map<String, Object> getSyncMetadata() {
+        return Collections.unmodifiableMap(syncMetadata);
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Convert.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Convert.java
@@ -1,0 +1,184 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Message;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Struct;
+
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.MutableStructure;
+import dev.openfeature.sdk.Structure;
+import dev.openfeature.sdk.Value;
+
+/**
+ * gRPC type conversion utils.
+ */
+public class Convert {
+    /**
+     * Recursively convert protobuf structure to openfeature value.
+     */
+    public static Value convertObjectResponse(Struct protobuf) {
+        return convertProtobufMap(protobuf.getFieldsMap());
+    }
+
+    /**
+     * Recursively convert the Evaluation context to a protobuf structure.
+     */
+    public static Struct convertContext(EvaluationContext ctx) {
+        Map<String, Value> ctxMap = ctx.asMap();
+        // asMap() does not provide explicitly set targeting key (ex:- new
+        // ImmutableContext("TargetingKey") ).
+        // Hence, we add this explicitly here for targeting rule processing.
+        ctxMap.put("targetingKey", new Value(ctx.getTargetingKey()));
+
+        return convertMap(ctxMap).getStructValue();
+    }
+
+    /**
+     * Convert any openfeature value to a protobuf value.
+     */
+    public static com.google.protobuf.Value convertAny(Value value) {
+        if (value.isList()) {
+            return convertList(value.asList());
+        } else if (value.isStructure()) {
+            return convertMap(value.asStructure().asMap());
+        } else {
+            return convertPrimitive(value);
+        }
+    }
+
+    /**
+     * Convert any protobuf value to {@link Value}.
+     */
+    public static Value convertAny(com.google.protobuf.Value protobuf) {
+        if (protobuf.hasListValue()) {
+            return convertList(protobuf.getListValue());
+        } else if (protobuf.hasStructValue()) {
+            return convertProtobufMap(protobuf.getStructValue().getFieldsMap());
+        } else {
+            return convertPrimitive(protobuf);
+        }
+    }
+
+    /**
+     * Convert OpenFeature map to protobuf {@link com.google.protobuf.Value}.
+     */
+    public static com.google.protobuf.Value convertMap(Map<String, Value> map) {
+        Map<String, com.google.protobuf.Value> values = new HashMap<>();
+
+        map.keySet().forEach((String key) -> {
+            Value value = map.get(key);
+            values.put(key, convertAny(value));
+        });
+        Struct struct = Struct.newBuilder()
+                .putAllFields(values).build();
+        return com.google.protobuf.Value.newBuilder().setStructValue(struct).build();
+    }
+
+    /**
+     * Convert protobuf map with {@link com.google.protobuf.Value} to OpenFeature
+     * map.
+     */
+    public static Value convertProtobufMap(Map<String, com.google.protobuf.Value> map) {
+        return new Value(convertProtobufMapToStructure(map));
+    }
+
+    /**
+     * Convert protobuf map with {@link com.google.protobuf.Value} to OpenFeature
+     * map.
+     */
+    public static Structure convertProtobufMapToStructure(Map<String, com.google.protobuf.Value> map) {
+        Map<String, Value> values = new HashMap<>();
+
+        map.keySet().forEach((String key) -> {
+            com.google.protobuf.Value value = map.get(key);
+            values.put(key, convertAny(value));
+        });
+        return new MutableStructure(values);
+    }
+
+    /**
+     * Convert OpenFeature list to protobuf {@link com.google.protobuf.Value}.
+     */
+    public static com.google.protobuf.Value convertList(List<Value> values) {
+        ListValue list = ListValue.newBuilder()
+                .addAllValues(values.stream()
+                        .map(v -> convertAny(v)).collect(Collectors.toList()))
+                .build();
+        return com.google.protobuf.Value.newBuilder().setListValue(list).build();
+    }
+
+    /**
+     * Convert protobuf list to OpenFeature {@link com.google.protobuf.Value}.
+     */
+    public static Value convertList(ListValue protobuf) {
+        return new Value(protobuf.getValuesList().stream().map(p -> convertAny(p)).collect(Collectors.toList()));
+    }
+
+    /**
+     * Convert OpenFeature {@link Value} to protobuf
+     * {@link com.google.protobuf.Value}.
+     */
+    public static com.google.protobuf.Value convertPrimitive(Value value) {
+        com.google.protobuf.Value.Builder builder = com.google.protobuf.Value.newBuilder();
+
+        if (value.isBoolean()) {
+            builder.setBoolValue(value.asBoolean());
+        } else if (value.isString()) {
+            builder.setStringValue(value.asString());
+        } else if (value.isNumber()) {
+            builder.setNumberValue(value.asDouble());
+        } else {
+            builder.setNullValue(NullValue.NULL_VALUE);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert protobuf {@link com.google.protobuf.Value} to OpenFeature
+     * {@link Value}.
+     */
+    public static Value convertPrimitive(com.google.protobuf.Value protobuf) {
+        final Value value;
+        if (protobuf.hasBoolValue()) {
+            value = new Value(protobuf.getBoolValue());
+        } else if (protobuf.hasStringValue()) {
+            value = new Value(protobuf.getStringValue());
+        } else if (protobuf.hasNumberValue()) {
+            value = new Value(protobuf.getNumberValue());
+        } else {
+            value = new Value();
+        }
+
+        return value;
+    }
+
+    /**
+     * Get the specified protobuf field from the message.
+     * 
+     * @param <T> type
+     * @param message protobuf message
+     * @param name    field name
+     * @return field value
+     */
+    public static <T> T getField(Message message, String name) {
+        return (T) message.getField(getFieldDescriptor(message, name));
+    }
+
+    /**
+     * Get the specified protobuf field descriptor from the message.
+     * 
+     * @param message protobuf message
+     * @param name    field name
+     * @return field descriptor
+     */
+    public static Descriptors.FieldDescriptor getFieldDescriptor(Message message, String name) {
+        return message.getDescriptorForType().findFieldByName(name);
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/Constants.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/Constants.java
@@ -1,0 +1,10 @@
+package dev.openfeature.contrib.providers.flagd.resolver.grpc;
+
+/**
+ * Constants for evaluation proto.
+ */
+public class Constants {
+    public static final String CONFIGURATION_CHANGE = "configuration_change";
+    public static final String PROVIDER_READY = "provider_ready";
+    public static final String FLAGS_KEY = "flags";
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -31,14 +31,14 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
     /**
      * Create a gRPC stream that get notified about flag changes.
      *
-     * @param sync          synchronization object from caller
-     * @param cache         cache to update
-     * @param onResponse lambda to call to handle the response
+     * @param sync              synchronization object from caller
+     * @param cache             cache to update
+     * @param onConnectionEvent lambda to call to handle the response
      */
-    EventStreamObserver(Object sync, Cache cache, BiConsumer<Boolean, List<String>> onResponse) {
+    EventStreamObserver(Object sync, Cache cache, BiConsumer<Boolean, List<String>> onConnectionEvent) {
         this.sync = sync;
         this.cache = cache;
-        this.onConnectionEvent = onResponse;
+        this.onConnectionEvent = onConnectionEvent;
     }
 
     @Override

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -24,10 +24,6 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
     private final Object sync;
     private final Cache cache;
 
-    public static final String CONFIGURATION_CHANGE = "configuration_change";
-    public static final String PROVIDER_READY = "provider_ready";
-    static final String FLAGS_KEY = "flags";
-
     /**
      * Create a gRPC stream that get notified about flag changes.
      *
@@ -44,10 +40,10 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
     @Override
     public void onNext(EventStreamResponse value) {
         switch (value.getType()) {
-            case CONFIGURATION_CHANGE:
+            case Constants.CONFIGURATION_CHANGE:
                 this.handleConfigurationChangeEvent(value);
                 break;
-            case PROVIDER_READY:
+            case Constants.PROVIDER_READY:
                 this.handleProviderReadyEvent();
                 break;
             default:
@@ -83,7 +79,7 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
         boolean cachingEnabled = this.cache.getEnabled();
 
         Map<String, Value> data = value.getData().getFieldsMap();
-        Value flagsValue = data.get(FLAGS_KEY);
+        Value flagsValue = data.get(Constants.FLAGS_KEY);
         if (flagsValue == null) {
             if (cachingEnabled) {
                 this.cache.clear();

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -159,7 +159,7 @@ public class GrpcConnector {
         this.grpconConnectionEvent(false, Collections.emptyList());
     }
 
-    private void grpconConnectionEvent(final boolean connected, final List<String> changedFlags) {
+    private void grpcOnConnectionEvent(final boolean connected, final List<String> changedFlags) {
         // reset reconnection states
         if (connected) {
             this.eventStreamAttempt = 1;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -2,9 +2,9 @@ package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
@@ -14,6 +14,7 @@ import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamRequest;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
+import dev.openfeature.sdk.internal.TriConsumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
@@ -37,7 +38,7 @@ public class GrpcConnector {
     private final long deadline;
 
     private final Cache cache;
-    private final BiConsumer<Boolean, List<String>> stateConsumer;
+    private final TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent;
     private final Supplier<Boolean> connectedSupplier;
 
     private int eventStreamAttempt = 1;
@@ -48,23 +49,23 @@ public class GrpcConnector {
 
     /**
      * GrpcConnector creates an abstraction over gRPC communication.
-     *
-     * @param options       options to build the gRPC channel.
-     * @param cache         cache to use.
-     * @param stateConsumer lambda to call for setting the state.
+     * 
+     * @param options flagd options
+     * @param cache cache to use
+     * @param connectedSupplier lambda providing current connection status from caller
+     * @param onConnectionEvent lambda which handles changes in the connection/stream
      */
     public GrpcConnector(final FlagdOptions options, final Cache cache, final Supplier<Boolean> connectedSupplier,
-            BiConsumer<Boolean, List<String>> stateConsumer) {
+            TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent) {
         this.channel = ChannelBuilder.nettyChannel(options);
         this.serviceStub = ServiceGrpc.newStub(channel);
         this.serviceBlockingStub = ServiceGrpc.newBlockingStub(channel);
-
         this.maxEventStreamRetries = options.getMaxEventStreamRetries();
         this.startEventStreamRetryBackoff = options.getRetryBackoffMs();
         this.eventStreamRetryBackoff = options.getRetryBackoffMs();
         this.deadline = options.getDeadline();
         this.cache = cache;
-        this.stateConsumer = stateConsumer;
+        this.onConnectionEvent = onConnectionEvent;
         this.connectedSupplier = connectedSupplier;
     }
 
@@ -104,7 +105,7 @@ public class GrpcConnector {
                 this.channel.awaitTermination(this.deadline, TimeUnit.MILLISECONDS);
                 log.warn(String.format("Unable to shut down channel by %d deadline", this.deadline));
             }
-            this.stateConsumer.accept(false, Collections.emptyList());
+            this.onConnectionEvent.accept(false, Collections.emptyList(), Collections.emptyMap());
         }
     }
 
@@ -124,7 +125,7 @@ public class GrpcConnector {
     private void observeEventStream() {
         while (this.eventStreamAttempt <= this.maxEventStreamRetries) {
             final StreamObserver<EventStreamResponse> responseObserver = new EventStreamObserver(sync, this.cache,
-                    this::grpcStateConsumer);
+                    this::grpconConnectionEvent);
             this.serviceStub.eventStream(EventStreamRequest.getDefaultInstance(), responseObserver);
 
             try {
@@ -155,16 +156,16 @@ public class GrpcConnector {
         }
 
         log.error("failed to connect to event stream, exhausted retries");
-        this.grpcStateConsumer(false, null);
+        this.grpconConnectionEvent(false, Collections.emptyList());
     }
 
-    private void grpcStateConsumer(final boolean connected, final List<String> changedFlags) {
+    private void grpconConnectionEvent(final boolean connected, final List<String> changedFlags) {
         // reset reconnection states
         if (connected) {
             this.eventStreamAttempt = 1;
             this.eventStreamRetryBackoff = this.startEventStreamRetryBackoff;
         }
         // chain to initiator
-        this.stateConsumer.accept(connected, changedFlags);
+        this.onConnectionEvent.accept(connected, changedFlags, Collections.emptyMap());
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -105,7 +105,7 @@ public class GrpcConnector {
                 this.channel.awaitTermination(this.deadline, TimeUnit.MILLISECONDS);
                 log.warn(String.format("Unable to shut down channel by %d deadline", this.deadline));
             }
-            this.onConnectionEvent.accept(new ConnectionEvent(false, Collections.emptyList(), Collections.emptyMap()));
+            this.onConnectionEvent.accept(new ConnectionEvent(false));
         }
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -125,7 +125,7 @@ public class GrpcConnector {
     private void observeEventStream() {
         while (this.eventStreamAttempt <= this.maxEventStreamRetries) {
             final StreamObserver<EventStreamResponse> responseObserver = new EventStreamObserver(sync, this.cache,
-                    this::grpconConnectionEvent);
+                    this::onConnectionEvent);
             this.serviceStub.eventStream(EventStreamRequest.getDefaultInstance(), responseObserver);
 
             try {
@@ -156,10 +156,10 @@ public class GrpcConnector {
         }
 
         log.error("failed to connect to event stream, exhausted retries");
-        this.grpconConnectionEvent(false, Collections.emptyList());
+        this.onConnectionEvent(false, Collections.emptyList());
     }
 
-    private void grpcOnConnectionEvent(final boolean connected, final List<String> changedFlags) {
+    private void onConnectionEvent(final boolean connected, final List<String> changedFlags) {
         // reset reconnection states
         if (connected) {
             this.eventStreamAttempt = 1;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
@@ -5,8 +5,8 @@ import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.co
 import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.getField;
 import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.getFieldDescriptor;
 
-import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -16,6 +16,7 @@ import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.Config;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.strategy.ResolveFactory;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.strategy.ResolveStrategy;
@@ -33,7 +34,6 @@ import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
-import dev.openfeature.sdk.internal.TriConsumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -61,7 +61,7 @@ public final class GrpcResolver implements Resolver {
      * @param onConnectionEvent lambda which handles changes in the connection/stream
      */
     public GrpcResolver(final FlagdOptions options, final Cache cache, final Supplier<Boolean> connectedSupplier,
-            final TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent) {
+            final Consumer<ConnectionEvent> onConnectionEvent) {
         this.cache = cache;
         this.connectedSupplier = connectedSupplier;
         this.strategy = ResolveFactory.getStrategy(options);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcResolver.java
@@ -1,16 +1,16 @@
 package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
-import java.util.HashMap;
+import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.convertContext;
+import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.convertObjectResponse;
+import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.getField;
+import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.getFieldDescriptor;
+
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.ListValue;
 import com.google.protobuf.Message;
-import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 
 import dev.openfeature.contrib.providers.flagd.Config;
@@ -26,9 +26,7 @@ import dev.openfeature.flagd.grpc.evaluation.Evaluation.ResolveObjectRequest;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.ResolveStringRequest;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.ImmutableMetadata;
-import dev.openfeature.sdk.MutableStructure;
 import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.GeneralError;
@@ -200,153 +198,6 @@ public final class GrpcResolver implements Resolver {
 
     private Boolean cacheAvailable() {
         return this.cache.getEnabled() && this.connectedSupplier.get();
-    }
-
-    /**
-     * Recursively convert protobuf structure to openfeature value.
-     */
-    public static Value convertObjectResponse(Struct protobuf) {
-        return convertProtobufMap(protobuf.getFieldsMap());
-    }
-
-    /**
-     * Recursively convert the Evaluation context to a protobuf structure.
-     */
-    public static Struct convertContext(EvaluationContext ctx) {
-        Map<String, Value> ctxMap = ctx.asMap();
-        // asMap() does not provide explicitly set targeting key (ex:- new
-        // ImmutableContext("TargetingKey") ).
-        // Hence, we add this explicitly here for targeting rule processing.
-        ctxMap.put("targetingKey", new Value(ctx.getTargetingKey()));
-
-        return convertMap(ctxMap).getStructValue();
-    }
-
-    /**
-     * Convert any openfeature value to a protobuf value.
-     */
-    public static com.google.protobuf.Value convertAny(Value value) {
-        if (value.isList()) {
-            return convertList(value.asList());
-        } else if (value.isStructure()) {
-            return convertMap(value.asStructure().asMap());
-        } else {
-            return convertPrimitive(value);
-        }
-    }
-
-    /**
-     * Convert any protobuf value to {@link Value}.
-     */
-    public static Value convertAny(com.google.protobuf.Value protobuf) {
-        if (protobuf.hasListValue()) {
-            return convertList(protobuf.getListValue());
-        } else if (protobuf.hasStructValue()) {
-            return convertProtobufMap(protobuf.getStructValue().getFieldsMap());
-        } else {
-            return convertPrimitive(protobuf);
-        }
-    }
-
-    /**
-     * Convert OpenFeature map to protobuf {@link com.google.protobuf.Value}.
-     */
-    public static com.google.protobuf.Value convertMap(Map<String, Value> map) {
-        Map<String, com.google.protobuf.Value> values = new HashMap<>();
-
-        map.keySet().forEach((String key) -> {
-            Value value = map.get(key);
-            values.put(key, convertAny(value));
-        });
-        Struct struct = Struct.newBuilder()
-                .putAllFields(values).build();
-        return com.google.protobuf.Value.newBuilder().setStructValue(struct).build();
-    }
-
-    /**
-     * Convert protobuf map with {@link com.google.protobuf.Value} to OpenFeature
-     * map.
-     */
-    public static Value convertProtobufMap(Map<String, com.google.protobuf.Value> map) {
-        return new Value(convertProtobufMapToStructure(map));
-    }
-
-    /**
-     * Convert protobuf map with {@link com.google.protobuf.Value} to OpenFeature
-     * map.
-     */
-    public static Structure convertProtobufMapToStructure(Map<String, com.google.protobuf.Value> map) {
-        Map<String, Value> values = new HashMap<>();
-
-        map.keySet().forEach((String key) -> {
-            com.google.protobuf.Value value = map.get(key);
-            values.put(key, convertAny(value));
-        });
-        return new MutableStructure(values);
-    }
-
-    /**
-     * Convert OpenFeature list to protobuf {@link com.google.protobuf.Value}.
-     */
-    public static com.google.protobuf.Value convertList(List<Value> values) {
-        ListValue list = ListValue.newBuilder()
-                .addAllValues(values.stream()
-                        .map(v -> convertAny(v)).collect(Collectors.toList()))
-                .build();
-        return com.google.protobuf.Value.newBuilder().setListValue(list).build();
-    }
-
-    /**
-     * Convert protobuf list to OpenFeature {@link com.google.protobuf.Value}.
-     */
-    public static Value convertList(ListValue protobuf) {
-        return new Value(protobuf.getValuesList().stream().map(p -> convertAny(p)).collect(Collectors.toList()));
-    }
-
-    /**
-     * Convert OpenFeature {@link Value} to protobuf
-     * {@link com.google.protobuf.Value}.
-     */
-    public static com.google.protobuf.Value convertPrimitive(Value value) {
-        com.google.protobuf.Value.Builder builder = com.google.protobuf.Value.newBuilder();
-
-        if (value.isBoolean()) {
-            builder.setBoolValue(value.asBoolean());
-        } else if (value.isString()) {
-            builder.setStringValue(value.asString());
-        } else if (value.isNumber()) {
-            builder.setNumberValue(value.asDouble());
-        } else {
-            builder.setNullValue(NullValue.NULL_VALUE);
-        }
-        return builder.build();
-    }
-
-    /**
-     * Convert protobuf {@link com.google.protobuf.Value} to OpenFeature
-     * {@link Value}.
-     */
-    public static Value convertPrimitive(com.google.protobuf.Value protobuf) {
-        final Value value;
-        if (protobuf.hasBoolValue()) {
-            value = new Value(protobuf.getBoolValue());
-        } else if (protobuf.hasStringValue()) {
-            value = new Value(protobuf.getStringValue());
-        } else if (protobuf.hasNumberValue()) {
-            value = new Value(protobuf.getNumberValue());
-        } else {
-            value = new Value();
-        }
-
-        return value;
-    }
-
-    private static <T> T getField(Message message, String name) {
-        return (T) message.getField(getFieldDescriptor(message, name));
-    }
-
-    private static Descriptors.FieldDescriptor getFieldDescriptor(Message message, String name) {
-        return message.getDescriptorForType().findFieldByName(name);
     }
 
     private static ImmutableMetadata metadataFromResponse(Message response) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -3,7 +3,7 @@ package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayload;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import java.util.HashMap;
@@ -94,15 +94,15 @@ public class FlagStore implements Storage {
     }
 
     private void streamerListener(final Connector connector) throws InterruptedException {
-        final BlockingQueue<StreamPayload> streamPayloads = connector.getStream();
+        final BlockingQueue<QueuePayload> streamPayloads = connector.getStream();
 
         while (!shutdown.get()) {
-            final StreamPayload take = streamPayloads.take();
+            final QueuePayload take = streamPayloads.take();
             switch (take.getType()) {
                 case DATA:
                     try {
                         List<String> changedFlagsKeys;
-                        Map<String, FeatureFlag> flagMap = FlagParser.parseString(take.getData(), throwIfInvalid);
+                        Map<String, FeatureFlag> flagMap = FlagParser.parseString(take.getFlagData(), throwIfInvalid);
                         writeLock.lock();
                         try {
                             changedFlagsKeys = getChangedFlagsKeys(flagMap);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/StorageStateChange.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/StorageStateChange.java
@@ -1,12 +1,12 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Represents a change in the stored flags.
@@ -17,14 +17,39 @@ import java.util.List;
 public class StorageStateChange {
     private final StorageState storageState;
     private final List<String> changedFlagsKeys;
+    private final Map<String, Object> syncMetadata;
 
-    public StorageStateChange(StorageState storageState, List<String> changedFlagsKeys) {
+    /**
+     * Construct a new StorageStateChange.
+     * @param storageState state of the storage
+     * @param changedFlagsKeys flags changed
+     * @param syncMetadata possibly updated metadata 
+     */
+    public StorageStateChange(StorageState storageState, List<String> changedFlagsKeys,
+            Map<String, Object> syncMetadata) {
         this.storageState = storageState;
-        this.changedFlagsKeys = new ArrayList<>(changedFlagsKeys);
+        this.changedFlagsKeys = Collections.unmodifiableList(changedFlagsKeys);
+        this.syncMetadata = Collections.unmodifiableMap(syncMetadata);
     }
 
+    /**
+     * Construct a new StorageStateChange.
+     * @param storageState state of the storage
+     * @param changedFlagsKeys flags changed
+     */
+    public StorageStateChange(StorageState storageState, List<String> changedFlagsKeys) {
+        this.storageState = storageState;
+        this.changedFlagsKeys = Collections.unmodifiableList(changedFlagsKeys);
+        this.syncMetadata = Collections.emptyMap();
+    }
+
+    /**
+     * Construct a new StorageStateChange.
+     * @param storageState state of the storage
+     */
     public StorageStateChange(StorageState storageState) {
         this.storageState = storageState;
         this.changedFlagsKeys = Collections.emptyList();
+        this.syncMetadata = Collections.emptyMap();
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/Connector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/Connector.java
@@ -4,12 +4,12 @@ import java.util.concurrent.BlockingQueue;
 
 /**
  * Contract of the in-process storage connector. Connectors are responsible to stream flag configurations in
- * {@link StreamPayload} format.
+ * {@link QueuePayload} format.
  */
 public interface Connector {
     void init() throws Exception;
 
-    BlockingQueue<StreamPayload> getStream();
+    BlockingQueue<QueuePayload> getStream();
 
     void shutdown() throws InterruptedException;
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
@@ -1,5 +1,6 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,7 +9,8 @@ import lombok.Getter;
  */
 @AllArgsConstructor
 @Getter
-public class StreamPayload {
-    private final StreamPayloadType type;
-    private final String data;
+public class QueuePayload {
+    private final QueuePayloadType type;
+    private final String flagData;
+    private final Map<String, Object> syncMetadata;
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
@@ -1,6 +1,6 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector;
 
-import java.util.Map;
+import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,5 +12,9 @@ import lombok.Getter;
 public class QueuePayload {
     private final QueuePayloadType type;
     private final String flagData;
-    private final Map<String, Object> syncMetadata;
+    private final GetMetadataResponse metadataResponse;
+
+    public QueuePayload(QueuePayloadType type, String flagData) {
+        this(type, flagData, GetMetadataResponse.getDefaultInstance());
+    }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayloadType.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayloadType.java
@@ -3,7 +3,7 @@ package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connect
 /**
  * Payload type emitted by {@link Connector}.
  */
-public enum StreamPayloadType {
+public enum QueuePayloadType {
     DATA,
     ERROR
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileConnector.java
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -46,7 +45,7 @@ public class FileConnector implements Connector {
 
                 // initial read
                 String flagData = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
-                if (!queue.offer(new QueuePayload(QueuePayloadType.DATA, flagData, Collections.emptyMap()))) {
+                if (!queue.offer(new QueuePayload(QueuePayloadType.DATA, flagData))) {
                     log.warn(OFFER_WARN);
                 }
 
@@ -59,7 +58,7 @@ public class FileConnector implements Connector {
                     if (currentTS > lastTS) {
                         lastTS = currentTS;
                         flagData = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
-                        if (!queue.offer(new QueuePayload(QueuePayloadType.DATA, flagData, Collections.emptyMap()))) {
+                        if (!queue.offer(new QueuePayload(QueuePayloadType.DATA, flagData))) {
                             log.warn(OFFER_WARN);
                         }
                     }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
@@ -135,8 +135,7 @@ public class GrpcStreamConnector implements Connector {
                 syncRequest.setSelector(selector);
             }
 
-            serviceStub.withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).syncFlags(syncRequest.build(),
-                    new GrpcStreamHandler(streamReceiver));
+            serviceStub.syncFlags(syncRequest.build(), new GrpcStreamHandler(streamReceiver));
             try {
                 GetMetadataResponse metadataResponse = serviceBlockingStub
                         .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getMetadata(metadataRequest.build());

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
@@ -1,5 +1,7 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc;
 
+import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.convertProtobufMapToStructure;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
@@ -10,7 +12,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
-import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
@@ -139,8 +140,7 @@ public class GrpcStreamConnector implements Connector {
             serviceStub.syncFlags(syncRequest.build(), new GrpcStreamHandler(streamReceiver));
             try {
                 GetMetadataResponse metadataResponse = serviceBlockingStub.getMetadata(metadataRequest.build());
-                metadata = GrpcResolver
-                        .convertProtobufMapToStructure(metadataResponse.getMetadata().getFieldsMap()).asObjectMap();
+                metadata = convertProtobufMapToStructure(metadataResponse.getMetadata().getFieldsMap()).asObjectMap();
             } catch (Exception e) {
                 // the chances this call fails but the syncRequest does not are slim
                 // it could be that the server doesn't implement this RPC

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -40,6 +41,7 @@ import org.mockito.Mockito;
 import com.google.protobuf.Struct;
 
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.GrpcResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
@@ -68,885 +70,942 @@ import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.internal.TriConsumer;
 import io.cucumber.java.AfterAll;
 import io.grpc.Channel;
 import io.grpc.Deadline;
 import lombok.val;
 
 class FlagdProviderTest {
-    private static final String FLAG_KEY = "some-key";
-    private static final String FLAG_KEY_BOOLEAN = "some-key-boolean";
-    private static final String FLAG_KEY_INTEGER = "some-key-integer";
-    private static final String FLAG_KEY_DOUBLE = "some-key-double";
-    private static final String FLAG_KEY_STRING = "some-key-string";
-    private static final String FLAG_KEY_OBJECT = "some-key-object";
-    private static final String BOOL_VARIANT = "on";
-    private static final String DOUBLE_VARIANT = "half";
-    private static final String INT_VARIANT = "one-hundred";
-    private static final String STRING_VARIANT = "greeting";
-    private static final String OBJECT_VARIANT = "obj";
-    private static final Reason DEFAULT = Reason.DEFAULT;
-    private static final Integer INT_VALUE = 100;
-    private static final Double DOUBLE_VALUE = .5d;
-    private static final String INNER_STRUCT_KEY = "inner_key";
-    private static final String INNER_STRUCT_VALUE = "inner_value";
-    private static final com.google.protobuf.Struct PROTOBUF_STRUCTURE_VALUE = Struct.newBuilder()
-            .putFields(INNER_STRUCT_KEY,
-                    com.google.protobuf.Value.newBuilder().setStringValue(INNER_STRUCT_VALUE).build())
-            .build();
-    private static final String STRING_VALUE = "hi!";
-
-    private static OpenFeatureAPI api;
-
-    @BeforeAll
-    public static void init() {
-        api = OpenFeatureAPI.getInstance();
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        api.shutdown();
-    }
-
-    @Test
-    void resolvers_call_grpc_service_and_return_details() {
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
-                .setValue(STRING_VALUE)
-                .setVariant(STRING_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
-                .setValue(INT_VALUE)
-                .setVariant(INT_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
-                .setValue(DOUBLE_VALUE)
-                .setVariant(DOUBLE_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
-                .setValue(PROTOBUF_STRUCTURE_VALUE)
-                .setVariant(OBJECT_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-        when(serviceBlockingStubMock
-                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey())))).thenReturn(floatResponse);
-        when(serviceBlockingStubMock
-                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey())))).thenReturn(intResponse);
-        when(serviceBlockingStubMock
-                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey())))).thenReturn(stringResponse);
-        when(serviceBlockingStubMock
-                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey())))).thenReturn(objectResponse);
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        assertTrue(booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(DEFAULT.toString(), booleanDetails.getReason());
-
-        FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        assertEquals(STRING_VALUE, stringDetails.getValue());
-        assertEquals(STRING_VARIANT, stringDetails.getVariant());
-        assertEquals(DEFAULT.toString(), stringDetails.getReason());
-
-        FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        assertEquals(INT_VALUE, intDetails.getValue());
-        assertEquals(INT_VARIANT, intDetails.getVariant());
-        assertEquals(DEFAULT.toString(), intDetails.getReason());
-
-        FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        assertEquals(DOUBLE_VALUE, floatDetails.getValue());
-        assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
-        assertEquals(DEFAULT.toString(), floatDetails.getReason());
-
-        FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
-                .asMap().get(INNER_STRUCT_KEY).asString());
-        assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
-        assertEquals(DEFAULT.toString(), objectDetails.getReason());
-    }
-
-    @Test
-    void zero_value() {
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setVariant(BOOL_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
-                .setVariant(STRING_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
-                .setVariant(INT_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
-                .setVariant(DOUBLE_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
-                .setVariant(OBJECT_VARIANT)
-                .setReason(DEFAULT.toString())
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-        when(serviceBlockingStubMock
-                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey())))).thenReturn(floatResponse);
-        when(serviceBlockingStubMock
-                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey())))).thenReturn(intResponse);
-        when(serviceBlockingStubMock
-                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey())))).thenReturn(stringResponse);
-        when(serviceBlockingStubMock
-                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey())))).thenReturn(objectResponse);
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        assertEquals(false, booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(DEFAULT.toString(), booleanDetails.getReason());
-
-        FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        assertEquals("", stringDetails.getValue());
-        assertEquals(STRING_VARIANT, stringDetails.getVariant());
-        assertEquals(DEFAULT.toString(), stringDetails.getReason());
-
-        FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        assertEquals(0, intDetails.getValue());
-        assertEquals(INT_VARIANT, intDetails.getVariant());
-        assertEquals(DEFAULT.toString(), intDetails.getReason());
-
-        FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        assertEquals(0.0, floatDetails.getValue());
-        assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
-        assertEquals(DEFAULT.toString(), floatDetails.getReason());
-
-        FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        assertEquals(new MutableStructure(), objectDetails.getValue().asObject());
-        assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
-        assertEquals(DEFAULT.toString(), objectDetails.getReason());
-    }
-
-    @Test
-    void test_metadata_from_grpc_response() {
-        // given
-        final Map<String, com.google.protobuf.Value> metadataInput = new HashMap<>();
-
-        com.google.protobuf.Value scope = com.google.protobuf.Value.newBuilder().setStringValue("flagd-scope").build();
-        metadataInput.put("scope", scope);
-
-        com.google.protobuf.Value bool = com.google.protobuf.Value.newBuilder().setBoolValue(true).build();
-        metadataInput.put("boolean", bool);
-
-        com.google.protobuf.Value number = com.google.protobuf.Value.newBuilder().setNumberValue(1).build();
-        metadataInput.put("number", number);
-
-        final Struct metadataStruct = Struct.newBuilder().putAllFields(metadataInput).build();
-
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(DEFAULT.toString())
-                .setMetadata(metadataStruct)
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(
-                serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        // when
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-
-        // then
-        final ImmutableMetadata metadata = booleanDetails.getFlagMetadata();
-
-        assertEquals("flagd-scope", metadata.getString("scope"));
-        assertEquals(true, metadata.getBoolean("boolean"));
-        assertEquals(1, metadata.getDouble("number"));
-    }
-
-    @Test
-    void resolvers_cache_responses_if_static_and_event_stream_alive() {
-        do_resolvers_cache_responses(STATIC_REASON, true, true);
-    }
-
-    @Test
-    void resolvers_should_not_cache_responses_if_not_static() {
-        do_resolvers_cache_responses(DEFAULT.toString(), true, false);
-    }
-
-    @Test
-    void resolvers_should_not_cache_responses_if_event_stream_not_alive() {
-        do_resolvers_cache_responses(STATIC_REASON, false, false);
-    }
-
-    @Test
-    void context_is_parsed_and_passed_to_grpc_service() {
-        final String BOOLEAN_ATTR_KEY = "bool-attr";
-        final String INT_ATTR_KEY = "int-attr";
-        final String STRING_ATTR_KEY = "string-attr";
-        final String STRUCT_ATTR_KEY = "struct-attr";
-        final String DOUBLE_ATTR_KEY = "double-attr";
-        final String LIST_ATTR_KEY = "list-attr";
-        final String STRUCT_ATTR_INNER_KEY = "struct-inner-key";
-
-        final Boolean BOOLEAN_ATTR_VALUE = true;
-        final int INT_ATTR_VALUE = 1;
-        final String STRING_ATTR_VALUE = "str";
-        final double DOUBLE_ATTR_VALUE = 0.5d;
-        final List<Value> LIST_ATTR_VALUE = new ArrayList<Value>() {
-            {
-                add(new Value(1));
-            }
-        };
-        final String STRUCT_ATTR_INNER_VALUE = "struct-inner-value";
-        final Structure STRUCT_ATTR_VALUE = new MutableStructure().add(STRUCT_ATTR_INNER_KEY, STRUCT_ATTR_INNER_VALUE);
-        final String DEFAULT_STRING = "DEFAULT";
-
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(DEFAULT_STRING.toString())
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.resolveBoolean(argThat(
-                x -> {
-                    final Struct struct = x.getContext();
-                    final Map<String, com.google.protobuf.Value> valueMap = struct.getFieldsMap();
-
-                    return STRING_ATTR_VALUE.equals(valueMap.get(STRING_ATTR_KEY).getStringValue())
-                            && INT_ATTR_VALUE == valueMap.get(INT_ATTR_KEY).getNumberValue()
-                            && DOUBLE_ATTR_VALUE == valueMap.get(DOUBLE_ATTR_KEY).getNumberValue()
-                            && valueMap.get(BOOLEAN_ATTR_KEY).getBoolValue()
-                            && "MY_TARGETING_KEY".equals(valueMap.get("targetingKey").getStringValue())
-                            && LIST_ATTR_VALUE.get(0).asInteger() == valueMap.get(LIST_ATTR_KEY).getListValue()
-                                    .getValuesList().get(0).getNumberValue()
-                            && STRUCT_ATTR_INNER_VALUE.equals(
-                                    valueMap.get(STRUCT_ATTR_KEY).getStructValue().getFieldsMap()
-                                            .get(STRUCT_ATTR_INNER_KEY).getStringValue());
-                }))).thenReturn(booleanResponse);
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        final MutableContext context = new MutableContext("MY_TARGETING_KEY");
-        context.add(BOOLEAN_ATTR_KEY, BOOLEAN_ATTR_VALUE);
-        context.add(INT_ATTR_KEY, INT_ATTR_VALUE);
-        context.add(DOUBLE_ATTR_KEY, DOUBLE_ATTR_VALUE);
-        context.add(LIST_ATTR_KEY, LIST_ATTR_VALUE);
-        context.add(STRING_ATTR_KEY, STRING_ATTR_VALUE);
-        context.add(STRUCT_ATTR_KEY, STRUCT_ATTR_VALUE);
-
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY, false, context);
-        assertTrue(booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(DEFAULT.toString(), booleanDetails.getReason());
-    }
-
-    // Validates null handling -
-    // https://github.com/open-feature/java-sdk-contrib/issues/258
-    @Test
-    void null_context_handling() {
-        // given
-        final String flagA = "flagA";
-        final boolean defaultVariant = false;
-        final boolean expectedVariant = true;
-
-        final MutableContext context = new MutableContext();
-        context.add("key", (String) null);
-
-        final ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-
-        // when
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.resolveBoolean(any()))
-                .thenReturn(ResolveBooleanResponse.newBuilder().setValue(expectedVariant).build());
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        // then
-        final Boolean evaluation = api.getClient().getBooleanValue(flagA, defaultVariant, context);
-
-        assertNotEquals(evaluation, defaultVariant);
-        assertEquals(evaluation, expectedVariant);
-    }
-
-    @Test
-    void reason_mapped_correctly_if_unknown() {
-        ResolveBooleanResponse badReasonResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason("UNKNOWN") // set an invalid reason string
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.resolveBoolean(any(ResolveBooleanRequest.class))).thenReturn(badReasonResponse);
-
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-
-        OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
-
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient()
-                .getBooleanDetails(FLAG_KEY, false, new MutableContext());
-        assertEquals(Reason.UNKNOWN.toString(), booleanDetails.getReason()); // reason should be converted to UNKNOWN
-    }
-
-    @Test
-    void invalidate_cache() {
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
-                .setValue(STRING_VALUE)
-                .setVariant(STRING_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
-                .setValue(INT_VALUE)
-                .setVariant(INT_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
-                .setValue(DOUBLE_VALUE)
-                .setVariant(DOUBLE_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
-                .setValue(PROTOBUF_STRUCTURE_VALUE)
-                .setVariant(OBJECT_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        ServiceStub serviceStubMock = mock(ServiceStub.class);
-        when(serviceStubMock.withWaitForReady()).thenReturn(serviceStubMock);
-        doNothing().when(serviceStubMock).eventStream(any(), any());
-        when(serviceStubMock.withDeadline(any(Deadline.class)))
-                .thenReturn(serviceStubMock);
-        when(serviceBlockingStubMock.withWaitForReady()).thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .withDeadline(any(Deadline.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-        when(serviceBlockingStubMock
-                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey())))).thenReturn(floatResponse);
-        when(serviceBlockingStubMock
-                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey())))).thenReturn(intResponse);
-        when(serviceBlockingStubMock
-                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey())))).thenReturn(stringResponse);
-        when(serviceBlockingStubMock
-                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey())))).thenReturn(objectResponse);
-
-        GrpcConnector grpc;
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(serviceBlockingStubMock);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any()))
-                    .thenReturn(serviceStubMock);
-
-            final Cache cache = new Cache("lru", 5);
-
-            class NoopInitGrpcConnector extends GrpcConnector {
-                public NoopInitGrpcConnector(FlagdOptions options, Cache cache, Supplier<Boolean> connectedSupplier, TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent) {
-                    super(options, cache, connectedSupplier, onConnectionEvent);
-                }
-
-                public void initialize() throws Exception {};
-            } 
-
-            grpc = new NoopInitGrpcConnector(FlagdOptions.builder().build(), cache, () -> true, (state, changedFlagKeys, syncMetadata) -> {
-            });
+        private static final String FLAG_KEY = "some-key";
+        private static final String FLAG_KEY_BOOLEAN = "some-key-boolean";
+        private static final String FLAG_KEY_INTEGER = "some-key-integer";
+        private static final String FLAG_KEY_DOUBLE = "some-key-double";
+        private static final String FLAG_KEY_STRING = "some-key-string";
+        private static final String FLAG_KEY_OBJECT = "some-key-object";
+        private static final String BOOL_VARIANT = "on";
+        private static final String DOUBLE_VARIANT = "half";
+        private static final String INT_VARIANT = "one-hundred";
+        private static final String STRING_VARIANT = "greeting";
+        private static final String OBJECT_VARIANT = "obj";
+        private static final Reason DEFAULT = Reason.DEFAULT;
+        private static final Integer INT_VALUE = 100;
+        private static final Double DOUBLE_VALUE = .5d;
+        private static final String INNER_STRUCT_KEY = "inner_key";
+        private static final String INNER_STRUCT_VALUE = "inner_value";
+        private static final com.google.protobuf.Struct PROTOBUF_STRUCTURE_VALUE = Struct.newBuilder()
+                        .putFields(INNER_STRUCT_KEY,
+                                        com.google.protobuf.Value.newBuilder().setStringValue(INNER_STRUCT_VALUE)
+                                                        .build())
+                        .build();
+        private static final String STRING_VALUE = "hi!";
+
+        private static OpenFeatureAPI api;
+
+        @BeforeAll
+        public static void init() {
+                api = OpenFeatureAPI.getInstance();
         }
 
-        FlagdProvider provider = createProvider(grpc);
-        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
-
-        HashMap<String, com.google.protobuf.Value> flagsMap = new HashMap<String, com.google.protobuf.Value>();
-        HashMap<String, com.google.protobuf.Value> structMap = new HashMap<String, com.google.protobuf.Value>();
-
-        flagsMap.put(FLAG_KEY_BOOLEAN, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
-        flagsMap.put(FLAG_KEY_STRING, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
-        flagsMap.put(FLAG_KEY_INTEGER, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
-        flagsMap.put(FLAG_KEY_DOUBLE, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
-        flagsMap.put(FLAG_KEY_OBJECT, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
-
-        structMap.put("flags", com.google.protobuf.Value.newBuilder()
-                .setStructValue(Struct.newBuilder().putAllFields(flagsMap)).build());
-
-        // should cache results
-        FlagEvaluationDetails<Boolean> booleanDetails;
-        FlagEvaluationDetails<String> stringDetails;
-        FlagEvaluationDetails<Integer> intDetails;
-        FlagEvaluationDetails<Double> floatDetails;
-        FlagEvaluationDetails<Value> objectDetails;
-
-        // assert cache has been invalidated
-        booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        assertTrue(booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(STATIC_REASON, booleanDetails.getReason());
-
-        stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        assertEquals(STRING_VALUE, stringDetails.getValue());
-        assertEquals(STRING_VARIANT, stringDetails.getVariant());
-        assertEquals(STATIC_REASON, stringDetails.getReason());
-
-        intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        assertEquals(INT_VALUE, intDetails.getValue());
-        assertEquals(INT_VARIANT, intDetails.getVariant());
-        assertEquals(STATIC_REASON, intDetails.getReason());
-
-        floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        assertEquals(DOUBLE_VALUE, floatDetails.getValue());
-        assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
-        assertEquals(STATIC_REASON, floatDetails.getReason());
-
-        objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
-                .asMap().get(INNER_STRUCT_KEY).asString());
-        assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
-        assertEquals(STATIC_REASON, objectDetails.getReason());
-    }
-
-    private void do_resolvers_cache_responses(String reason, Boolean eventStreamAlive, Boolean shouldCache) {
-        String expectedReason = CACHED_REASON;
-        if (!shouldCache) {
-            expectedReason = reason;
+        @AfterAll
+        public static void cleanUp() {
+                api.shutdown();
         }
 
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(reason)
-                .build();
+        @Test
+        void resolvers_call_grpc_service_and_return_details() {
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
 
-        ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
-                .setValue(STRING_VALUE)
-                .setVariant(STRING_VARIANT)
-                .setReason(reason)
-                .build();
+                ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
+                                .setValue(STRING_VALUE)
+                                .setVariant(STRING_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
 
-        ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
-                .setValue(INT_VALUE)
-                .setVariant(INT_VARIANT)
-                .setReason(reason)
-                .build();
+                ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
+                                .setValue(INT_VALUE)
+                                .setVariant(INT_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
 
-        ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
-                .setValue(DOUBLE_VALUE)
-                .setVariant(DOUBLE_VARIANT)
-                .setReason(reason)
-                .build();
+                ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
+                                .setValue(DOUBLE_VALUE)
+                                .setVariant(DOUBLE_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
 
-        ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
-                .setValue(PROTOBUF_STRUCTURE_VALUE)
-                .setVariant(OBJECT_VARIANT)
-                .setReason(reason)
-                .build();
+                ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
+                                .setValue(PROTOBUF_STRUCTURE_VALUE)
+                                .setVariant(OBJECT_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
 
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-        when(serviceBlockingStubMock
-                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey())))).thenReturn(floatResponse);
-        when(serviceBlockingStubMock
-                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey())))).thenReturn(intResponse);
-        when(serviceBlockingStubMock
-                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey())))).thenReturn(stringResponse);
-        when(serviceBlockingStubMock
-                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey())))).thenReturn(objectResponse);
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
 
-        GrpcConnector grpc = mock(GrpcConnector.class);
-        when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
-        FlagdProvider provider = createProvider(grpc, () -> eventStreamAlive);
-        // provider.setState(eventStreamAlive); // caching only available when event
-        // stream is alive
-        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
-
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        booleanDetails = api.getClient()
-                .getBooleanDetails(FLAG_KEY_BOOLEAN, false); // should retrieve from cache on second invocation
-        assertTrue(booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(expectedReason, booleanDetails.getReason());
-
-        FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        assertEquals(STRING_VALUE, stringDetails.getValue());
-        assertEquals(STRING_VARIANT, stringDetails.getVariant());
-        assertEquals(expectedReason, stringDetails.getReason());
-
-        FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        assertEquals(INT_VALUE, intDetails.getValue());
-        assertEquals(INT_VARIANT, intDetails.getVariant());
-        assertEquals(expectedReason, intDetails.getReason());
-
-        FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        assertEquals(DOUBLE_VALUE, floatDetails.getValue());
-        assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
-        assertEquals(expectedReason, floatDetails.getReason());
-
-        FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
-                .asMap().get(INNER_STRUCT_KEY).asString());
-        assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
-        assertEquals(expectedReason, objectDetails.getReason());
-    }
-
-    @Test
-    void disabled_cache() {
-        ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
-                .setValue(true)
-                .setVariant(BOOL_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
-                .setValue(STRING_VALUE)
-                .setVariant(STRING_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
-                .setValue(INT_VALUE)
-                .setVariant(INT_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
-                .setValue(DOUBLE_VALUE)
-                .setVariant(DOUBLE_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
-                .setValue(PROTOBUF_STRUCTURE_VALUE)
-                .setVariant(OBJECT_VARIANT)
-                .setReason(STATIC_REASON)
-                .build();
-
-        ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
-        ServiceStub serviceStubMock = mock(ServiceStub.class);
-        when(serviceStubMock.withWaitForReady()).thenReturn(serviceStubMock);
-        when(serviceStubMock.withDeadline(any(Deadline.class)))
-                .thenReturn(serviceStubMock);
-        when(serviceBlockingStubMock.withWaitForReady()).thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.withDeadline(any(Deadline.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
-                .thenReturn(serviceBlockingStubMock);
-        when(serviceBlockingStubMock
-                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey())))).thenReturn(booleanResponse);
-        when(serviceBlockingStubMock
-                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey())))).thenReturn(floatResponse);
-        when(serviceBlockingStubMock
-                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey())))).thenReturn(intResponse);
-        when(serviceBlockingStubMock
-                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey())))).thenReturn(stringResponse);
-        when(serviceBlockingStubMock
-                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey())))).thenReturn(objectResponse);
-
-        // disabled cache
-        final Cache cache = new Cache("disabled", 0);
-
-        GrpcConnector grpc;
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-                mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
                                 .thenReturn(serviceBlockingStubMock);
-                mockStaticService.when(() -> ServiceGrpc.newStub(any()))
-                                .thenReturn(serviceStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+                when(serviceBlockingStubMock
+                                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey()))))
+                                .thenReturn(floatResponse);
+                when(serviceBlockingStubMock
+                                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey()))))
+                                .thenReturn(intResponse);
+                when(serviceBlockingStubMock
+                                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey()))))
+                                .thenReturn(stringResponse);
+                when(serviceBlockingStubMock
+                                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey()))))
+                                .thenReturn(objectResponse);
 
-                class NoopInitGrpcConnector extends GrpcConnector {
-                        public NoopInitGrpcConnector(FlagdOptions options, Cache cache,
-                                        Supplier<Boolean> connectedSupplier,
-                                        TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent) {
-                                super(options, cache, connectedSupplier, onConnectionEvent);
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN,
+                                false);
+                assertTrue(booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(DEFAULT.toString(), booleanDetails.getReason());
+
+                FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING,
+                                "wrong");
+                assertEquals(STRING_VALUE, stringDetails.getValue());
+                assertEquals(STRING_VARIANT, stringDetails.getVariant());
+                assertEquals(DEFAULT.toString(), stringDetails.getReason());
+
+                FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                assertEquals(INT_VALUE, intDetails.getValue());
+                assertEquals(INT_VARIANT, intDetails.getVariant());
+                assertEquals(DEFAULT.toString(), intDetails.getReason());
+
+                FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                assertEquals(DOUBLE_VALUE, floatDetails.getValue());
+                assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
+                assertEquals(DEFAULT.toString(), floatDetails.getReason());
+
+                FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT,
+                                new Value());
+                assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
+                                .asMap().get(INNER_STRUCT_KEY).asString());
+                assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
+                assertEquals(DEFAULT.toString(), objectDetails.getReason());
+        }
+
+        @Test
+        void zero_value() {
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
+
+                ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
+                                .setVariant(STRING_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
+
+                ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
+                                .setVariant(INT_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
+
+                ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
+                                .setVariant(DOUBLE_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
+
+                ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
+                                .setVariant(OBJECT_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+                when(serviceBlockingStubMock
+                                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey()))))
+                                .thenReturn(floatResponse);
+                when(serviceBlockingStubMock
+                                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey()))))
+                                .thenReturn(intResponse);
+                when(serviceBlockingStubMock
+                                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey()))))
+                                .thenReturn(stringResponse);
+                when(serviceBlockingStubMock
+                                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey()))))
+                                .thenReturn(objectResponse);
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN,
+                                false);
+                assertEquals(false, booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(DEFAULT.toString(), booleanDetails.getReason());
+
+                FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING,
+                                "wrong");
+                assertEquals("", stringDetails.getValue());
+                assertEquals(STRING_VARIANT, stringDetails.getVariant());
+                assertEquals(DEFAULT.toString(), stringDetails.getReason());
+
+                FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                assertEquals(0, intDetails.getValue());
+                assertEquals(INT_VARIANT, intDetails.getVariant());
+                assertEquals(DEFAULT.toString(), intDetails.getReason());
+
+                FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                assertEquals(0.0, floatDetails.getValue());
+                assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
+                assertEquals(DEFAULT.toString(), floatDetails.getReason());
+
+                FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT,
+                                new Value());
+                assertEquals(new MutableStructure(), objectDetails.getValue().asObject());
+                assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
+                assertEquals(DEFAULT.toString(), objectDetails.getReason());
+        }
+
+        @Test
+        void test_metadata_from_grpc_response() {
+                // given
+                final Map<String, com.google.protobuf.Value> metadataInput = new HashMap<>();
+
+                com.google.protobuf.Value scope = com.google.protobuf.Value.newBuilder().setStringValue("flagd-scope")
+                                .build();
+                metadataInput.put("scope", scope);
+
+                com.google.protobuf.Value bool = com.google.protobuf.Value.newBuilder().setBoolValue(true).build();
+                metadataInput.put("boolean", bool);
+
+                com.google.protobuf.Value number = com.google.protobuf.Value.newBuilder().setNumberValue(1).build();
+                metadataInput.put("number", number);
+
+                final Struct metadataStruct = Struct.newBuilder().putAllFields(metadataInput).build();
+
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(DEFAULT.toString())
+                                .setMetadata(metadataStruct)
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(
+                                serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                // when
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN,
+                                false);
+
+                // then
+                final ImmutableMetadata metadata = booleanDetails.getFlagMetadata();
+
+                assertEquals("flagd-scope", metadata.getString("scope"));
+                assertEquals(true, metadata.getBoolean("boolean"));
+                assertEquals(1, metadata.getDouble("number"));
+        }
+
+        @Test
+        void resolvers_cache_responses_if_static_and_event_stream_alive() {
+                do_resolvers_cache_responses(STATIC_REASON, true, true);
+        }
+
+        @Test
+        void resolvers_should_not_cache_responses_if_not_static() {
+                do_resolvers_cache_responses(DEFAULT.toString(), true, false);
+        }
+
+        @Test
+        void resolvers_should_not_cache_responses_if_event_stream_not_alive() {
+                do_resolvers_cache_responses(STATIC_REASON, false, false);
+        }
+
+        @Test
+        void context_is_parsed_and_passed_to_grpc_service() {
+                final String BOOLEAN_ATTR_KEY = "bool-attr";
+                final String INT_ATTR_KEY = "int-attr";
+                final String STRING_ATTR_KEY = "string-attr";
+                final String STRUCT_ATTR_KEY = "struct-attr";
+                final String DOUBLE_ATTR_KEY = "double-attr";
+                final String LIST_ATTR_KEY = "list-attr";
+                final String STRUCT_ATTR_INNER_KEY = "struct-inner-key";
+
+                final Boolean BOOLEAN_ATTR_VALUE = true;
+                final int INT_ATTR_VALUE = 1;
+                final String STRING_ATTR_VALUE = "str";
+                final double DOUBLE_ATTR_VALUE = 0.5d;
+                final List<Value> LIST_ATTR_VALUE = new ArrayList<Value>() {
+                        {
+                                add(new Value(1));
+                        }
+                };
+                final String STRUCT_ATTR_INNER_VALUE = "struct-inner-value";
+                final Structure STRUCT_ATTR_VALUE = new MutableStructure().add(STRUCT_ATTR_INNER_KEY,
+                                STRUCT_ATTR_INNER_VALUE);
+                final String DEFAULT_STRING = "DEFAULT";
+
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(DEFAULT_STRING.toString())
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.resolveBoolean(argThat(
+                                x -> {
+                                        final Struct struct = x.getContext();
+                                        final Map<String, com.google.protobuf.Value> valueMap = struct.getFieldsMap();
+
+                                        return STRING_ATTR_VALUE.equals(valueMap.get(STRING_ATTR_KEY).getStringValue())
+                                                        && INT_ATTR_VALUE == valueMap.get(INT_ATTR_KEY).getNumberValue()
+                                                        && DOUBLE_ATTR_VALUE == valueMap.get(DOUBLE_ATTR_KEY)
+                                                                        .getNumberValue()
+                                                        && valueMap.get(BOOLEAN_ATTR_KEY).getBoolValue()
+                                                        && "MY_TARGETING_KEY".equals(
+                                                                        valueMap.get("targetingKey").getStringValue())
+                                                        && LIST_ATTR_VALUE.get(0).asInteger() == valueMap
+                                                                        .get(LIST_ATTR_KEY).getListValue()
+                                                                        .getValuesList().get(0).getNumberValue()
+                                                        && STRUCT_ATTR_INNER_VALUE.equals(
+                                                                        valueMap.get(STRUCT_ATTR_KEY).getStructValue()
+                                                                                        .getFieldsMap()
+                                                                                        .get(STRUCT_ATTR_INNER_KEY)
+                                                                                        .getStringValue());
+                                }))).thenReturn(booleanResponse);
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                final MutableContext context = new MutableContext("MY_TARGETING_KEY");
+                context.add(BOOLEAN_ATTR_KEY, BOOLEAN_ATTR_VALUE);
+                context.add(INT_ATTR_KEY, INT_ATTR_VALUE);
+                context.add(DOUBLE_ATTR_KEY, DOUBLE_ATTR_VALUE);
+                context.add(LIST_ATTR_KEY, LIST_ATTR_VALUE);
+                context.add(STRING_ATTR_KEY, STRING_ATTR_VALUE);
+                context.add(STRUCT_ATTR_KEY, STRUCT_ATTR_VALUE);
+
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY, false,
+                                context);
+                assertTrue(booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(DEFAULT.toString(), booleanDetails.getReason());
+        }
+
+        // Validates null handling -
+        // https://github.com/open-feature/java-sdk-contrib/issues/258
+        @Test
+        void null_context_handling() {
+                // given
+                final String flagA = "flagA";
+                final boolean defaultVariant = false;
+                final boolean expectedVariant = true;
+
+                final MutableContext context = new MutableContext();
+                context.add("key", (String) null);
+
+                final ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+
+                // when
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.resolveBoolean(any()))
+                                .thenReturn(ResolveBooleanResponse.newBuilder().setValue(expectedVariant).build());
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                // then
+                final Boolean evaluation = api.getClient().getBooleanValue(flagA, defaultVariant, context);
+
+                assertNotEquals(evaluation, defaultVariant);
+                assertEquals(evaluation, expectedVariant);
+        }
+
+        @Test
+        void reason_mapped_correctly_if_unknown() {
+                ResolveBooleanResponse badReasonResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason("UNKNOWN") // set an invalid reason string
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.resolveBoolean(any(ResolveBooleanRequest.class)))
+                                .thenReturn(badReasonResponse);
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+
+                OpenFeatureAPI.getInstance().setProviderAndWait(createProvider(grpc));
+
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient()
+                                .getBooleanDetails(FLAG_KEY, false, new MutableContext());
+                assertEquals(Reason.UNKNOWN.toString(), booleanDetails.getReason()); // reason should be converted to
+                                                                                     // UNKNOWN
+        }
+
+        @Test
+        void invalidate_cache() {
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
+
+                ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
+                                .setValue(STRING_VALUE)
+                                .setVariant(STRING_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
+
+                ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
+                                .setValue(INT_VALUE)
+                                .setVariant(INT_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
+
+                ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
+                                .setValue(DOUBLE_VALUE)
+                                .setVariant(DOUBLE_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
+
+                ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
+                                .setValue(PROTOBUF_STRUCTURE_VALUE)
+                                .setVariant(OBJECT_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                ServiceStub serviceStubMock = mock(ServiceStub.class);
+                when(serviceStubMock.withWaitForReady()).thenReturn(serviceStubMock);
+                doNothing().when(serviceStubMock).eventStream(any(), any());
+                when(serviceStubMock.withDeadline(any(Deadline.class)))
+                                .thenReturn(serviceStubMock);
+                when(serviceBlockingStubMock.withWaitForReady()).thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .withDeadline(any(Deadline.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+                when(serviceBlockingStubMock
+                                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey()))))
+                                .thenReturn(floatResponse);
+                when(serviceBlockingStubMock
+                                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey()))))
+                                .thenReturn(intResponse);
+                when(serviceBlockingStubMock
+                                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey()))))
+                                .thenReturn(stringResponse);
+                when(serviceBlockingStubMock
+                                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey()))))
+                                .thenReturn(objectResponse);
+
+                GrpcConnector grpc;
+                try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
+                        mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
+                                        .thenReturn(serviceBlockingStubMock);
+                        mockStaticService.when(() -> ServiceGrpc.newStub(any()))
+                                        .thenReturn(serviceStubMock);
+
+                        final Cache cache = new Cache("lru", 5);
+
+                        class NoopInitGrpcConnector extends GrpcConnector {
+                                public NoopInitGrpcConnector(FlagdOptions options, Cache cache,
+                                                Supplier<Boolean> connectedSupplier,
+                                                Consumer<ConnectionEvent> onConnectionEvent) {
+                                        super(options, cache, connectedSupplier, onConnectionEvent);
+                                }
+
+                                public void initialize() throws Exception {
+                                };
                         }
 
-                        public void initialize() throws Exception {
-                        };
+                        grpc = new NoopInitGrpcConnector(FlagdOptions.builder().build(), cache, () -> true,
+                                        (connectionEvent) -> {
+                                        });
                 }
 
-                grpc = new NoopInitGrpcConnector(FlagdOptions.builder().build(), cache, () -> true, (state, changedFlagKeys, syncMetadata) -> {
-                });
+                FlagdProvider provider = createProvider(grpc);
+                OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+
+                HashMap<String, com.google.protobuf.Value> flagsMap = new HashMap<String, com.google.protobuf.Value>();
+                HashMap<String, com.google.protobuf.Value> structMap = new HashMap<String, com.google.protobuf.Value>();
+
+                flagsMap.put(FLAG_KEY_BOOLEAN, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
+                flagsMap.put(FLAG_KEY_STRING, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
+                flagsMap.put(FLAG_KEY_INTEGER, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
+                flagsMap.put(FLAG_KEY_DOUBLE, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
+                flagsMap.put(FLAG_KEY_OBJECT, com.google.protobuf.Value.newBuilder().setStringValue("foo").build());
+
+                structMap.put("flags", com.google.protobuf.Value.newBuilder()
+                                .setStructValue(Struct.newBuilder().putAllFields(flagsMap)).build());
+
+                // should cache results
+                FlagEvaluationDetails<Boolean> booleanDetails;
+                FlagEvaluationDetails<String> stringDetails;
+                FlagEvaluationDetails<Integer> intDetails;
+                FlagEvaluationDetails<Double> floatDetails;
+                FlagEvaluationDetails<Value> objectDetails;
+
+                // assert cache has been invalidated
+                booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
+                assertTrue(booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(STATIC_REASON, booleanDetails.getReason());
+
+                stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
+                assertEquals(STRING_VALUE, stringDetails.getValue());
+                assertEquals(STRING_VARIANT, stringDetails.getVariant());
+                assertEquals(STATIC_REASON, stringDetails.getReason());
+
+                intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                assertEquals(INT_VALUE, intDetails.getValue());
+                assertEquals(INT_VARIANT, intDetails.getVariant());
+                assertEquals(STATIC_REASON, intDetails.getReason());
+
+                floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                assertEquals(DOUBLE_VALUE, floatDetails.getValue());
+                assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
+                assertEquals(STATIC_REASON, floatDetails.getReason());
+
+                objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
+                assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
+                                .asMap().get(INNER_STRUCT_KEY).asString());
+                assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
+                assertEquals(STATIC_REASON, objectDetails.getReason());
         }
 
-        FlagdProvider provider = createProvider(grpc, cache, () -> true);
+        private void do_resolvers_cache_responses(String reason, Boolean eventStreamAlive, Boolean shouldCache) {
+                String expectedReason = CACHED_REASON;
+                if (!shouldCache) {
+                        expectedReason = reason;
+                }
 
-        try {
-            provider.initialize(null);
-        } catch (Exception e) {
-            // ignore exception if any
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(reason)
+                                .build();
+
+                ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
+                                .setValue(STRING_VALUE)
+                                .setVariant(STRING_VARIANT)
+                                .setReason(reason)
+                                .build();
+
+                ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
+                                .setValue(INT_VALUE)
+                                .setVariant(INT_VARIANT)
+                                .setReason(reason)
+                                .build();
+
+                ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
+                                .setValue(DOUBLE_VALUE)
+                                .setVariant(DOUBLE_VARIANT)
+                                .setReason(reason)
+                                .build();
+
+                ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
+                                .setValue(PROTOBUF_STRUCTURE_VALUE)
+                                .setVariant(OBJECT_VARIANT)
+                                .setReason(reason)
+                                .build();
+
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+                when(serviceBlockingStubMock
+                                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey()))))
+                                .thenReturn(floatResponse);
+                when(serviceBlockingStubMock
+                                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey()))))
+                                .thenReturn(intResponse);
+                when(serviceBlockingStubMock
+                                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey()))))
+                                .thenReturn(stringResponse);
+                when(serviceBlockingStubMock
+                                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey()))))
+                                .thenReturn(objectResponse);
+
+                GrpcConnector grpc = mock(GrpcConnector.class);
+                when(grpc.getResolver()).thenReturn(serviceBlockingStubMock);
+                FlagdProvider provider = createProvider(grpc, () -> eventStreamAlive);
+                // provider.setState(eventStreamAlive); // caching only available when event
+                // stream is alive
+                OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN,
+                                false);
+                booleanDetails = api.getClient()
+                                .getBooleanDetails(FLAG_KEY_BOOLEAN, false); // should retrieve from cache on second
+                                                                             // invocation
+                assertTrue(booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(expectedReason, booleanDetails.getReason());
+
+                FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING,
+                                "wrong");
+                stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
+                assertEquals(STRING_VALUE, stringDetails.getValue());
+                assertEquals(STRING_VARIANT, stringDetails.getVariant());
+                assertEquals(expectedReason, stringDetails.getReason());
+
+                FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                assertEquals(INT_VALUE, intDetails.getValue());
+                assertEquals(INT_VARIANT, intDetails.getVariant());
+                assertEquals(expectedReason, intDetails.getReason());
+
+                FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                assertEquals(DOUBLE_VALUE, floatDetails.getValue());
+                assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
+                assertEquals(expectedReason, floatDetails.getReason());
+
+                FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT,
+                                new Value());
+                objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
+                assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
+                                .asMap().get(INNER_STRUCT_KEY).asString());
+                assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
+                assertEquals(expectedReason, objectDetails.getReason());
         }
 
-        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+        @Test
+        void disabled_cache() {
+                ResolveBooleanResponse booleanResponse = ResolveBooleanResponse.newBuilder()
+                                .setValue(true)
+                                .setVariant(BOOL_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
 
-        HashMap<String, com.google.protobuf.Value> flagsMap = new HashMap<>();
-        HashMap<String, com.google.protobuf.Value> structMap = new HashMap<>();
+                ResolveStringResponse stringResponse = ResolveStringResponse.newBuilder()
+                                .setValue(STRING_VALUE)
+                                .setVariant(STRING_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
 
-        flagsMap.put("foo", com.google.protobuf.Value.newBuilder().setStringValue("foo")
-                .build()); // assert that a configuration_change event works
+                ResolveIntResponse intResponse = ResolveIntResponse.newBuilder()
+                                .setValue(INT_VALUE)
+                                .setVariant(INT_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
 
-        structMap.put("flags", com.google.protobuf.Value.newBuilder()
-                .setStructValue(Struct.newBuilder().putAllFields(flagsMap)).build());
+                ResolveFloatResponse floatResponse = ResolveFloatResponse.newBuilder()
+                                .setValue(DOUBLE_VALUE)
+                                .setVariant(DOUBLE_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
 
-        // should not cache results
-        FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
+                ResolveObjectResponse objectResponse = ResolveObjectResponse.newBuilder()
+                                .setValue(PROTOBUF_STRUCTURE_VALUE)
+                                .setVariant(OBJECT_VARIANT)
+                                .setReason(STATIC_REASON)
+                                .build();
 
-        // assert values are not cached
-        booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
-        assertTrue(booleanDetails.getValue());
-        assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
-        assertEquals(STATIC_REASON, booleanDetails.getReason());
+                ServiceBlockingStub serviceBlockingStubMock = mock(ServiceBlockingStub.class);
+                ServiceStub serviceStubMock = mock(ServiceStub.class);
+                when(serviceStubMock.withWaitForReady()).thenReturn(serviceStubMock);
+                when(serviceStubMock.withDeadline(any(Deadline.class)))
+                                .thenReturn(serviceStubMock);
+                when(serviceBlockingStubMock.withWaitForReady()).thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.withDeadline(any(Deadline.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock.withDeadlineAfter(anyLong(), any(TimeUnit.class)))
+                                .thenReturn(serviceBlockingStubMock);
+                when(serviceBlockingStubMock
+                                .resolveBoolean(argThat(x -> FLAG_KEY_BOOLEAN.equals(x.getFlagKey()))))
+                                .thenReturn(booleanResponse);
+                when(serviceBlockingStubMock
+                                .resolveFloat(argThat(x -> FLAG_KEY_DOUBLE.equals(x.getFlagKey()))))
+                                .thenReturn(floatResponse);
+                when(serviceBlockingStubMock
+                                .resolveInt(argThat(x -> FLAG_KEY_INTEGER.equals(x.getFlagKey()))))
+                                .thenReturn(intResponse);
+                when(serviceBlockingStubMock
+                                .resolveString(argThat(x -> FLAG_KEY_STRING.equals(x.getFlagKey()))))
+                                .thenReturn(stringResponse);
+                when(serviceBlockingStubMock
+                                .resolveObject(argThat(x -> FLAG_KEY_OBJECT.equals(x.getFlagKey()))))
+                                .thenReturn(objectResponse);
 
-        stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
-        assertEquals(STRING_VALUE, stringDetails.getValue());
-        assertEquals(STRING_VARIANT, stringDetails.getVariant());
-        assertEquals(STATIC_REASON, stringDetails.getReason());
+                // disabled cache
+                final Cache cache = new Cache("disabled", 0);
 
-        intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
-        assertEquals(INT_VALUE, intDetails.getValue());
-        assertEquals(INT_VARIANT, intDetails.getVariant());
-        assertEquals(STATIC_REASON, intDetails.getReason());
+                GrpcConnector grpc;
+                try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
+                        mockStaticService.when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
+                                        .thenReturn(serviceBlockingStubMock);
+                        mockStaticService.when(() -> ServiceGrpc.newStub(any()))
+                                        .thenReturn(serviceStubMock);
 
-        floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
-        assertEquals(DOUBLE_VALUE, floatDetails.getValue());
-        assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
-        assertEquals(STATIC_REASON, floatDetails.getReason());
+                        class NoopInitGrpcConnector extends GrpcConnector {
+                                public NoopInitGrpcConnector(FlagdOptions options, Cache cache,
+                                                Supplier<Boolean> connectedSupplier,
+                                                Consumer<ConnectionEvent> onConnectionEvent) {
+                                        super(options, cache, connectedSupplier, onConnectionEvent);
+                                }
 
-        objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
-        assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
-                .asMap().get(INNER_STRUCT_KEY).asString());
-        assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
-        assertEquals(STATIC_REASON, objectDetails.getReason());
-    }
+                                public void initialize() throws Exception {
+                                };
+                        }
 
-    @Test
-    void contextMerging() throws Exception {
-        // given
-        final FlagdProvider provider = new FlagdProvider();
+                        grpc = new NoopInitGrpcConnector(FlagdOptions.builder().build(), cache, () -> true,
+                                        (connectionEvent) -> {
+                                        });
+                }
 
-        final Resolver resolverMock = mock(Resolver.class);
+                FlagdProvider provider = createProvider(grpc, cache, () -> true);
 
-        Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
-        flagResolver.setAccessible(true);
-        flagResolver.set(provider, resolverMock);
+                try {
+                        provider.initialize(null);
+                } catch (Exception e) {
+                        // ignore exception if any
+                }
 
-        final HashMap<String, Value> globalCtxMap = new HashMap<>();
-        globalCtxMap.put("id", new Value("GlobalID"));
-        globalCtxMap.put("env", new Value("A"));
+                OpenFeatureAPI.getInstance().setProviderAndWait(provider);
 
-        final HashMap<String, Value> localCtxMap = new HashMap<>();
-        localCtxMap.put("id", new Value("localID"));
-        localCtxMap.put("client", new Value("999"));
+                HashMap<String, com.google.protobuf.Value> flagsMap = new HashMap<>();
+                HashMap<String, com.google.protobuf.Value> structMap = new HashMap<>();
 
-        final HashMap<String, Value> expectedCtx = new HashMap<>();
-        expectedCtx.put("id", new Value("localID"));
-        expectedCtx.put("env", new Value("A"));
-        localCtxMap.put("client", new Value("999"));
+                flagsMap.put("foo", com.google.protobuf.Value.newBuilder().setStringValue("foo")
+                                .build()); // assert that a configuration_change event works
 
-        // when
-        provider.initialize(new ImmutableContext(globalCtxMap));
-        provider.getBooleanEvaluation("ket", false, new ImmutableContext(localCtxMap));
+                structMap.put("flags", com.google.protobuf.Value.newBuilder()
+                                .setStructValue(Struct.newBuilder().putAllFields(flagsMap)).build());
 
-        // then
-        verify(resolverMock).booleanEvaluation(any(), any(), argThat(
-                ctx -> ctx.asMap().entrySet().containsAll(expectedCtx.entrySet())));
-    }
+                // should not cache results
+                FlagEvaluationDetails<Boolean> booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN,
+                                false);
+                FlagEvaluationDetails<String> stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING,
+                                "wrong");
+                FlagEvaluationDetails<Integer> intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                FlagEvaluationDetails<Double> floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                FlagEvaluationDetails<Value> objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT,
+                                new Value());
 
-    @Test
-    void initializationAndShutdown() throws Exception {
-        // given
-        final FlagdProvider provider = new FlagdProvider();
-        final EvaluationContext ctx = new ImmutableContext();
+                // assert values are not cached
+                booleanDetails = api.getClient().getBooleanDetails(FLAG_KEY_BOOLEAN, false);
+                assertTrue(booleanDetails.getValue());
+                assertEquals(BOOL_VARIANT, booleanDetails.getVariant());
+                assertEquals(STATIC_REASON, booleanDetails.getReason());
 
-        final Resolver resolverMock = mock(Resolver.class);
+                stringDetails = api.getClient().getStringDetails(FLAG_KEY_STRING, "wrong");
+                assertEquals(STRING_VALUE, stringDetails.getValue());
+                assertEquals(STRING_VARIANT, stringDetails.getVariant());
+                assertEquals(STATIC_REASON, stringDetails.getReason());
 
-        Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
-        flagResolver.setAccessible(true);
-        flagResolver.set(provider, resolverMock);
+                intDetails = api.getClient().getIntegerDetails(FLAG_KEY_INTEGER, 0);
+                assertEquals(INT_VALUE, intDetails.getValue());
+                assertEquals(INT_VARIANT, intDetails.getVariant());
+                assertEquals(STATIC_REASON, intDetails.getReason());
 
-        // when
+                floatDetails = api.getClient().getDoubleDetails(FLAG_KEY_DOUBLE, 0.1);
+                assertEquals(DOUBLE_VALUE, floatDetails.getValue());
+                assertEquals(DOUBLE_VARIANT, floatDetails.getVariant());
+                assertEquals(STATIC_REASON, floatDetails.getReason());
 
-        // validate multiple initialization
-        provider.initialize(ctx);
-        provider.initialize(ctx);
-
-        // validate multiple shutdowns
-        provider.shutdown();
-        provider.shutdown();
-
-        // then
-        verify(resolverMock, times(1)).init();
-        verify(resolverMock, times(1)).shutdown();
-    }
-
-    @Test
-    void updatesSyncMetadataWithCallback() throws Exception {
-
-        final EvaluationContext ctx = new ImmutableContext();
-        String key = "key1";
-        String val = "val1";
-        Map<String, Object> metadata = new HashMap<>();
-        metadata.put(key, val);
-
-        // mock a resolver
-        try (MockedConstruction<GrpcResolver> mockResolver = mockConstruction(GrpcResolver.class,
-                (mock, context) -> {
-                    TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent;
-
-                    // get a reference to the onConnectionEvent callback
-                    onConnectionEvent = (TriConsumer<Boolean, List<String>, Map<String, Object>>) context
-                            .arguments().get(3);
-                    
-                    // when our mock resolver initializes, it runs the passed onConnectionEvent callback
-                    doAnswer(invocation -> {
-                        onConnectionEvent.accept(true, Collections.emptyList(),
-                                metadata);
-                        return null;
-                    }).when(mock).init();
-                })) {
-
-            FlagdProvider provider = new FlagdProvider();
-            provider.initialize(ctx);
-
-            // the onConnectionEvent should have updated the sync metadata
-            assertEquals(val, provider.getSyncMetadata().get(key));
-        }
-    }
-
-    // test helper
-
-    // create provider with given grpc connector
-    private FlagdProvider createProvider(GrpcConnector grpc) {
-        return createProvider(grpc, () -> true);
-    }
-
-    // create provider with given grpc provider and state supplier
-    private FlagdProvider createProvider(GrpcConnector grpc, Supplier<Boolean> getConnected) {
-        final Cache cache = new Cache("lru", 5);
-
-        return createProvider(grpc, cache, getConnected);
-    }
-
-    // create provider with given grpc provider, cache and state supplier
-    private FlagdProvider createProvider(GrpcConnector grpc, Cache cache, Supplier<Boolean> getConnected) {
-            final FlagdOptions flagdOptions = FlagdOptions.builder().build();
-            final GrpcResolver grpcResolver = new GrpcResolver(flagdOptions, cache, getConnected,
-                            (providerState, changedFlagKeys, syncMetadata) -> {
-                            });
-
-            final FlagdProvider provider = new FlagdProvider();
-
-        try {
-            Field connector = GrpcResolver.class.getDeclaredField("connector");
-            connector.setAccessible(true);
-            connector.set(grpcResolver, grpc);
-
-            Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
-            flagResolver.setAccessible(true);
-            flagResolver.set(provider, grpcResolver);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
+                objectDetails = api.getClient().getObjectDetails(FLAG_KEY_OBJECT, new Value());
+                assertEquals(INNER_STRUCT_VALUE, objectDetails.getValue().asStructure()
+                                .asMap().get(INNER_STRUCT_KEY).asString());
+                assertEquals(OBJECT_VARIANT, objectDetails.getVariant());
+                assertEquals(STATIC_REASON, objectDetails.getReason());
         }
 
-        return provider;
-    }
+        @Test
+        void contextMerging() throws Exception {
+                // given
+                final FlagdProvider provider = new FlagdProvider();
 
-    // Create an in process provider
-    private FlagdProvider createInProcessProvider() {
+                final Resolver resolverMock = mock(Resolver.class);
 
-        final FlagdOptions flagdOptions = FlagdOptions.builder()
-                .resolverType(Config.Resolver.IN_PROCESS)
-                .deadline(1000)
-                .build();
-        final FlagdProvider provider = new FlagdProvider(flagdOptions);
-        final MockStorage mockStorage = new MockStorage(new HashMap<String, FeatureFlag>(),
-                new LinkedBlockingQueue<StorageStateChange>(Arrays.asList(new StorageStateChange(StorageState.OK))));
+                Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
+                flagResolver.setAccessible(true);
+                flagResolver.set(provider, resolverMock);
 
-        try {
-            final Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
-            flagResolver.setAccessible(true);
-            final Resolver resolver = (Resolver) flagResolver.get(provider);
+                final HashMap<String, Value> globalCtxMap = new HashMap<>();
+                globalCtxMap.put("id", new Value("GlobalID"));
+                globalCtxMap.put("env", new Value("A"));
 
-            final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
-            flagStore.setAccessible(true);
-            flagStore.set(resolver, mockStorage);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
+                final HashMap<String, Value> localCtxMap = new HashMap<>();
+                localCtxMap.put("id", new Value("localID"));
+                localCtxMap.put("client", new Value("999"));
+
+                final HashMap<String, Value> expectedCtx = new HashMap<>();
+                expectedCtx.put("id", new Value("localID"));
+                expectedCtx.put("env", new Value("A"));
+                localCtxMap.put("client", new Value("999"));
+
+                // when
+                provider.initialize(new ImmutableContext(globalCtxMap));
+                provider.getBooleanEvaluation("ket", false, new ImmutableContext(localCtxMap));
+
+                // then
+                verify(resolverMock).booleanEvaluation(any(), any(), argThat(
+                                ctx -> ctx.asMap().entrySet().containsAll(expectedCtx.entrySet())));
         }
 
-        return provider;
-    }
+        @Test
+        void initializationAndShutdown() throws Exception {
+                // given
+                final FlagdProvider provider = new FlagdProvider();
+                final EvaluationContext ctx = new ImmutableContext();
+
+                final Resolver resolverMock = mock(Resolver.class);
+
+                Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
+                flagResolver.setAccessible(true);
+                flagResolver.set(provider, resolverMock);
+
+                // when
+
+                // validate multiple initialization
+                provider.initialize(ctx);
+                provider.initialize(ctx);
+
+                // validate multiple shutdowns
+                provider.shutdown();
+                provider.shutdown();
+
+                // then
+                verify(resolverMock, times(1)).init();
+                verify(resolverMock, times(1)).shutdown();
+        }
+
+        @Test
+        void updatesSyncMetadataWithCallback() throws Exception {
+
+                final EvaluationContext ctx = new ImmutableContext();
+                String key = "key1";
+                String val = "val1";
+                Map<String, Object> metadata = new HashMap<>();
+                metadata.put(key, val);
+
+                // mock a resolver
+                try (MockedConstruction<GrpcResolver> mockResolver = mockConstruction(GrpcResolver.class,
+                                (mock, context) -> {
+                                        Consumer<ConnectionEvent> onConnectionEvent;
+
+                                        // get a reference to the onConnectionEvent callback
+                                        onConnectionEvent = (Consumer<ConnectionEvent>) context
+                                                        .arguments().get(3);
+
+                                        // when our mock resolver initializes, it runs the passed onConnectionEvent
+                                        // callback
+                                        doAnswer(invocation -> {
+                                                onConnectionEvent.accept(
+                                                                new ConnectionEvent(true, metadata));
+                                                return null;
+                                        }).when(mock).init();
+                                })) {
+
+                        FlagdProvider provider = new FlagdProvider();
+                        provider.initialize(ctx);
+
+                        // the onConnectionEvent should have updated the sync metadata
+                        assertEquals(val, provider.getSyncMetadata().get(key));
+                }
+        }
+
+        // test helper
+
+        // create provider with given grpc connector
+        private FlagdProvider createProvider(GrpcConnector grpc) {
+                return createProvider(grpc, () -> true);
+        }
+
+        // create provider with given grpc provider and state supplier
+        private FlagdProvider createProvider(GrpcConnector grpc, Supplier<Boolean> getConnected) {
+                final Cache cache = new Cache("lru", 5);
+
+                return createProvider(grpc, cache, getConnected);
+        }
+
+        // create provider with given grpc provider, cache and state supplier
+        private FlagdProvider createProvider(GrpcConnector grpc, Cache cache, Supplier<Boolean> getConnected) {
+                final FlagdOptions flagdOptions = FlagdOptions.builder().build();
+                final GrpcResolver grpcResolver = new GrpcResolver(flagdOptions, cache, getConnected,
+                                (connectionEvent) -> {
+                                });
+
+                final FlagdProvider provider = new FlagdProvider();
+
+                try {
+                        Field connector = GrpcResolver.class.getDeclaredField("connector");
+                        connector.setAccessible(true);
+                        connector.set(grpcResolver, grpc);
+
+                        Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
+                        flagResolver.setAccessible(true);
+                        flagResolver.set(provider, grpcResolver);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                }
+
+                return provider;
+        }
+
+        // Create an in process provider
+        private FlagdProvider createInProcessProvider() {
+
+                final FlagdOptions flagdOptions = FlagdOptions.builder()
+                                .resolverType(Config.Resolver.IN_PROCESS)
+                                .deadline(1000)
+                                .build();
+                final FlagdProvider provider = new FlagdProvider(flagdOptions);
+                final MockStorage mockStorage = new MockStorage(new HashMap<String, FeatureFlag>(),
+                                new LinkedBlockingQueue<StorageStateChange>(
+                                                Arrays.asList(new StorageStateChange(StorageState.OK))));
+
+                try {
+                        final Field flagResolver = FlagdProvider.class.getDeclaredField("flagResolver");
+                        flagResolver.setAccessible(true);
+                        final Resolver resolver = (Resolver) flagResolver.get(provider);
+
+                        final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
+                        flagStore.setAccessible(true);
+                        flagStore.set(resolver, mockStorage);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                }
+
+                return provider;
+        }
 
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/process/FlagdInProcessSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/process/FlagdInProcessSetup.java
@@ -26,6 +26,7 @@ public class FlagdInProcessSetup {
         flagdContainer.start();
         FlagdInProcessSetup.provider = new FlagdProvider(FlagdOptions.builder()
         .resolverType(Config.Resolver.IN_PROCESS)
+        // set a generous deadline, to prevent timeouts in actions
         .deadline(3000)
         .port(flagdContainer.getFirstMappedPort())
         .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
@@ -24,6 +24,8 @@ public class FlagdInProcessSetup {
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
         .resolverType(Config.Resolver.IN_PROCESS)
         .port(flagdContainer.getFirstMappedPort())
+        // set a generous deadline, to prevent timeouts in actions
+        .deadline(3000)
         .build());
         StepDefinitions.setUnstableProvider(workingProvider);
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/process/FlagdInProcessSetup.java
@@ -23,7 +23,6 @@ public class FlagdInProcessSetup {
         flagdContainer.start();
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
         .resolverType(Config.Resolver.IN_PROCESS)
-        .deadline(3000)
         .port(flagdContainer.getFirstMappedPort())
         .build());
         StepDefinitions.setUnstableProvider(workingProvider);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
@@ -28,6 +28,8 @@ public class FlagdRpcSetup {
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
                 .resolverType(Config.Resolver.RPC)
                 .port(flagdContainer.getFirstMappedPort())
+                // set a generous deadline, to prevent timeouts in actions
+                .deadline(3000)
                 .cacheType(CacheType.DISABLED.getValue())
                 .build());
         StepDefinitions.setUnstableProvider(workingProvider);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
@@ -28,8 +28,6 @@ public class FlagdRpcSetup {
         FeatureProvider workingProvider = new FlagdProvider(FlagdOptions.builder()
                 .resolverType(Config.Resolver.RPC)
                 .port(flagdContainer.getFirstMappedPort())
-                // set a generous deadline, to prevent timeouts in actions
-                .deadline(3000)
                 .cacheType(CacheType.DISABLED.getValue())
                 .build());
         StepDefinitions.setUnstableProvider(workingProvider);
@@ -37,7 +35,6 @@ public class FlagdRpcSetup {
         FeatureProvider unavailableProvider = new FlagdProvider(FlagdOptions.builder()
                 .resolverType(Config.Resolver.RPC)
                 .port(8015) // this port isn't serving anything, error expected
-                // set a generous deadline, to prevent timeouts in actions
                 .deadline(100)
                 .cacheType(CacheType.DISABLED.getValue())
                 .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
@@ -93,7 +93,7 @@ class EventStreamObserverTest {
             Value flagsValue = mock(Value.class);
             Struct flagsStruct = mock(Struct.class);
             HashMap<String, Value> fields = new HashMap<>();
-            fields.put(EventStreamObserver.FLAGS_KEY, flagsValue);
+            fields.put(Constants.FLAGS_KEY, flagsValue);
             HashMap<String, Value> flags = new HashMap<>();
             flags.put(key1, null);
             flags.put(key2, null);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
@@ -3,7 +3,6 @@ package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -19,9 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
@@ -40,7 +36,6 @@ import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceBlockingStub;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceStub;
-import dev.openfeature.sdk.internal.TriConsumer;
 import io.grpc.Channel;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
@@ -104,7 +99,7 @@ public class GrpcConnectorTest {
         doAnswer((InvocationOnMock invocation) -> {
             EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
             eventStreamObserver
-                    .onNext(EventStreamResponse.newBuilder().setType(EventStreamObserver.PROVIDER_READY).build());
+                    .onNext(EventStreamResponse.newBuilder().setType(Constants.PROVIDER_READY).build());
             return null;
         }).when(mockStub).eventStream(any(), any());
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
@@ -3,6 +3,7 @@ package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,6 +19,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -27,12 +30,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
 
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
+import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceBlockingStub;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceStub;
+import dev.openfeature.sdk.internal.TriConsumer;
 import io.grpc.Channel;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
@@ -43,7 +49,7 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 public class GrpcConnectorTest {
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3})
+    @ValueSource(ints = { 1, 2, 3 })
     void validate_retry_calls(int retries) throws NoSuchFieldException, IllegalAccessException {
         final int backoffMs = 100;
 
@@ -58,8 +64,9 @@ public class GrpcConnectorTest {
         final ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
         doAnswer(invocation -> null).when(mockStub).eventStream(any(), any());
 
-        final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, (state,changedFlagKeys) -> {
-        });
+        final GrpcConnector connector = new GrpcConnector(options, cache, () -> true,
+                (state, changedFlagKeys, syncMetadata) -> {
+                });
 
         Field serviceStubField = GrpcConnector.class.getDeclaredField("serviceStub");
         serviceStubField.setAccessible(true);
@@ -90,29 +97,52 @@ public class GrpcConnectorTest {
     @Test
     void initialization_succeed_with_connected_status() throws NoSuchFieldException, IllegalAccessException {
         final Cache cache = new Cache("disabled", 0);
-
         final ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
-        doAnswer(invocation -> null).when(mockStub).eventStream(any(), any());
+        TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent = mock(TriConsumer.class);
+        doAnswer((InvocationOnMock invocation) -> {
+            EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
+            eventStreamObserver
+                    .onNext(EventStreamResponse.newBuilder().setType(EventStreamObserver.PROVIDER_READY).build());
+            return null;
+        }).when(mockStub).eventStream(any(), any());
 
-        // pass true in connected lambda
-        final GrpcConnector connector = new GrpcConnector(FlagdOptions.builder().build(), cache, () -> true, (state, changedFlagKeys) -> {
-        });
+        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
+            mockStaticService.when(() -> ServiceGrpc.newStub(any()))
+                    .thenReturn(mockStub);
 
-        assertDoesNotThrow(connector::initialize);
+            // pass true in connected lambda
+            final GrpcConnector connector = new GrpcConnector(FlagdOptions.builder().build(), cache, () -> {
+                try {
+                    Thread.sleep(100);
+                    return true;
+                } catch (Exception e) {
+                }
+                return false;
+
+            },
+                    onConnectionEvent);
+
+            assertDoesNotThrow(connector::initialize);
+
+            // assert that onConnectionEvent was called with true
+            verify(onConnectionEvent).accept(argThat(arg -> arg), any(), any());
+        }
     }
 
     @Test
     void initialization_fail_with_timeout() throws Exception {
         final Cache cache = new Cache("disabled", 0);
-
         final ServiceGrpc.ServiceStub mockStub = mock(ServiceGrpc.ServiceStub.class);
+        TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent = mock(TriConsumer.class);
         doAnswer(invocation -> null).when(mockStub).eventStream(any(), any());
 
-        // pass false in connected lambda
-        final GrpcConnector connector = new GrpcConnector(FlagdOptions.builder().build(), cache, () -> false, (state, changedFlagKeys) -> {
-        });
+        final GrpcConnector connector = new GrpcConnector(FlagdOptions.builder().build(), cache, () -> false,
+                onConnectionEvent);
 
+        // assert throws
         assertThrows(RuntimeException.class, connector::initialize);
+        // assert that onConnectionEvent was called with false
+        verify(onConnectionEvent).accept(argThat(arg -> !arg), any(), any());
     }
 
     @Test
@@ -170,17 +200,16 @@ public class GrpcConnectorTest {
                     new GrpcConnector(FlagdOptions.builder().build(), null, null, null);
 
                     // verify host/port matches & called times(= 1 as we rely on reusable channel)
-                    mockStaticChannelBuilder.verify(() -> NettyChannelBuilder.
-                            forAddress(host, port), times(1));
+                    mockStaticChannelBuilder.verify(() -> NettyChannelBuilder.forAddress(host, port), times(1));
                 }
             }
         });
     }
 
-
     /**
-     * OS Specific test - This test is valid only on Linux system as it rely on epoll availability
-    * */
+     * OS Specific test - This test is valid only on Linux system as it rely on
+     * epoll availability
+     */
     @Test
     @EnabledOnOs(OS.LINUX)
     void path_arg_should_build_domain_socket_with_correct_path() {
@@ -218,8 +247,9 @@ public class GrpcConnectorTest {
     }
 
     /**
-     * OS Specific test - This test is valid only on Linux system as it rely on epoll availability
-     * */
+     * OS Specific test - This test is valid only on Linux system as it rely on
+     * epoll availability
+     */
     @Test
     @EnabledOnOs(OS.LINUX)
     void no_args_socket_env_should_build_domain_socket_with_correct_path() throws Exception {
@@ -249,7 +279,7 @@ public class GrpcConnectorTest {
 
                         new GrpcConnector(FlagdOptions.builder().build(), null, null, null);
 
-                        //verify path matches & called times(= 1 as we rely on reusable channel)
+                        // verify path matches & called times(= 1 as we rely on reusable channel)
                         mockStaticChannelBuilder.verify(() -> NettyChannelBuilder
                                 .forAddress(argThat((DomainSocketAddress d) -> {
                                     return d.path() == path;

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -2,6 +2,7 @@ package dev.openfeature.contrib.providers.flagd.resolver.process;
 
 import dev.openfeature.contrib.providers.flagd.Config;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.MockConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.StorageState;
@@ -19,7 +20,6 @@ import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
-import dev.openfeature.sdk.internal.TriConsumer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,6 +34,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.BOOLEAN_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.MockFlags.DISABLED_FLAG;
@@ -53,404 +54,405 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class InProcessResolverTest {
 
-    @Test
-    public void connectorSetup() {
-        // given
-        FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                .host("localhost")
-                .port(8080).build();
-        FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                .offlineFlagSourcePath("path").build();
-        FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                .customConnector(new MockConnector(null)).build();
+        @Test
+        public void connectorSetup() {
+                // given
+                FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .host("localhost")
+                                .port(8080).build();
+                FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .offlineFlagSourcePath("path").build();
+                FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                                .customConnector(new MockConnector(null)).build();
 
-        // then
-        assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
-        assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
-        assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
-    }
-
-    @Test
-    public void eventHandling() throws Throwable {
-        // given
-        // note - queues with adequate capacity
-        final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
-        final BlockingQueue<StorageStateChange> receiver = new LinkedBlockingQueue<>(5);
-        final String key = "key1";
-        final String val = "val1";
-        final Map<String, Object> syncMetadata = new HashMap<>();
-        syncMetadata.put(key, val);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
-                (connectedState, changedFlagKeys, sm) -> receiver.offer(new StorageStateChange(
-                        connectedState ? StorageState.OK : StorageState.ERROR, changedFlagKeys, sm)));
-
-        // when - init and emit events
-        Thread initThread = new Thread(() -> {
-            try {
-                inProcessResolver.init();
-            } catch (Exception e) {
-            }
-        });
-        initThread.start();
-        if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.emptyList(), syncMetadata), 100,
-                TimeUnit.MILLISECONDS)) {
-            Assertions.fail("failed to send the event");
-        }
-        if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
-            Assertions.fail("failed to send the event");
+                // then
+                assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
+                assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
+                assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
         }
 
-        // then - receive events in order
-        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-            StorageStateChange storageState = receiver.take();
-            assertEquals(StorageState.OK, storageState.getStorageState());
-            assertEquals(val, storageState.getSyncMetadata().get(key));
-        });
+        @Test
+        public void eventHandling() throws Throwable {
+                // given
+                // note - queues with adequate capacity
+                final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
+                final BlockingQueue<StorageStateChange> receiver = new LinkedBlockingQueue<>(5);
+                final String key = "key1";
+                final String val = "val1";
+                final Map<String, Object> syncMetadata = new HashMap<>();
+                syncMetadata.put(key, val);
 
-        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-            assertEquals(StorageState.ERROR, receiver.take().getStorageState());
-        });
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
+                                (connectionEvent) -> receiver.offer(new StorageStateChange(
+                                                connectionEvent.isConnected() ? StorageState.OK : StorageState.ERROR,
+                                                connectionEvent.getFlagsChanged(), connectionEvent.getSyncMetadata())));
 
-    @Test
-    public void simpleBooleanResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("booleanFlag", BOOLEAN_FLAG);
+                // when - init and emit events
+                Thread initThread = new Thread(() -> {
+                        try {
+                                inProcessResolver.init();
+                        } catch (Exception e) {
+                        }
+                });
+                initThread.start();
+                if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.emptyList(), syncMetadata), 100,
+                                TimeUnit.MILLISECONDS)) {
+                        Assertions.fail("failed to send the event");
+                }
+                if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
+                        Assertions.fail("failed to send the event");
+                }
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
+                // then - receive events in order
+                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+                        StorageStateChange storageState = receiver.take();
+                        assertEquals(StorageState.OK, storageState.getStorageState());
+                        assertEquals(val, storageState.getSyncMetadata().get(key));
                 });
 
-        // when
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
-                false,
-                new ImmutableContext());
-
-        // then
-        assertEquals(true, providerEvaluation.getValue());
-        assertEquals("on", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void simpleDoubleResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("doubleFlag", DOUBLE_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
+                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+                        assertEquals(StorageState.ERROR, receiver.take().getStorageState());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
-                new ImmutableContext());
+        @Test
+        public void simpleBooleanResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("booleanFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(3.141d, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
 
-    @Test
-    public void fetchIntegerAsDouble() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("doubleFlag", DOUBLE_FLAG);
+                // when
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                                false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
+                // then
+                assertEquals(true, providerEvaluation.getValue());
+                assertEquals("on", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleDoubleResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(3.141d, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void fetchIntegerAsDouble() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(3, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void fetchDoubleAsInt() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("integerFlag", INT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(1d, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleIntResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("integerFlag", INT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
+                                new ImmutableContext());
+
+                // then
+                assertEquals(1, providerEvaluation.getValue());
+                assertEquals("one", providerEvaluation.getVariant());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void simpleObjectResolving() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("objectFlag", OBJECT_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                Map<String, Object> typeDefault = new HashMap<>();
+                typeDefault.put("key", "0164");
+                typeDefault.put("date", "01.01.1990");
+
+                // when
+                ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
+                                Value.objectToValue(typeDefault), new ImmutableContext());
+
+                // then
+                Value value = providerEvaluation.getValue();
+                Map<String, Value> valueMap = value.asStructure().asMap();
+
+                assertEquals("0165", valueMap.get("key").asString());
+                assertEquals("01.01.2000", valueMap.get("date").asString());
+                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+                assertEquals("typeA", providerEvaluation.getVariant());
+        }
+
+        @Test
+        public void missingFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when/then
+                ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false,
+                                new ImmutableContext());
+                assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
+        }
+
+        @Test
+        public void disabledFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("disabledFlag", DISABLED_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when/then
+                ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false,
+                                new ImmutableContext());
+                assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
+        }
+
+        @Test
+        public void variantMismatchFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when/then
+                assertThrows(TypeMismatchError.class, () -> {
+                        inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
-                new ImmutableContext());
+        @Test
+        public void typeMismatchEvaluation() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(3, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
 
-    @Test
-    public void fetchDoubleAsInt() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("integerFlag", INT_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
+                // when/then
+                assertThrows(TypeMismatchError.class, () -> {
+                        inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
-                new ImmutableContext());
+        @Test
+        public void booleanShorthandEvaluation() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
 
-        // then
-        assertEquals(1d, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
 
-    @Test
-    public void simpleIntResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("integerFlag", INT_FLAG);
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
+                // then
+                assertEquals(true, providerEvaluation.getValue());
+                assertEquals("true", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingMatchedEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                                "loopAlg",
+                                new MutableContext().add("email", "abc@faas.com"));
+
+                // then
+                assertEquals("binetAlg", providerEvaluation.getValue());
+                assertEquals("binet", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingUnmatchedEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                                "loopAlg",
+                                new MutableContext().add("email", "abc@abc.com"));
+
+                // then
+                assertEquals("loopAlg", providerEvaluation.getValue());
+                assertEquals("loop", providerEvaluation.getVariant());
+                assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when
+                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
+                                new MutableContext("xyz"));
+
+                // then
+                assertEquals("binetAlg", providerEvaluation.getValue());
+                assertEquals("binet", providerEvaluation.getVariant());
+                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+        }
+
+        @Test
+        public void targetingErrorEvaluationFlag() throws Exception {
+                // given
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
+
+                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                                (connectionEvent) -> {
+                                });
+
+                // when/then
+                assertThrows(ParseError.class, () -> {
+                        inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
                 });
+        }
 
-        // when
-        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
-                new ImmutableContext());
+        @Test
+        public void validateMetadataInEvaluationResult() throws Exception {
+                // given
+                final String scope = "appName=myApp";
+                final Map<String, FeatureFlag> flagMap = new HashMap<>();
+                flagMap.put("booleanFlag", BOOLEAN_FLAG);
 
-        // then
-        assertEquals(1, providerEvaluation.getValue());
-        assertEquals("one", providerEvaluation.getVariant());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-    }
+                InProcessResolver inProcessResolver = getInProcessResolverWth(
+                                FlagdOptions.builder().selector(scope).build(),
+                                new MockStorage(flagMap));
 
-    @Test
-    public void simpleObjectResolving() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("objectFlag", OBJECT_FLAG);
+                // when
+                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                                false,
+                                new ImmutableContext());
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
+                // then
+                final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
+                assertNotNull(metadata);
+                assertEquals(scope, metadata.getString("scope"));
+        }
 
-        Map<String, Object> typeDefault = new HashMap<>();
-        typeDefault.put("key", "0164");
-        typeDefault.put("date", "01.01.1990");
+        private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        // when
-        ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
-                Value.objectToValue(typeDefault), new ImmutableContext());
+                final InProcessResolver resolver = new InProcessResolver(options, () -> true,
+                                (connectionEvent) -> {
+                                });
+                return injectFlagStore(resolver, storage);
+        }
 
-        // then
-        Value value = providerEvaluation.getValue();
-        Map<String, Value> valueMap = value.asStructure().asMap();
+        private InProcessResolver getInProcessResolverWth(final MockStorage storage,
+                        final Consumer<ConnectionEvent> onConnectionEvent)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        assertEquals("0165", valueMap.get("key").asString());
-        assertEquals("01.01.2000", valueMap.get("date").asString());
-        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        assertEquals("typeA", providerEvaluation.getVariant());
-    }
+                final InProcessResolver resolver = new InProcessResolver(
+                                FlagdOptions.builder().deadline(1000).build(), () -> true, onConnectionEvent);
+                return injectFlagStore(resolver, storage);
+        }
 
-    @Test
-    public void missingFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        // helper to inject flagStore override
+        private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
+                        throws NoSuchFieldException, IllegalAccessException {
 
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
+                final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
+                flagStore.setAccessible(true);
+                flagStore.set(resolver, storage);
 
-        // when/then
-        ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false,
-                new ImmutableContext());
-        assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
-    }
-
-    @Test
-    public void disabledFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("disabledFlag", DISABLED_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when/then
-        ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false,
-                new ImmutableContext());
-        assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
-    }
-
-    @Test
-    public void variantMismatchFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when/then
-        assertThrows(TypeMismatchError.class, () -> {
-            inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void typeMismatchEvaluation() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", BOOLEAN_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when/then
-        assertThrows(TypeMismatchError.class, () -> {
-            inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void booleanShorthandEvaluation() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
-                new ImmutableContext());
-
-        // then
-        assertEquals(true, providerEvaluation.getValue());
-        assertEquals("true", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingMatchedEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
-                "loopAlg",
-                new MutableContext().add("email", "abc@faas.com"));
-
-        // then
-        assertEquals("binetAlg", providerEvaluation.getValue());
-        assertEquals("binet", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingUnmatchedEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
-                "loopAlg",
-                new MutableContext().add("email", "abc@abc.com"));
-
-        // then
-        assertEquals("loopAlg", providerEvaluation.getValue());
-        assertEquals("loop", providerEvaluation.getVariant());
-        assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when
-        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
-                new MutableContext("xyz"));
-
-        // then
-        assertEquals("binetAlg", providerEvaluation.getValue());
-        assertEquals("binet", providerEvaluation.getVariant());
-        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-    }
-
-    @Test
-    public void targetingErrorEvaluationFlag() throws Exception {
-        // given
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-
-        // when/then
-        assertThrows(ParseError.class, () -> {
-            inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
-        });
-    }
-
-    @Test
-    public void validateMetadataInEvaluationResult() throws Exception {
-        // given
-        final String scope = "appName=myApp";
-        final Map<String, FeatureFlag> flagMap = new HashMap<>();
-        flagMap.put("booleanFlag", BOOLEAN_FLAG);
-
-        InProcessResolver inProcessResolver = getInProcessResolverWth(
-                FlagdOptions.builder().selector(scope).build(),
-                new MockStorage(flagMap));
-
-        // when
-        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
-                false,
-                new ImmutableContext());
-
-        // then
-        final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
-        assertNotNull(metadata);
-        assertEquals(scope, metadata.getString("scope"));
-    }
-
-    private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final InProcessResolver resolver = new InProcessResolver(options, () -> true,
-                (providerState, changedFlagKeys, syncMetadata) -> {
-                });
-        return injectFlagStore(resolver, storage);
-    }
-
-    private InProcessResolver getInProcessResolverWth(final MockStorage storage,
-            final TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final InProcessResolver resolver = new InProcessResolver(
-                FlagdOptions.builder().deadline(1000).build(), () -> true, onConnectionEvent);
-        return injectFlagStore(resolver, storage);
-    }
-
-    // helper to inject flagStore override
-    private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
-            throws NoSuchFieldException, IllegalAccessException {
-
-        final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
-        flagStore.setAccessible(true);
-        flagStore.set(resolver, storage);
-
-        return resolver;
-    }
+                return resolver;
+        }
 
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -19,6 +19,8 @@ import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
+import dev.openfeature.sdk.internal.TriConsumer;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -51,397 +53,404 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class InProcessResolverTest {
 
-        @Test
-        public void connectorSetup() {
-                // given
-                FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                                .host("localhost")
-                                .port(8080).build();
-                FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                                .offlineFlagSourcePath("path").build();
-                FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
-                                .customConnector(new MockConnector(null)).build();
+    @Test
+    public void connectorSetup() {
+        // given
+        FlagdOptions forGrpcOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                .host("localhost")
+                .port(8080).build();
+        FlagdOptions forOfflineOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                .offlineFlagSourcePath("path").build();
+        FlagdOptions forCustomConnectorOptions = FlagdOptions.builder().resolverType(Config.Resolver.IN_PROCESS)
+                .customConnector(new MockConnector(null)).build();
 
-                // then
-                assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
-                assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
-                assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
+        // then
+        assertInstanceOf(GrpcStreamConnector.class, InProcessResolver.getConnector(forGrpcOptions));
+        assertInstanceOf(FileConnector.class, InProcessResolver.getConnector(forOfflineOptions));
+        assertInstanceOf(MockConnector.class, InProcessResolver.getConnector(forCustomConnectorOptions));
+    }
+
+    @Test
+    public void eventHandling() throws Throwable {
+        // given
+        // note - queues with adequate capacity
+        final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
+        final BlockingQueue<StorageStateChange> receiver = new LinkedBlockingQueue<>(5);
+        final String key = "key1";
+        final String val = "val1";
+        final Map<String, Object> syncMetadata = new HashMap<>();
+        syncMetadata.put(key, val);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
+                (connectedState, changedFlagKeys, sm) -> receiver.offer(new StorageStateChange(
+                        connectedState ? StorageState.OK : StorageState.ERROR, changedFlagKeys, sm)));
+
+        // when - init and emit events
+        Thread initThread = new Thread(() -> {
+            try {
+                inProcessResolver.init();
+            } catch (Exception e) {
+            }
+        });
+        initThread.start();
+        if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.emptyList(), syncMetadata), 100,
+                TimeUnit.MILLISECONDS)) {
+            Assertions.fail("failed to send the event");
+        }
+        if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
+            Assertions.fail("failed to send the event");
         }
 
-        @Test
-        public void eventHandling() throws Throwable {
-                // given
-                // note - queues with adequate capacity
-                final BlockingQueue<StorageStateChange> sender = new LinkedBlockingQueue<>(5);
-                final BlockingQueue<Boolean> receiver = new LinkedBlockingQueue<>(5);
+        // then - receive events in order
+        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+            StorageStateChange storageState = receiver.take();
+            assertEquals(StorageState.OK, storageState.getStorageState());
+            assertEquals(val, storageState.getSyncMetadata().get(key));
+        });
 
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(new HashMap<>(), sender),
-                                (connectedState, changedFlagKeys) -> receiver.offer(connectedState));
+        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+            assertEquals(StorageState.ERROR, receiver.take().getStorageState());
+        });
+    }
 
-                // when - init and emit events
-                Thread initThread = new Thread(() -> {
-                        try {
-                                inProcessResolver.init();
-                        } catch (Exception e) {
-                        }
+    @Test
+    public void simpleBooleanResolving() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("booleanFlag", BOOLEAN_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
-                initThread.start();
-                if (!sender.offer(new StorageStateChange(StorageState.OK, Collections.EMPTY_LIST), 100,
-                                TimeUnit.MILLISECONDS)) {
-                        Assertions.fail("failed to send the event");
-                }
-                if (!sender.offer(new StorageStateChange(StorageState.ERROR), 100, TimeUnit.MILLISECONDS)) {
-                        Assertions.fail("failed to send the event");
-                }
 
-                // then - receive events in order
-                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-                        Assertions.assertTrue(receiver.take());
+        // when
+        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                false,
+                new ImmutableContext());
+
+        // then
+        assertEquals(true, providerEvaluation.getValue());
+        assertEquals("on", providerEvaluation.getVariant());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void simpleDoubleResolving() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
 
-                assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
-                        Assertions.assertFalse(receiver.take());
+        // when
+        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
+                new ImmutableContext());
+
+        // then
+        assertEquals(3.141d, providerEvaluation.getValue());
+        assertEquals("one", providerEvaluation.getVariant());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void fetchIntegerAsDouble() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("doubleFlag", DOUBLE_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
-        }
 
-        @Test
-        public void simpleBooleanResolving() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("booleanFlag", BOOLEAN_FLAG);
+        // when
+        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
+                new ImmutableContext());
 
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
+        // then
+        assertEquals(3, providerEvaluation.getValue());
+        assertEquals("one", providerEvaluation.getVariant());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+    }
 
-                // when
-                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
-                                false,
-                                new ImmutableContext());
+    @Test
+    public void fetchDoubleAsInt() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("integerFlag", INT_FLAG);
 
-                // then
-                assertEquals(true, providerEvaluation.getValue());
-                assertEquals("on", providerEvaluation.getVariant());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void simpleDoubleResolving() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("doubleFlag", DOUBLE_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("doubleFlag", 0d,
-                                new ImmutableContext());
-
-                // then
-                assertEquals(3.141d, providerEvaluation.getValue());
-                assertEquals("one", providerEvaluation.getVariant());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void fetchIntegerAsDouble() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("doubleFlag", DOUBLE_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("doubleFlag", 0,
-                                new ImmutableContext());
-
-                // then
-                assertEquals(3, providerEvaluation.getValue());
-                assertEquals("one", providerEvaluation.getVariant());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void fetchDoubleAsInt() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("integerFlag", INT_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
-                                new ImmutableContext());
-
-                // then
-                assertEquals(1d, providerEvaluation.getValue());
-                assertEquals("one", providerEvaluation.getVariant());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void simpleIntResolving() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("integerFlag", INT_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
-                                new ImmutableContext());
-
-                // then
-                assertEquals(1, providerEvaluation.getValue());
-                assertEquals("one", providerEvaluation.getVariant());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void simpleObjectResolving() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("objectFlag", OBJECT_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                Map<String, Object> typeDefault = new HashMap<>();
-                typeDefault.put("key", "0164");
-                typeDefault.put("date", "01.01.1990");
-
-                // when
-                ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
-                                Value.objectToValue(typeDefault), new ImmutableContext());
-
-                // then
-                Value value = providerEvaluation.getValue();
-                Map<String, Value> valueMap = value.asStructure().asMap();
-
-                assertEquals("0165", valueMap.get("key").asString());
-                assertEquals("01.01.2000", valueMap.get("date").asString());
-                assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
-                assertEquals("typeA", providerEvaluation.getVariant());
-        }
-
-        @Test
-        public void missingFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when/then
-                ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false,
-                                new ImmutableContext());
-                assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
-        }
-
-        @Test
-        public void disabledFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("disabledFlag", DISABLED_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when/then
-                ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false,
-                                new ImmutableContext());
-                assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
-        }
-
-        @Test
-        public void variantMismatchFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when/then
-                assertThrows(TypeMismatchError.class, () -> {
-                        inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
-        }
 
-        @Test
-        public void typeMismatchEvaluation() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("stringFlag", BOOLEAN_FLAG);
+        // when
+        ProviderEvaluation<Double> providerEvaluation = inProcessResolver.doubleEvaluation("integerFlag", 0d,
+                new ImmutableContext());
 
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
+        // then
+        assertEquals(1d, providerEvaluation.getValue());
+        assertEquals("one", providerEvaluation.getVariant());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+    }
 
-                // when/then
-                assertThrows(TypeMismatchError.class, () -> {
-                        inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
+    @Test
+    public void simpleIntResolving() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("integerFlag", INT_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
-        }
 
-        @Test
-        public void booleanShorthandEvaluation() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
+        // when
+        ProviderEvaluation<Integer> providerEvaluation = inProcessResolver.integerEvaluation("integerFlag", 0,
+                new ImmutableContext());
 
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
+        // then
+        assertEquals(1, providerEvaluation.getValue());
+        assertEquals("one", providerEvaluation.getVariant());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+    }
 
-                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
-                                new ImmutableContext());
+    @Test
+    public void simpleObjectResolving() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("objectFlag", OBJECT_FLAG);
 
-                // then
-                assertEquals(true, providerEvaluation.getValue());
-                assertEquals("true", providerEvaluation.getVariant());
-                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void targetingMatchedEvaluationFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
-                                "loopAlg",
-                                new MutableContext().add("email", "abc@faas.com"));
-
-                // then
-                assertEquals("binetAlg", providerEvaluation.getValue());
-                assertEquals("binet", providerEvaluation.getVariant());
-                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void targetingUnmatchedEvaluationFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
-                                "loopAlg",
-                                new MutableContext().add("email", "abc@abc.com"));
-
-                // then
-                assertEquals("loopAlg", providerEvaluation.getValue());
-                assertEquals("loop", providerEvaluation.getVariant());
-                assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when
-                ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
-                                new MutableContext("xyz"));
-
-                // then
-                assertEquals("binetAlg", providerEvaluation.getValue());
-                assertEquals("binet", providerEvaluation.getVariant());
-                assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
-        }
-
-        @Test
-        public void targetingErrorEvaluationFlag() throws Exception {
-                // given
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
-
-                InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
-                                (providerState, changedFlagKeys) -> {
-                                });
-
-                // when/then
-                assertThrows(ParseError.class, () -> {
-                        inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
                 });
-        }
 
-        @Test
-        public void validateMetadataInEvaluationResult() throws Exception {
-                // given
-                final String scope = "appName=myApp";
-                final Map<String, FeatureFlag> flagMap = new HashMap<>();
-                flagMap.put("booleanFlag", BOOLEAN_FLAG);
+        Map<String, Object> typeDefault = new HashMap<>();
+        typeDefault.put("key", "0164");
+        typeDefault.put("date", "01.01.1990");
 
-                InProcessResolver inProcessResolver = getInProcessResolverWth(
-                                FlagdOptions.builder().selector(scope).build(),
-                                new MockStorage(flagMap));
+        // when
+        ProviderEvaluation<Value> providerEvaluation = inProcessResolver.objectEvaluation("objectFlag",
+                Value.objectToValue(typeDefault), new ImmutableContext());
 
-                // when
-                ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
-                                false,
-                                new ImmutableContext());
+        // then
+        Value value = providerEvaluation.getValue();
+        Map<String, Value> valueMap = value.asStructure().asMap();
 
-                // then
-                final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
-                assertNotNull(metadata);
-                assertEquals(scope, metadata.getString("scope"));
-        }
+        assertEquals("0165", valueMap.get("key").asString());
+        assertEquals("01.01.2000", valueMap.get("date").asString());
+        assertEquals(Reason.STATIC.toString(), providerEvaluation.getReason());
+        assertEquals("typeA", providerEvaluation.getVariant());
+    }
 
-        private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
-                        throws NoSuchFieldException, IllegalAccessException {
+    @Test
+    public void missingFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
 
-                final InProcessResolver resolver = new InProcessResolver(options, () -> true,
-                                (providerState, changedFlagKeys) -> {
-                                });
-                return injectFlagStore(resolver, storage);
-        }
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
 
-        private InProcessResolver getInProcessResolverWth(final MockStorage storage,
-                        final BiConsumer<Boolean, List<String>> stateConsumer)
-                        throws NoSuchFieldException, IllegalAccessException {
+        // when/then
+        ProviderEvaluation<Boolean> missingFlag = inProcessResolver.booleanEvaluation("missingFlag", false,
+                new ImmutableContext());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, missingFlag.getErrorCode());
+    }
 
-                final InProcessResolver resolver = new InProcessResolver(
-                                FlagdOptions.builder().deadline(1000).build(), () -> true, stateConsumer);
-                return injectFlagStore(resolver, storage);
-        }
+    @Test
+    public void disabledFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("disabledFlag", DISABLED_FLAG);
 
-        // helper to inject flagStore override
-        private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
-                        throws NoSuchFieldException, IllegalAccessException {
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
 
-                final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
-                flagStore.setAccessible(true);
-                flagStore.set(resolver, storage);
+        // when/then
+        ProviderEvaluation<Boolean> disabledFlag = inProcessResolver.booleanEvaluation("disabledFlag", false,
+                new ImmutableContext());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
+    }
 
-                return resolver;
-        }
+    @Test
+    public void variantMismatchFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("mismatchFlag", VARIANT_MISMATCH_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when/then
+        assertThrows(TypeMismatchError.class, () -> {
+            inProcessResolver.booleanEvaluation("mismatchFlag", false, new ImmutableContext());
+        });
+    }
+
+    @Test
+    public void typeMismatchEvaluation() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("stringFlag", BOOLEAN_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when/then
+        assertThrows(TypeMismatchError.class, () -> {
+            inProcessResolver.stringEvaluation("stringFlag", "false", new ImmutableContext());
+        });
+    }
+
+    @Test
+    public void booleanShorthandEvaluation() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("shorthand", FLAG_WIH_SHORTHAND_TARGETING);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("shorthand", false,
+                new ImmutableContext());
+
+        // then
+        assertEquals(true, providerEvaluation.getValue());
+        assertEquals("true", providerEvaluation.getVariant());
+        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void targetingMatchedEvaluationFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when
+        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                "loopAlg",
+                new MutableContext().add("email", "abc@faas.com"));
+
+        // then
+        assertEquals("binetAlg", providerEvaluation.getValue());
+        assertEquals("binet", providerEvaluation.getVariant());
+        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void targetingUnmatchedEvaluationFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("stringFlag", FLAG_WIH_IF_IN_TARGET);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when
+        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag",
+                "loopAlg",
+                new MutableContext().add("email", "abc@abc.com"));
+
+        // then
+        assertEquals("loopAlg", providerEvaluation.getValue());
+        assertEquals("loop", providerEvaluation.getVariant());
+        assertEquals(Reason.DEFAULT.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void explicitTargetingKeyHandling() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("stringFlag", FLAG_WITH_TARGETING_KEY);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when
+        ProviderEvaluation<String> providerEvaluation = inProcessResolver.stringEvaluation("stringFlag", "loop",
+                new MutableContext("xyz"));
+
+        // then
+        assertEquals("binetAlg", providerEvaluation.getValue());
+        assertEquals("binet", providerEvaluation.getVariant());
+        assertEquals(Reason.TARGETING_MATCH.toString(), providerEvaluation.getReason());
+    }
+
+    @Test
+    public void targetingErrorEvaluationFlag() throws Exception {
+        // given
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("targetingErrorFlag", FLAG_WIH_INVALID_TARGET);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(new MockStorage(flagMap),
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+
+        // when/then
+        assertThrows(ParseError.class, () -> {
+            inProcessResolver.booleanEvaluation("targetingErrorFlag", false, new ImmutableContext());
+        });
+    }
+
+    @Test
+    public void validateMetadataInEvaluationResult() throws Exception {
+        // given
+        final String scope = "appName=myApp";
+        final Map<String, FeatureFlag> flagMap = new HashMap<>();
+        flagMap.put("booleanFlag", BOOLEAN_FLAG);
+
+        InProcessResolver inProcessResolver = getInProcessResolverWth(
+                FlagdOptions.builder().selector(scope).build(),
+                new MockStorage(flagMap));
+
+        // when
+        ProviderEvaluation<Boolean> providerEvaluation = inProcessResolver.booleanEvaluation("booleanFlag",
+                false,
+                new ImmutableContext());
+
+        // then
+        final ImmutableMetadata metadata = providerEvaluation.getFlagMetadata();
+        assertNotNull(metadata);
+        assertEquals(scope, metadata.getString("scope"));
+    }
+
+    private InProcessResolver getInProcessResolverWth(final FlagdOptions options, final MockStorage storage)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        final InProcessResolver resolver = new InProcessResolver(options, () -> true,
+                (providerState, changedFlagKeys, syncMetadata) -> {
+                });
+        return injectFlagStore(resolver, storage);
+    }
+
+    private InProcessResolver getInProcessResolverWth(final MockStorage storage,
+            final TriConsumer<Boolean, List<String>, Map<String, Object>> onConnectionEvent)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        final InProcessResolver resolver = new InProcessResolver(
+                FlagdOptions.builder().deadline(1000).build(), () -> true, onConnectionEvent);
+        return injectFlagStore(resolver, storage);
+    }
+
+    // helper to inject flagStore override
+    private InProcessResolver injectFlagStore(final InProcessResolver resolver, final MockStorage storage)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        final Field flagStore = InProcessResolver.class.getDeclaredField("flagStore");
+        flagStore.setAccessible(true);
+        flagStore.set(resolver, storage);
+
+        return resolver;
+    }
 
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
@@ -1,26 +1,27 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 
-import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
-import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Collections;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
-
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_LONG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_SIMPLE;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.getFlagsFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
+import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
+import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 
 class FlagStoreTest {
 
@@ -36,7 +37,7 @@ class FlagStoreTest {
 
         // OK for simple flag
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE), Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE), GetMetadataResponse.getDefaultInstance()));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
@@ -45,7 +46,7 @@ class FlagStoreTest {
 
         // STALE for invalid flag
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(INVALID_FLAG), Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(INVALID_FLAG), GetMetadataResponse.getDefaultInstance()));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
@@ -54,7 +55,7 @@ class FlagStoreTest {
 
         // OK again for next payload
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), GetMetadataResponse.getDefaultInstance()));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
@@ -63,7 +64,7 @@ class FlagStoreTest {
 
         // ERROR is propagated correctly
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.ERROR, null, Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.ERROR, null, GetMetadataResponse.getDefaultInstance()));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
@@ -87,7 +88,7 @@ class FlagStoreTest {
         final BlockingQueue<StorageStateChange> storageStateDTOS = store.getStateQueue();
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE), Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE), GetMetadataResponse.getDefaultInstance()));
         });
         // flags changed for first time
         assertEquals(FlagParser.parseString(
@@ -95,7 +96,7 @@ class FlagStoreTest {
                 storageStateDTOS.take().getChangedFlagsKeys());
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), ()-> {
-            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), Collections.emptyMap()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), GetMetadataResponse.getDefaultInstance()));
         });
         Map<String, FeatureFlag> expectedChangedFlags =
                 FlagParser.parseString(getFlagsFromResource(VALID_LONG),true);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
@@ -26,7 +26,7 @@ class FlagStoreTest {
 
     @Test
     public void connectorHandling() throws Exception {
-        final int maxDelay = 500;
+        final int maxDelay = 1000;
 
         final BlockingQueue<QueuePayload> payload = new LinkedBlockingQueue<>();
         FlagStore store = new FlagStore(new MockConnector(payload), true);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
@@ -1,18 +1,19 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayload;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayloadType;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.Collections;
 
 @Slf4j
 public class MockConnector implements Connector {
 
-    private BlockingQueue<StreamPayload> mockQueue;
+    private BlockingQueue<QueuePayload> mockQueue;
 
-    public MockConnector(final BlockingQueue<StreamPayload> mockQueue) {
+    public MockConnector(final BlockingQueue<QueuePayload> mockQueue) {
         this.mockQueue = mockQueue;
     }
 
@@ -20,13 +21,13 @@ public class MockConnector implements Connector {
         // no-op
     }
 
-    public BlockingQueue<StreamPayload> getStream() {
+    public BlockingQueue<QueuePayload> getStream() {
         return mockQueue;
     }
 
     public void shutdown() {
         // Emit error mocking closed connection scenario
-        if (!mockQueue.offer(new StreamPayload(StreamPayloadType.ERROR, "shutdown invoked"))) {
+        if (!mockQueue.offer(new QueuePayload(QueuePayloadType.ERROR, "shutdown invoked", Collections.emptyMap()))) {
             log.warn("Failed to offer shutdown status");
         }
     }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
@@ -1,12 +1,12 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 
+import java.util.concurrent.BlockingQueue;
+
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
+import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.concurrent.BlockingQueue;
-import java.util.Collections;
 
 @Slf4j
 public class MockConnector implements Connector {
@@ -27,7 +27,7 @@ public class MockConnector implements Connector {
 
     public void shutdown() {
         // Emit error mocking closed connection scenario
-        if (!mockQueue.offer(new QueuePayload(QueuePayloadType.ERROR, "shutdown invoked", Collections.emptyMap()))) {
+        if (!mockQueue.offer(new QueuePayload(QueuePayloadType.ERROR, "shutdown invoked", GetMetadataResponse.getDefaultInstance()))) {
             log.warn("Failed to offer shutdown status");
         }
     }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileConnectorTest.java
@@ -1,7 +1,7 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.file;
 
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayload;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayloadType;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -31,16 +31,16 @@ class FileConnectorTest {
         connector.init();
 
         // then
-        final BlockingQueue<StreamPayload> stream = connector.getStream();
-        final StreamPayload[] payload = new StreamPayload[1];
+        final BlockingQueue<QueuePayload> stream = connector.getStream();
+        final QueuePayload[] payload = new QueuePayload[1];
 
         assertNotNull(stream);
         assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
             payload[0] = stream.take();
         });
 
-        assertNotNull(payload[0].getData());
-        assertEquals(StreamPayloadType.DATA, payload[0].getType());
+        assertNotNull(payload[0].getFlagData());
+        assertEquals(QueuePayloadType.DATA, payload[0].getType());
     }
 
     @Test
@@ -52,16 +52,16 @@ class FileConnectorTest {
         connector.init();
 
         // then
-        final BlockingQueue<StreamPayload> stream = connector.getStream();
+        final BlockingQueue<QueuePayload> stream = connector.getStream();
 
         // Must emit an error within considerable time
-        final StreamPayload[] payload = new StreamPayload[1];
+        final QueuePayload[] payload = new QueuePayload[1];
         assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
             payload[0] = stream.take();
         });
 
-        assertNotNull(payload[0].getData());
-        assertEquals(StreamPayloadType.ERROR, payload[0].getType());
+        assertNotNull(payload[0].getFlagData());
+        assertEquals(QueuePayloadType.ERROR, payload[0].getType());
     }
 
     @Test
@@ -80,15 +80,15 @@ class FileConnectorTest {
         connector.init();
 
         // then
-        final BlockingQueue<StreamPayload> stream = connector.getStream();
-        final StreamPayload[] payload = new StreamPayload[1];
+        final BlockingQueue<QueuePayload> stream = connector.getStream();
+        final QueuePayload[] payload = new QueuePayload[1];
 
         // first validate the initial payload
         assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
             payload[0] = stream.take();
         });
 
-        assertEquals(initial, payload[0].getData());
+        assertEquals(initial, payload[0].getFlagData());
 
         // then update the flags
         Files.write(updPath, updatedFlags.getBytes(), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -98,7 +98,7 @@ class FileConnectorTest {
             payload[0] = stream.take();
         });
 
-        assertEquals(updatedFlags, payload[0].getData());
+        assertEquals(updatedFlags, payload[0].getFlagData());
     }
 
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnectorTest.java
@@ -49,7 +49,6 @@ class GrpcStreamConnectorTest {
         final FlagSyncServiceBlockingStub blockingStubMock = mockBlockingStubAndReturn(connector);
         final SyncFlagsRequest[] request = new SyncFlagsRequest[1];
 
-        when(stubMock.withDeadlineAfter(anyLong(), any())).thenReturn(stubMock);
         doAnswer(invocation -> {
             request[0] = invocation.getArgument(0, SyncFlagsRequest.class);
             return null;
@@ -58,7 +57,6 @@ class GrpcStreamConnectorTest {
         // when
         connector.init();
         verify(stubMock, timeout(MAX_WAIT_MS.toMillis()).times(1)).syncFlags(any(), any());
-        verify(stubMock).withDeadlineAfter(1337, TimeUnit.MILLISECONDS);
         verify(blockingStubMock).withDeadlineAfter(1337, TimeUnit.MILLISECONDS);
 
         // then
@@ -87,7 +85,6 @@ class GrpcStreamConnectorTest {
 
         final GrpcStreamHandler[] injectedHandler = new GrpcStreamHandler[1];
 
-        when(stubMock.withDeadlineAfter(anyLong(), any())).thenReturn(stubMock);
         doAnswer(invocation -> {
             injectedHandler[0] = invocation.getArgument(1, GrpcStreamHandler.class);
             return null;

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnectorTest.java
@@ -1,12 +1,15 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.grpc;
 
+import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -16,10 +19,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.google.protobuf.Struct;
+
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayload;
-import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.StreamPayloadType;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
+import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
+import dev.openfeature.flagd.grpc.sync.FlagSyncServiceGrpc.FlagSyncServiceBlockingStub;
 import dev.openfeature.flagd.grpc.sync.FlagSyncServiceGrpc.FlagSyncServiceStub;
+import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import dev.openfeature.flagd.grpc.sync.Sync.SyncFlagsRequest;
 import dev.openfeature.flagd.grpc.sync.Sync.SyncFlagsResponse;
 
@@ -57,8 +64,19 @@ class GrpcStreamConnectorTest {
     @Test
     public void grpcConnectionStatus() throws Throwable {
         // given
+        final String key = "key1";
+        final String val = "value1";
         final GrpcStreamConnector connector = new GrpcStreamConnector(FlagdOptions.builder().build());
         final FlagSyncServiceStub stubMock = mockStubAndReturn(connector);
+        final FlagSyncServiceBlockingStub blockingStubMock = mockBlockingStubAndReturn(connector);
+
+final Struct metadata = Struct.newBuilder()
+            .putFields(key,
+                    com.google.protobuf.Value.newBuilder().setStringValue(val).build())
+            .build();
+
+
+        when(blockingStubMock.getMetadata(any())).thenReturn(GetMetadataResponse.newBuilder().setMetadata(metadata).build());
 
         final GrpcStreamHandler[] injectedHandler = new GrpcStreamHandler[1];
 
@@ -71,12 +89,13 @@ class GrpcStreamConnectorTest {
         connector.init();
         // verify and wait for initialization
         verify(stubMock, Mockito.timeout(MAX_WAIT_MS.toMillis()).times(1)).syncFlags(any(), any());
+        verify(blockingStubMock).getMetadata(any());
 
         // then
         final GrpcStreamHandler grpcStreamHandler = injectedHandler[0];
         assertNotNull(grpcStreamHandler);
 
-        final BlockingQueue<StreamPayload> streamPayloads = connector.getStream();
+        final BlockingQueue<QueuePayload> streamPayloads = connector.getStream();
 
         // accepted data
         grpcStreamHandler.onNext(
@@ -84,8 +103,9 @@ class GrpcStreamConnectorTest {
                         .build());
 
         assertTimeoutPreemptively(MAX_WAIT_MS, () -> {
-            StreamPayload payload = streamPayloads.take();
-            assertEquals(StreamPayloadType.DATA, payload.getType());
+            QueuePayload payload = streamPayloads.take();
+            assertEquals(QueuePayloadType.DATA, payload.getType());
+            assertTrue(() -> payload.getSyncMetadata().get(key).equals(val));
         });
 
         // ping must be ignored
@@ -99,8 +119,8 @@ class GrpcStreamConnectorTest {
                         .build());
 
         assertTimeoutPreemptively(MAX_WAIT_MS, () -> {
-            StreamPayload payload = streamPayloads.take();
-            assertEquals(StreamPayloadType.DATA, payload.getType());
+            QueuePayload payload = streamPayloads.take();
+            assertEquals(QueuePayloadType.DATA, payload.getType());
         });
     }
 
@@ -109,6 +129,7 @@ class GrpcStreamConnectorTest {
         // given
         final GrpcStreamConnector connector = new GrpcStreamConnector(FlagdOptions.builder().build());
         final FlagSyncServiceStub stubMock = mockStubAndReturn(connector);
+        final FlagSyncServiceBlockingStub blockingStubMock = mockBlockingStubAndReturn(connector);
 
         final GrpcStreamHandler[] injectedHandler = new GrpcStreamHandler[1];
 
@@ -121,6 +142,7 @@ class GrpcStreamConnectorTest {
         connector.init();
         // verify and wait for initialization
         verify(stubMock, Mockito.timeout(MAX_WAIT_MS.toMillis()).times(1)).syncFlags(any(), any());
+        verify(blockingStubMock).getMetadata(any());
 
         // then
         final GrpcStreamHandler grpcStreamHandler = injectedHandler[0];
@@ -132,8 +154,8 @@ class GrpcStreamConnectorTest {
         grpcStreamHandler.onError(new Exception("Channel closed, exiting"));
 
         assertTimeoutPreemptively(MAX_WAIT_MS, () -> {
-            StreamPayload payload = connector.getStream().take();
-            assertEquals(StreamPayloadType.ERROR, payload.getType());
+            QueuePayload payload = connector.getStream().take();
+            assertEquals(QueuePayloadType.ERROR, payload.getType());
         });
 
         // Validate mock calls & no more event propagation
@@ -159,6 +181,18 @@ class GrpcStreamConnectorTest {
         serviceStubField.set(connector, stubMock);
 
         return stubMock;
+    }
+
+    private static FlagSyncServiceBlockingStub mockBlockingStubAndReturn(final GrpcStreamConnector connector)
+        throws Throwable {
+    final Field blockingStubField = GrpcStreamConnector.class.getDeclaredField("serviceBlockingStub");
+    blockingStubField.setAccessible(true);
+
+    final FlagSyncServiceBlockingStub blockingStubMock = Mockito.mock(FlagSyncServiceBlockingStub.class);
+
+    blockingStubField.set(connector, blockingStubMock);
+
+    return blockingStubMock;
     }
 
 }


### PR DESCRIPTION
This PR: 

- adds call to [GetMetadata](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata) on gRPC connection init with the in-process provider
  - this returns metadata from flagd which can be used to enrich local (in-process) evaluation
  - the metadata is exposed on the provider in the protected `getSyncMetadata` accessor, and updated when the stream is (re)established, from here it can be used in provider hooks, events, etc
- associated tests and refactors

Please note the call logic may look a bit strange, but I think it's optimal. We call the `getMetadata` RPC as soon as we initiate the stream, and ignore exceptions. This is because it's very unlikely that the metadata RPC will fail while the stream succeeds, and every attempt to reconnect the stream will also retry the metadata - so we should be good with this pattern. If for some reason the metadata call fails but we connect without an issue, we log it.