### PR TITLE
chore: pin protobuf-java

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -33,6 +33,15 @@
 
     <dependencies>
         <!-- we inherent dev.openfeature.javasdk and the test dependencies from the parent pom -->
+        
+        <!-- pin protobuf-java to version used by io.grpc deps; update to 4.0 when io.grpc requires it -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <!-- 4.0.0-rc < 4.0.0, unfortunately -->
+            <version>[3.25.5,3.999999)</version>
+        </dependency>
+
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>


### PR DESCRIPTION
Our grpc deps are not compatible with protobuf-java 4.0+