### PR TITLE
fix: remove pinned protobuf version

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -32,13 +32,6 @@
     </developers>
 
     <dependencies>
-        <!-- temporary to fix CVE-2024-7254 (see: https://github.com/advisories/GHSA-735f-pc8j-v9w8) - remove once this is in gRPC-java -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-        </dependency>
-
         <!-- we inherent dev.openfeature.javasdk and the test dependencies from the parent pom -->
         <dependency>
             <groupId>io.grpc</groupId>


### PR DESCRIPTION
GRPC Java released a new version: https://github.com/grpc/grpc-java/releases/tag/v1.68.1, which fixes the dependency issue. Hence that we don't need the pinned dependency anymore

closes: #1031
