### PR TITLE
feat: added interception of parameterized tests to Junit OpenFeature Extension

### DIFF
--- a/tools/junit-openfeature/README.md
+++ b/tools/junit-openfeature/README.md
@@ -16,7 +16,8 @@ A JUnit5 extension to reduce boilerplate code for testing code which utilizes Op
 
 ## Getting Started
 
-We are supporting two different flavors for testing, a [simple](#simple-configuration) and an [extended](#extended-configuration) configuration.
+- We are supporting two different flavors for testing, a [simple](#simple-configuration) and an [extended](#extended-configuration) configuration.
+- Both the [`@Test`](https://junit.org/junit5/docs/5.9.0/api/org.junit.jupiter.api/org/junit/jupiter/api/Test.html) annotation and the [`@ParameterizedTest`](https://junit.org/junit5/docs/5.9.0/api/org.junit.jupiter.params/org/junit/jupiter/params/ParameterizedTest.html) annotation are supported.
       
 Notice: We are most likely not multithread compatible!
 ### Simple Configuration

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeatureExtension.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeatureExtension.java
@@ -3,7 +3,11 @@ package dev.openfeature.contrib.tools.junitopenfeature;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.providers.memory.Flag;
 import org.apache.commons.lang3.BooleanUtils;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 
 import java.lang.reflect.Method;

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlagTest.java
@@ -4,6 +4,8 @@ import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +47,14 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
         }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = "true")
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
     }
 
     @Nested
@@ -80,6 +90,14 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
             assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = "true")
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
     }
 
@@ -123,6 +141,16 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
             assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature({
+                @Flag(name = FLAG, value = "true")
+        })
+        void existingFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
 
         @Nested

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlagTest.java
@@ -4,6 +4,8 @@ import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,6 +54,14 @@ class DoubleFlagTest {
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
         }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
     }
 
     @Nested
@@ -87,6 +97,14 @@ class DoubleFlagTest {
                 assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
     }
 
@@ -130,6 +148,16 @@ class DoubleFlagTest {
             assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature({
+                @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
+        })
+        void existingFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Nested

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlagTest.java
@@ -4,6 +4,8 @@ import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,6 +54,14 @@ class IntegerFlagTest {
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
         }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
     }
 
     @Nested
@@ -87,6 +97,14 @@ class IntegerFlagTest {
                 assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
     }
 
@@ -130,6 +148,16 @@ class IntegerFlagTest {
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature({
+                @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
+        })
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Nested

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlagTest.java
@@ -4,6 +4,8 @@ import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +52,14 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
     }
 
     @Nested
@@ -85,6 +95,14 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
     }
 
@@ -128,6 +146,16 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature({
+                @Flag(name = FLAG , value = FLAG_VALUE, valueType = String.class)
+        })
+        void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Nested


### PR DESCRIPTION

## This PR
If the JUnit Open Feature Extension is used, a developer needs to use the `@Flag` annotation on test methods annotated with  `@Test` and `@ParameterizedTest`. This PR adds support for parameterized tests.

### Related Issues
Fixes #1091 

