### PR TITLE
fix: make flagd config EvaluatorType public

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -94,8 +94,10 @@ public final class Config {
         }
     }
 
-    // intermediate interface to unify deprecated Evaluator & new Resolver
-    interface EvaluatorType {
+    /**
+     * intermediate interface to unify deprecated Evaluator and new Resolver.
+     **/
+    public interface EvaluatorType {
         String asString();
     }
 


### PR DESCRIPTION
## Make flagd config EvaluatorType public
This PR makes the EvaluatorType interface public, so that the implementing enums can then be used in Kotlin.

### Related Issues
Fixes #1013 

### Notes
This bug in Kotlin prevents the usage of that enums in a Kotlin project: https://youtrack.jetbrains.com/issue/KT-11700

### How to test

Code like the following should not lead to a runtime error:
```
    fun getFlagdProvider(): FlagdProvider = FlagdProvider(
        FlagdOptions.builder()
            .resolverType(Config.Resolver.IN_PROCESS)
            .build()
    )
```

