### PR TITLE
feat!: Use grpc intern reconnections for  rpc event stream

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -15,6 +15,7 @@ public final class Config {
 
     static final int DEFAULT_DEADLINE = 500;
     static final int DEFAULT_STREAM_DEADLINE_MS = 10 * 60 * 1000;
+    static final int DEFAULT_STREAM_RETRY_GRACE_PERIOD = 5;
     static final int DEFAULT_MAX_CACHE_SIZE = 1000;
     static final long DEFAULT_KEEP_ALIVE = 0;
 
@@ -35,6 +36,7 @@ public final class Config {
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME_OLD = "FLAGD_KEEP_ALIVE_TIME";
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE_TIME_MS";
     static final String TARGET_URI_ENV_VAR_NAME = "FLAGD_TARGET_URI";
+    static final String STREAM_RETRY_GRACE_PERIOD = "FLAGD_RETRY_GRACE_PERIOD";
 
     static final String RESOLVER_RPC = "rpc";
     static final String RESOLVER_IN_PROCESS = "in-process";
@@ -52,7 +54,6 @@ public final class Config {
     public static final String LRU_CACHE = CacheType.LRU.getValue();
     static final String DEFAULT_CACHE = LRU_CACHE;
 
-    static final int DEFAULT_MAX_EVENT_STREAM_RETRIES = 5;
     static final int BASE_EVENT_STREAM_RETRY_BACKOFF_MS = 1000;
 
     static String fallBackToEnvOrDefault(String key, String defaultValue) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -13,82 +13,111 @@ import java.util.function.Function;
 import lombok.Builder;
 import lombok.Getter;
 
-/** FlagdOptions is a builder to build flagd provider options. */
+/**
+ * FlagdOptions is a builder to build flagd provider options.
+ */
 @Builder
 @Getter
 @SuppressWarnings("PMD.TooManyStaticImports")
 public class FlagdOptions {
 
-    /** flagd resolving type. */
+    /**
+     * flagd resolving type.
+     */
     private Config.EvaluatorType resolverType;
 
-    /** flagd connection host. */
+    /**
+     * flagd connection host.
+     */
     @Builder.Default
     private String host = fallBackToEnvOrDefault(Config.HOST_ENV_VAR_NAME, Config.DEFAULT_HOST);
 
-    /** flagd connection port. */
+    /**
+     * flagd connection port.
+     */
     private int port;
 
-    /** Use TLS connectivity. */
+    /**
+     * Use TLS connectivity.
+     */
     @Builder.Default
     private boolean tls = Boolean.parseBoolean(fallBackToEnvOrDefault(Config.TLS_ENV_VAR_NAME, Config.DEFAULT_TLS));
 
-    /** TLS certificate overriding if TLS connectivity is used. */
+    /**
+     * TLS certificate overriding if TLS connectivity is used.
+     */
     @Builder.Default
     private String certPath = fallBackToEnvOrDefault(Config.SERVER_CERT_PATH_ENV_VAR_NAME, null);
 
-    /** Unix socket path to flagd. */
+    /**
+     * Unix socket path to flagd.
+     */
     @Builder.Default
     private String socketPath = fallBackToEnvOrDefault(Config.SOCKET_PATH_ENV_VAR_NAME, null);
 
-    /** Cache type to use. Supports - lru, disabled. */
+    /**
+     * Cache type to use. Supports - lru, disabled.
+     */
     @Builder.Default
     private String cacheType = fallBackToEnvOrDefault(Config.CACHE_ENV_VAR_NAME, Config.DEFAULT_CACHE);
 
-    /** Max cache size. */
+    /**
+     * Max cache size.
+     */
     @Builder.Default
     private int maxCacheSize =
             fallBackToEnvOrDefault(Config.MAX_CACHE_SIZE_ENV_VAR_NAME, Config.DEFAULT_MAX_CACHE_SIZE);
 
-    /** Max event stream connection retries. */
-    @Builder.Default
-    private int maxEventStreamRetries = fallBackToEnvOrDefault(
-            Config.MAX_EVENT_STREAM_RETRIES_ENV_VAR_NAME, Config.DEFAULT_MAX_EVENT_STREAM_RETRIES);
-
-    /** Backoff interval in milliseconds. */
+    /**
+     * Backoff interval in milliseconds.
+     */
     @Builder.Default
     private int retryBackoffMs = fallBackToEnvOrDefault(
             Config.BASE_EVENT_STREAM_RETRY_BACKOFF_MS_ENV_VAR_NAME, Config.BASE_EVENT_STREAM_RETRY_BACKOFF_MS);
 
     /**
-     * Connection deadline in milliseconds. For RPC resolving, this is the deadline to connect to
-     * flagd for flag evaluation. For in-process resolving, this is the deadline for sync stream
-     * termination.
+     * Connection deadline in milliseconds.
+     * For RPC resolving, this is the deadline to connect to flagd for flag
+     * evaluation.
+     * For in-process resolving, this is the deadline for sync stream termination.
      */
     @Builder.Default
     private int deadline = fallBackToEnvOrDefault(Config.DEADLINE_MS_ENV_VAR_NAME, Config.DEFAULT_DEADLINE);
 
     /**
-     * Streaming connection deadline in milliseconds. Set to 0 to disable the deadline. Defaults to
-     * 600000 (10 minutes); recommended to prevent infrastructure from killing idle connections.
+     * Streaming connection deadline in milliseconds.
+     * Set to 0 to disable the deadline.
+     * Defaults to 600000 (10 minutes); recommended to prevent infrastructure from killing idle connections.
      */
     @Builder.Default
     private int streamDeadlineMs =
             fallBackToEnvOrDefault(Config.STREAM_DEADLINE_MS_ENV_VAR_NAME, Config.DEFAULT_STREAM_DEADLINE_MS);
 
-    /** Selector to be used with flag sync gRPC contract. */
+    /**
+     * Grace time period in seconds before provider moves from STALE to ERROR.
+     * Defaults to 5
+     */
+    @Builder.Default
+    private int streamRetryGracePeriod =
+            fallBackToEnvOrDefault(Config.STREAM_RETRY_GRACE_PERIOD, Config.DEFAULT_STREAM_RETRY_GRACE_PERIOD);
+    /**
+     * Selector to be used with flag sync gRPC contract.
+     **/
     @Builder.Default
     private String selector = fallBackToEnvOrDefault(Config.SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
-    /** gRPC client KeepAlive in milliseconds. Disabled with 0. Defaults to 0 (disabled). */
+    /**
+     * gRPC client KeepAlive in milliseconds. Disabled with 0.
+     * Defaults to 0 (disabled).
+     **/
     @Builder.Default
     private long keepAlive = fallBackToEnvOrDefault(
             Config.KEEP_ALIVE_MS_ENV_VAR_NAME,
             fallBackToEnvOrDefault(Config.KEEP_ALIVE_MS_ENV_VAR_NAME_OLD, Config.DEFAULT_KEEP_ALIVE));
 
     /**
-     * File source of flags to be used by offline mode. Setting this enables the offline mode of the
-     * in-process provider.
+     * File source of flags to be used by offline mode.
+     * Setting this enables the offline mode of the in-process provider.
      */
     @Builder.Default
     private String offlineFlagSourcePath = fallBackToEnvOrDefault(Config.OFFLINE_SOURCE_PATH, null);
@@ -96,31 +125,35 @@ public class FlagdOptions {
     /**
      * gRPC custom target string.
      *
-     * <p>Setting this will allow user to use custom gRPC name resolver at present we are supporting
-     * all core resolver along with a custom resolver for envoy proxy resolution. For more visit
-     * (https://grpc.io/docs/guides/custom-name-resolution/)
+     * <p>Setting this will allow user to use custom gRPC name resolver at present
+     * we are supporting all core resolver along with a custom resolver for envoy proxy
+     * resolution. For more visit (https://grpc.io/docs/guides/custom-name-resolution/)
      */
     @Builder.Default
     private String targetUri = fallBackToEnvOrDefault(Config.TARGET_URI_ENV_VAR_NAME, null);
 
     /**
-     * Function providing an EvaluationContext to mix into every evaluations. The sync-metadata
-     * response
+     * Function providing an EvaluationContext to mix into every evaluations.
+     * The sync-metadata response
      * (https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.GetMetadataResponse),
-     * represented as a {@link dev.openfeature.sdk.Structure}, is passed as an argument. This function
-     * runs every time the provider (re)connects, and its result is cached and used in every
-     * evaluation. By default, the entire sync response (converted to a Structure) is used.
+     * represented as a {@link dev.openfeature.sdk.Structure}, is passed as an
+     * argument.
+     * This function runs every time the provider (re)connects, and its result is cached and used in every evaluation.
+     * By default, the entire sync response (converted to a Structure) is used.
      */
     @Builder.Default
     private Function<Structure, EvaluationContext> contextEnricher =
             (syncMetadata) -> new ImmutableContext(syncMetadata.asMap());
 
-    /** Inject a Custom Connector for fetching flags. */
+    /**
+     * Inject a Custom Connector for fetching flags.
+     */
     private Connector customConnector;
 
     /**
-     * Inject OpenTelemetry for the library runtime. Providing sdk will initiate distributed tracing
-     * for flagd grpc connectivity.
+     * Inject OpenTelemetry for the library runtime. Providing sdk will initiate
+     * distributed tracing for flagd grpc
+     * connectivity.
      */
     private OpenTelemetry openTelemetry;
 
@@ -139,11 +172,14 @@ public class FlagdOptions {
         };
     }
 
-    /** Overload default lombok builder. */
+    /**
+     * Overload default lombok builder.
+     */
     public static class FlagdOptionsBuilder {
         /**
-         * Enable OpenTelemetry instance extraction from GlobalOpenTelemetry. Note that, this is only
-         * useful if global configurations are registered.
+         * Enable OpenTelemetry instance extraction from GlobalOpenTelemetry. Note that,
+         * this is only useful if global
+         * configurations are registered.
          */
         public FlagdOptionsBuilder withGlobalTelemetry(final boolean b) {
             if (b) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -98,7 +98,7 @@ public class FlagdOptions {
      * Defaults to 5
      */
     @Builder.Default
-    private int streamRetryGracePeriod =
+    private int retryGracePeriod =
             fallBackToEnvOrDefault(Config.STREAM_RETRY_GRACE_PERIOD, Config.DEFAULT_STREAM_RETRY_GRACE_PERIOD);
     /**
      * Selector to be used with flag sync gRPC contract.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelMonitor.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelMonitor.java
@@ -1,0 +1,98 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+import dev.openfeature.sdk.exceptions.GeneralError;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A utility class to monitor and manage the connectivity state of a gRPC ManagedChannel.
+ */
+@Slf4j
+public class ChannelMonitor {
+
+    private ChannelMonitor() {}
+
+    /**
+     * Monitors the state of a gRPC channel and triggers the specified callbacks based on state changes.
+     *
+     * @param expectedState     the initial state to monitor.
+     * @param channel           the ManagedChannel to monitor.
+     * @param onConnectionReady callback invoked when the channel transitions to a READY state.
+     * @param onConnectionLost  callback invoked when the channel transitions to a FAILURE or SHUTDOWN state.
+     */
+    public static void monitorChannelState(
+            ConnectivityState expectedState,
+            ManagedChannel channel,
+            Runnable onConnectionReady,
+            Runnable onConnectionLost) {
+        channel.notifyWhenStateChanged(expectedState, () -> {
+            ConnectivityState currentState = channel.getState(true);
+            log.info("Channel state changed to: {}", currentState);
+            if (currentState == ConnectivityState.READY) {
+                onConnectionReady.run();
+            } else if (currentState == ConnectivityState.TRANSIENT_FAILURE
+                    || currentState == ConnectivityState.SHUTDOWN) {
+                onConnectionLost.run();
+            }
+            // Re-register the state monitor to watch for the next state transition.
+            monitorChannelState(currentState, channel, onConnectionReady, onConnectionLost);
+        });
+    }
+
+    /**
+     * Waits for the channel to reach a desired state within a specified timeout period.
+     *
+     * @param channel         the ManagedChannel to monitor.
+     * @param desiredState    the ConnectivityState to wait for.
+     * @param connectCallback callback invoked when the desired state is reached.
+     * @param timeout         the maximum amount of time to wait.
+     * @param unit            the time unit of the timeout.
+     * @throws InterruptedException if the current thread is interrupted while waiting.
+     */
+    public static void waitForDesiredState(
+            ManagedChannel channel,
+            ConnectivityState desiredState,
+            Runnable connectCallback,
+            long timeout,
+            TimeUnit unit)
+            throws InterruptedException {
+        waitForDesiredState(channel, desiredState, connectCallback, new CountDownLatch(1), timeout, unit);
+    }
+
+    private static void waitForDesiredState(
+            ManagedChannel channel,
+            ConnectivityState desiredState,
+            Runnable connectCallback,
+            CountDownLatch latch,
+            long timeout,
+            TimeUnit unit)
+            throws InterruptedException {
+        channel.notifyWhenStateChanged(ConnectivityState.SHUTDOWN, () -> {
+            try {
+                ConnectivityState state = channel.getState(true);
+                log.debug("Channel state changed to: {}", state);
+
+                if (state == desiredState) {
+                    connectCallback.run();
+                    latch.countDown();
+                    return;
+                }
+                waitForDesiredState(channel, desiredState, connectCallback, latch, timeout, unit);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Thread interrupted while waiting for desired state", e);
+            } catch (Exception e) {
+                log.error("Error occurred while waiting for desired state", e);
+            }
+        });
+
+        // Await the latch or timeout for the state change
+        if (!latch.await(timeout, unit)) {
+            throw new GeneralError(String.format(
+                    "Deadline exceeded. Condition did not complete within the %d " + "deadline", timeout));
+        }
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionEvent.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionEvent.java
@@ -4,65 +4,121 @@ import dev.openfeature.sdk.ImmutableStructure;
 import dev.openfeature.sdk.Structure;
 import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 /**
- * Event payload for a {@link dev.openfeature.contrib.providers.flagd.resolver.Resolver} connection
- * state change event.
+ * Represents an event payload for a connection state change in a
+ * {@link dev.openfeature.contrib.providers.flagd.resolver.Resolver}.
+ * The event includes information about the connection status, any flags that have changed,
+ * and metadata associated with the synchronization process.
  */
-@AllArgsConstructor
 public class ConnectionEvent {
-    @Getter
-    private final boolean connected;
 
+    /**
+     * The current state of the connection.
+     */
+    private final ConnectionState connected;
+
+    /**
+     * A list of flags that have changed due to this connection event.
+     */
     private final List<String> flagsChanged;
+
+    /**
+     * Metadata associated with synchronization in this connection event.
+     */
     private final Structure syncMetadata;
 
     /**
-     * Construct a new ConnectionEvent.
+     * Constructs a new {@code ConnectionEvent} with the connection status only.
      *
-     * @param connected status of the connection
+     * @param connected {@code true} if the connection is established, otherwise {@code false}.
      */
     public ConnectionEvent(boolean connected) {
+        this(
+                connected ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
+                Collections.emptyList(),
+                new ImmutableStructure());
+    }
+
+    /**
+     * Constructs a new {@code ConnectionEvent} with the specified connection state.
+     *
+     * @param connected the connection state indicating if the connection is established or not.
+     */
+    public ConnectionEvent(ConnectionState connected) {
         this(connected, Collections.emptyList(), new ImmutableStructure());
     }
 
     /**
-     * Construct a new ConnectionEvent.
+     * Constructs a new {@code ConnectionEvent} with the specified connection state and changed flags.
      *
-     * @param connected status of the connection
-     * @param flagsChanged list of flags changed
+     * @param connected    the connection state indicating if the connection is established or not.
+     * @param flagsChanged a list of flags that have changed due to this connection event.
      */
-    public ConnectionEvent(boolean connected, List<String> flagsChanged) {
+    public ConnectionEvent(ConnectionState connected, List<String> flagsChanged) {
         this(connected, flagsChanged, new ImmutableStructure());
     }
 
     /**
-     * Construct a new ConnectionEvent.
+     * Constructs a new {@code ConnectionEvent} with the specified connection state and synchronization metadata.
      *
-     * @param connected status of the connection
-     * @param syncMetadata sync.getMetadata
+     * @param connected    the connection state indicating if the connection is established or not.
+     * @param syncMetadata metadata related to the synchronization process of this event.
      */
-    public ConnectionEvent(boolean connected, Structure syncMetadata) {
+    public ConnectionEvent(ConnectionState connected, Structure syncMetadata) {
         this(connected, Collections.emptyList(), new ImmutableStructure(syncMetadata.asMap()));
     }
 
     /**
-     * Get changed flags.
+     * Constructs a new {@code ConnectionEvent} with the specified connection state, changed flags, and
+     * synchronization metadata.
      *
-     * @return an unmodifiable view of the changed flags
+     * @param connectionState the state of the connection.
+     * @param flagsChanged    a list of flags that have changed due to this connection event.
+     * @param syncMetadata    metadata related to the synchronization process of this event.
+     */
+    public ConnectionEvent(ConnectionState connectionState, List<String> flagsChanged, Structure syncMetadata) {
+        this.connected = connectionState;
+        this.flagsChanged = flagsChanged != null ? flagsChanged : Collections.emptyList(); // Ensure non-null list
+        this.syncMetadata = syncMetadata != null
+                ? new ImmutableStructure(syncMetadata.asMap())
+                : new ImmutableStructure(); // Ensure valid syncMetadata
+    }
+
+    /**
+     * Retrieves an unmodifiable view of the list of changed flags.
+     *
+     * @return an unmodifiable list of changed flags.
      */
     public List<String> getFlagsChanged() {
         return Collections.unmodifiableList(flagsChanged);
     }
 
     /**
-     * Get changed sync metadata represented as SDK structure type.
+     * Retrieves the synchronization metadata represented as an immutable SDK structure type.
      *
-     * @return an unmodifiable view of the sync metadata
+     * @return an immutable structure containing the synchronization metadata.
      */
     public Structure getSyncMetadata() {
         return new ImmutableStructure(syncMetadata.asMap());
+    }
+
+    /**
+     * Indicates whether the current connection state is connected.
+     *
+     * @return {@code true} if connected, otherwise {@code false}.
+     */
+    public boolean isConnected() {
+        return this.connected == ConnectionState.CONNECTED;
+    }
+
+    /**
+     * Indicates
+     * whether the current connection state is stale.
+     *
+     * @return {@code true} if stale, otherwise {@code false}.
+     */
+    public boolean isStale() {
+        return this.connected == ConnectionState.STALE;
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionState.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ConnectionState.java
@@ -1,0 +1,27 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+/**
+ * Represents the possible states of a connection.
+ */
+public enum ConnectionState {
+
+    /**
+     * The connection is active and functioning as expected.
+     */
+    CONNECTED,
+
+    /**
+     * The connection is not active and has been fully disconnected.
+     */
+    DISCONNECTED,
+
+    /**
+     * The connection is inactive or degraded but may still recover.
+     */
+    STALE,
+
+    /**
+     * The connection has encountered an error and cannot function correctly.
+     */
+    ERROR,
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/Util.java
@@ -2,18 +2,26 @@ package dev.openfeature.contrib.providers.flagd.resolver.common;
 
 import dev.openfeature.sdk.exceptions.GeneralError;
 import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
 
-/** Utils for flagd resolvers. */
+/**
+ * Utility class for managing gRPC connection states and handling synchronization operations.
+ */
+@Slf4j
 public class Util {
 
+    /**
+     * Private constructor to prevent instantiation of utility class.
+     */
     private Util() {}
 
     /**
-     * A helper to block the caller for given conditions.
+     * A helper method to block the caller until a condition is met or a timeout occurs.
      *
-     * @param deadline number of milliseconds to block
-     * @param connectedSupplier func to check for status true
-     * @throws InterruptedException if interrupted
+     * @param deadline          the maximum number of milliseconds to block
+     * @param connectedSupplier a function that evaluates to {@code true} when the desired condition is met
+     * @throws InterruptedException if the thread is interrupted during the waiting process
+     * @throws GeneralError         if the deadline is exceeded before the condition is met
      */
     public static void busyWaitAndCheck(final Long deadline, final Supplier<Boolean> connectedSupplier)
             throws InterruptedException {
@@ -22,7 +30,7 @@ public class Util {
         do {
             if (deadline <= System.currentTimeMillis() - start) {
                 throw new GeneralError(String.format(
-                        "Deadline exceeded. Condition did not complete within the %d deadline", deadline));
+                        "Deadline exceeded. Condition did not complete within the %d " + "deadline", deadline));
             }
 
             Thread.sleep(50L);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserver.java
@@ -10,38 +10,42 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
-/** EventStreamObserver handles events emitted by flagd. */
+/**
+ * Observer for a gRPC event stream that handles notifications about flag changes and provider readiness events.
+ * This class updates a cache and notifies listeners via a lambda callback when events occur.
+ */
 @Slf4j
 @SuppressFBWarnings(justification = "cache needs to be read and write by multiple objects")
 class EventStreamObserver implements StreamObserver<EventStreamResponse> {
+
+    /**
+     * A consumer to handle connection events with a flag indicating success and a list of changed flags.
+     */
     private final BiConsumer<Boolean, List<String>> onConnectionEvent;
-    private final Supplier<Boolean> shouldRetrySilently;
-    private final Object sync;
+
+    /**
+     * The cache to update based on received events.
+     */
     private final Cache cache;
 
     /**
-     * Create a gRPC stream that get notified about flag changes.
+     * Constructs a new {@code EventStreamObserver} instance.
      *
-     * @param sync synchronization object from caller
-     * @param cache cache to update
-     * @param onConnectionEvent lambda to call to handle the response
-     * @param shouldRetrySilently Boolean supplier indicating if the GRPC connector will try to
-     *     recover silently
+     * @param cache             the cache to update based on received events
+     * @param onConnectionEvent a consumer to handle connection events with a boolean and a list of changed flags
      */
-    EventStreamObserver(
-            Object sync,
-            Cache cache,
-            BiConsumer<Boolean, List<String>> onConnectionEvent,
-            Supplier<Boolean> shouldRetrySilently) {
-        this.sync = sync;
+    EventStreamObserver(Cache cache, BiConsumer<Boolean, List<String>> onConnectionEvent) {
         this.cache = cache;
         this.onConnectionEvent = onConnectionEvent;
-        this.shouldRetrySilently = shouldRetrySilently;
     }
 
+    /**
+     * Called when a new event is received from the stream.
+     *
+     * @param value the event stream response containing event data
+     */
     @Override
     public void onNext(EventStreamResponse value) {
         switch (value.getType()) {
@@ -52,37 +56,38 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
                 this.handleProviderReadyEvent();
                 break;
             default:
-                log.debug("unhandled event type {}", value.getType());
+                log.debug("Unhandled event type {}", value.getType());
         }
     }
 
+    /**
+     * Called when an error occurs in the stream.
+     *
+     * @param throwable the error that occurred
+     */
     @Override
     public void onError(Throwable throwable) {
-        if (Boolean.TRUE.equals(shouldRetrySilently.get())) {
-            log.debug("Event stream error, trying to recover", throwable);
-        } else {
-            log.error("Event stream error", throwable);
-            if (this.cache.getEnabled()) {
-                this.cache.clear();
-            }
-            this.onConnectionEvent.accept(false, Collections.emptyList());
+        if (this.cache.getEnabled().equals(Boolean.TRUE)) {
+            this.cache.clear();
         }
-
-        // handle last call of this stream
-        handleEndOfStream();
     }
 
+    /**
+     * Called when the stream is completed.
+     */
     @Override
     public void onCompleted() {
-        if (this.cache.getEnabled()) {
+        if (this.cache.getEnabled().equals(Boolean.TRUE)) {
             this.cache.clear();
         }
         this.onConnectionEvent.accept(false, Collections.emptyList());
-
-        // handle last call of this stream
-        handleEndOfStream();
     }
 
+    /**
+     * Handles configuration change events by updating the cache and notifying listeners about changed flags.
+     *
+     * @param value the event stream response containing configuration change data
+     */
     private void handleConfigurationChangeEvent(EventStreamResponse value) {
         List<String> changedFlags = new ArrayList<>();
         boolean cachingEnabled = this.cache.getEnabled();
@@ -95,7 +100,6 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
             }
         } else {
             Map<String, Value> flags = flagsValue.getStructValue().getFieldsMap();
-            this.cache.getEnabled();
             for (String flagKey : flags.keySet()) {
                 changedFlags.add(flagKey);
                 if (cachingEnabled) {
@@ -107,16 +111,12 @@ class EventStreamObserver implements StreamObserver<EventStreamResponse> {
         this.onConnectionEvent.accept(true, changedFlags);
     }
 
+    /**
+     * Handles provider readiness events by clearing the cache (if enabled) and notifying listeners of readiness.
+     */
     private void handleProviderReadyEvent() {
-        this.onConnectionEvent.accept(true, Collections.emptyList());
-        if (this.cache.getEnabled()) {
+        if (this.cache.getEnabled().equals(Boolean.TRUE)) {
             this.cache.clear();
-        }
-    }
-
-    private void handleEndOfStream() {
-        synchronized (this.sync) {
-            this.sync.notifyAll();
         }
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -1,169 +1,246 @@
 package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
-import static dev.openfeature.contrib.providers.flagd.resolver.common.backoff.BackoffStrategies.maxRetriesWithExponentialTimeBackoffStrategy;
-
+import com.google.common.annotations.VisibleForTesting;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelMonitor;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
-import dev.openfeature.contrib.providers.flagd.resolver.common.Util;
-import dev.openfeature.contrib.providers.flagd.resolver.common.backoff.GrpcStreamConnectorBackoffService;
-import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
-import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamRequest;
-import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
-import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionState;
+import dev.openfeature.sdk.ImmutableStructure;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
-import io.grpc.stub.StreamObserver;
+import io.grpc.stub.AbstractBlockingStub;
+import io.grpc.stub.AbstractStub;
 import java.util.Collections;
-import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.Function;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-/** Class that abstracts the gRPC communication with flagd. */
+/**
+ * A generic GRPC connector that manages connection states, reconnection logic, and event streaming for
+ * GRPC services.
+ *
+ * @param <T> the type of the asynchronous stub for the GRPC service
+ * @param <K> the type of the blocking stub for the GRPC service
+ */
 @Slf4j
-@SuppressFBWarnings(justification = "cache needs to be read and write by multiple objects")
-public class GrpcConnector {
-    private final Object sync = new Object();
-
-    private final ServiceGrpc.ServiceBlockingStub serviceBlockingStub;
-    private final ServiceGrpc.ServiceStub serviceStub;
-    private final ManagedChannel channel;
-
-    private final long deadline;
-    private final long streamDeadlineMs;
-
-    private final Cache cache;
-    private final Consumer<ConnectionEvent> onConnectionEvent;
-    private final Supplier<Boolean> connectedSupplier;
-    private final GrpcStreamConnectorBackoffService backoff;
-
-    // Thread responsible for event observation
-    private Thread eventObserverThread;
+public class GrpcConnector<T extends AbstractStub<T>, K extends AbstractBlockingStub<K>> {
 
     /**
-     * GrpcConnector creates an abstraction over gRPC communication.
+     * The asynchronous service stub for making non-blocking GRPC calls.
+     */
+    private final T serviceStub;
+
+    /**
+     * The blocking service stub for making blocking GRPC calls.
+     */
+    private final K blockingStub;
+
+    /**
+     * The GRPC managed channel for managing the underlying GRPC connection.
+     */
+    private final ManagedChannel channel;
+
+    /**
+     * The deadline in milliseconds for GRPC operations.
+     */
+    private final long deadline;
+
+    /**
+     * The deadline in milliseconds for event streaming operations.
+     */
+    private final long streamDeadlineMs;
+
+    /**
+     * A consumer that handles connection events such as connection loss or reconnection.
+     */
+    private final Consumer<ConnectionEvent> onConnectionEvent;
+
+    /**
+     * A consumer that handles GRPC service stubs for event stream handling.
+     */
+    private final Consumer<T> streamObserver;
+
+    /**
+     * An executor service responsible for scheduling reconnection attempts.
+     */
+    private final ScheduledExecutorService reconnectExecutor;
+
+    /**
+     * The grace period in milliseconds to wait for reconnection before emitting an error event.
+     */
+    private final long gracePeriod;
+
+    /**
+     * Indicates whether the connector is currently connected to the GRPC service.
+     */
+    @Getter
+    private boolean connected = false;
+
+    /**
+     * A scheduled task for managing reconnection attempts.
+     */
+    private ScheduledFuture<?> reconnectTask;
+
+    /**
+     * Constructs a new {@code GrpcConnector} instance with the specified options and parameters.
      *
-     * @param options flagd options
-     * @param cache cache to use
-     * @param connectedSupplier lambda providing current connection status from caller
-     * @param onConnectionEvent lambda which handles changes in the connection/stream
+     * @param options             the configuration options for the GRPC connection
+     * @param stub                a function to create the asynchronous service stub from a {@link ManagedChannel}
+     * @param blockingStub        a function to create the blocking service stub from a {@link ManagedChannel}
+     * @param onConnectionEvent   a consumer to handle connection events
+     * @param eventStreamObserver a consumer to handle the event stream
+     * @param channel             the managed channel for the GRPC connection
      */
     public GrpcConnector(
             final FlagdOptions options,
-            final Cache cache,
-            final Supplier<Boolean> connectedSupplier,
-            Consumer<ConnectionEvent> onConnectionEvent) {
-        this.channel = ChannelBuilder.nettyChannel(options);
-        this.serviceStub = ServiceGrpc.newStub(channel);
-        this.serviceBlockingStub = ServiceGrpc.newBlockingStub(channel);
+            final Function<ManagedChannel, T> stub,
+            final Function<ManagedChannel, K> blockingStub,
+            final Consumer<ConnectionEvent> onConnectionEvent,
+            final Consumer<T> eventStreamObserver,
+            ManagedChannel channel) {
+
+        this.channel = channel;
+        this.serviceStub = stub.apply(channel);
+        this.blockingStub = blockingStub.apply(channel);
         this.deadline = options.getDeadline();
         this.streamDeadlineMs = options.getStreamDeadlineMs();
-        this.cache = cache;
         this.onConnectionEvent = onConnectionEvent;
-        this.connectedSupplier = connectedSupplier;
-        this.backoff = new GrpcStreamConnectorBackoffService(maxRetriesWithExponentialTimeBackoffStrategy(
-                options.getMaxEventStreamRetries(), options.getRetryBackoffMs()));
+        this.streamObserver = eventStreamObserver;
+        this.gracePeriod = options.getStreamRetryGracePeriod();
+        this.reconnectExecutor = Executors.newSingleThreadScheduledExecutor();
     }
 
-    /** Initialize the gRPC stream. */
+    /**
+     * Constructs a {@code GrpcConnector} instance for testing purposes.
+     *
+     * @param options             the configuration options for the GRPC connection
+     * @param stub                a function to create the asynchronous service stub from a {@link ManagedChannel}
+     * @param blockingStub        a function to create the blocking service stub from a {@link ManagedChannel}
+     * @param onConnectionEvent   a consumer to handle connection events
+     * @param eventStreamObserver a consumer to handle the event stream
+     */
+    @VisibleForTesting
+    GrpcConnector(
+            final FlagdOptions options,
+            final Function<ManagedChannel, T> stub,
+            final Function<ManagedChannel, K> blockingStub,
+            final Consumer<ConnectionEvent> onConnectionEvent,
+            final Consumer<T> eventStreamObserver) {
+        this(options, stub, blockingStub, onConnectionEvent, eventStreamObserver, ChannelBuilder.nettyChannel(options));
+    }
+
+    /**
+     * Initializes the GRPC connection by waiting for the channel to be ready and monitoring its state.
+     *
+     * @throws Exception if the channel does not reach the desired state within the deadline
+     */
     public void initialize() throws Exception {
-        eventObserverThread = new Thread(this::observeEventStream);
-        eventObserverThread.setDaemon(true);
-        eventObserverThread.start();
-
-        // block till ready
-        Util.busyWaitAndCheck(this.deadline, this.connectedSupplier);
+        log.info("Initializing GRPC connection...");
+        ChannelMonitor.waitForDesiredState(
+                channel, ConnectivityState.READY, this::onInitialConnect, deadline, TimeUnit.MILLISECONDS);
+        ChannelMonitor.monitorChannelState(ConnectivityState.READY, channel, this::onReady, this::onConnectionLost);
     }
 
     /**
-     * Shuts down all gRPC resources.
+     * Returns the blocking service stub for making blocking GRPC calls.
      *
-     * @throws Exception is something goes wrong while terminating the communication.
+     * @return the blocking service stub
      */
-    public void shutdown() throws Exception {
-        // first shutdown the event listener
-        if (this.eventObserverThread != null) {
-            this.eventObserverThread.interrupt();
+    public K getResolver() {
+        return blockingStub;
+    }
+
+    /**
+     * Shuts down the GRPC connection and cleans up associated resources.
+     *
+     * @throws InterruptedException if interrupted while waiting for termination
+     */
+    public void shutdown() throws InterruptedException {
+        log.info("Shutting down GRPC connection...");
+        if (reconnectExecutor != null) {
+            reconnectExecutor.shutdownNow();
+            reconnectExecutor.awaitTermination(deadline, TimeUnit.MILLISECONDS);
         }
 
-        try {
-            if (this.channel != null && !this.channel.isShutdown()) {
-                this.channel.shutdown();
-                this.channel.awaitTermination(this.deadline, TimeUnit.MILLISECONDS);
-            }
-        } finally {
-            this.cache.clear();
-            if (this.channel != null && !this.channel.isShutdown()) {
-                this.channel.shutdownNow();
-                this.channel.awaitTermination(this.deadline, TimeUnit.MILLISECONDS);
-                log.warn(String.format("Unable to shut down channel by %d deadline", this.deadline));
-            }
+        if (!channel.isShutdown()) {
+            channel.shutdownNow();
+            channel.awaitTermination(deadline, TimeUnit.MILLISECONDS);
+        }
+
+        if (connected) {
             this.onConnectionEvent.accept(new ConnectionEvent(false));
+            connected = false;
+        }
+    }
+
+    private synchronized void onInitialConnect() {
+        connected = true;
+        restartStream();
+    }
+
+    /**
+     * Handles the event when the GRPC channel becomes ready, marking the connection as established.
+     * Cancels any pending reconnection task and restarts the event stream.
+     */
+    private synchronized void onReady() {
+        connected = true;
+
+        if (reconnectTask != null && !reconnectTask.isCancelled()) {
+            reconnectTask.cancel(false);
+            log.debug("Reconnection task cancelled as connection became READY.");
+        }
+        restartStream();
+        this.onConnectionEvent.accept(new ConnectionEvent(true));
+    }
+
+    /**
+     * Handles the event when the GRPC channel loses its connection, marking the connection as lost.
+     * Schedules a reconnection task after a grace period and emits a stale connection event.
+     */
+    private synchronized void onConnectionLost() {
+        log.debug("Connection lost. Emit STALE event...");
+        log.debug("Waiting {}s for connection to become available...", gracePeriod);
+        connected = false;
+
+        this.onConnectionEvent.accept(
+                new ConnectionEvent(ConnectionState.STALE, Collections.emptyList(), new ImmutableStructure()));
+
+        if (reconnectTask != null && !reconnectTask.isCancelled()) {
+            reconnectTask.cancel(false);
+        }
+
+        if (!reconnectExecutor.isShutdown()) {
+            reconnectTask = reconnectExecutor.schedule(
+                    () -> {
+                        log.debug(
+                                "Provider did not reconnect successfully within {}s. Emit ERROR event...", gracePeriod);
+                        this.onConnectionEvent.accept(new ConnectionEvent(false));
+                    },
+                    gracePeriod,
+                    TimeUnit.SECONDS);
         }
     }
 
     /**
-     * Provide the object that can be used to resolve Feature Flag values.
-     *
-     * @return a {@link ServiceGrpc.ServiceBlockingStub} for running FF resolution.
+     * Restarts the event stream using the asynchronous service stub, applying a deadline if configured.
+     * Emits a connection event if the restart is successful.
      */
-    public ServiceGrpc.ServiceBlockingStub getResolver() {
-        return serviceBlockingStub.withDeadlineAfter(this.deadline, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Event stream observer logic. This contains blocking mechanisms, hence must be run in a
-     * dedicated thread.
-     */
-    private void observeEventStream() {
-        while (backoff.shouldRetry()) {
-            final StreamObserver<EventStreamResponse> responseObserver =
-                    new EventStreamObserver(sync, this.cache, this::onConnectionEvent, backoff::shouldRetrySilently);
-
-            ServiceGrpc.ServiceStub localServiceStub = this.serviceStub;
-
-            if (this.streamDeadlineMs > 0) {
+    private synchronized void restartStream() {
+        if (connected) {
+            log.debug("(Re)initializing event stream.");
+            T localServiceStub = this.serviceStub;
+            if (streamDeadlineMs > 0) {
                 localServiceStub = localServiceStub.withDeadlineAfter(this.streamDeadlineMs, TimeUnit.MILLISECONDS);
             }
-
-            localServiceStub.eventStream(EventStreamRequest.getDefaultInstance(), responseObserver);
-
-            try {
-                synchronized (sync) {
-                    sync.wait();
-                }
-            } catch (InterruptedException e) {
-                // Interruptions are considered end calls for this observer, hence log and
-                // return
-                // Note - this is the most common interruption when shutdown, hence the log
-                // level debug
-                log.debug("interruption while waiting for condition", e);
-                Thread.currentThread().interrupt();
-            }
-
-            try {
-                backoff.waitUntilNextAttempt();
-            } catch (InterruptedException e) {
-                // Interruptions are considered end calls for this observer, hence log and
-                // return
-                log.warn("interrupted while restarting gRPC Event Stream");
-                Thread.currentThread().interrupt();
-            }
+            streamObserver.accept(localServiceStub);
+            return;
         }
-
-        log.error("failed to connect to event stream, exhausted retries");
-        this.onConnectionEvent(false, Collections.emptyList());
-    }
-
-    private void onConnectionEvent(final boolean connected, final List<String> changedFlags) {
-        // reset reconnection states
-        if (connected) {
-            backoff.reset();
-        }
-
-        // chain to initiator
-        this.onConnectionEvent.accept(new ConnectionEvent(connected, changedFlags));
+        log.debug("Stream restart skipped. Not connected.");
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnector.java
@@ -112,7 +112,7 @@ public class GrpcConnector<T extends AbstractStub<T>, K extends AbstractBlocking
         this.streamDeadlineMs = options.getStreamDeadlineMs();
         this.onConnectionEvent = onConnectionEvent;
         this.streamObserver = eventStreamObserver;
-        this.gracePeriod = options.getStreamRetryGracePeriod();
+        this.gracePeriod = options.getRetryGracePeriod();
         this.reconnectExecutor = Executors.newSingleThreadScheduledExecutor();
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -5,6 +5,7 @@ import static dev.openfeature.contrib.providers.flagd.resolver.process.model.Fea
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionState;
 import dev.openfeature.contrib.providers.flagd.resolver.common.Util;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.FlagStore;
@@ -28,8 +29,9 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Resolves flag values using https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1. Flags
- * are evaluated locally.
+ * Resolves flag values using
+ * https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1.
+ * Flags are evaluated locally.
  */
 @Slf4j
 public class InProcessResolver implements Resolver {
@@ -41,12 +43,15 @@ public class InProcessResolver implements Resolver {
     private final Supplier<Boolean> connectedSupplier;
 
     /**
-     * Resolves flag values using https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1. Flags
-     * are evaluated locally.
+     * Resolves flag values using
+     * https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1.
+     * Flags are evaluated locally.
      *
-     * @param options flagd options
-     * @param connectedSupplier lambda providing current connection status from caller
-     * @param onConnectionEvent lambda which handles changes in the connection/stream
+     * @param options           flagd options
+     * @param connectedSupplier lambda providing current connection status from
+     *                          caller
+     * @param onConnectionEvent lambda which handles changes in the
+     *                          connection/stream
      */
     public InProcessResolver(
             FlagdOptions options,
@@ -64,7 +69,9 @@ public class InProcessResolver implements Resolver {
                         .build();
     }
 
-    /** Initialize in-process resolver. */
+    /**
+     * Initialize in-process resolver.
+     */
     public void init() throws Exception {
         flagStore.init();
         final Thread stateWatcher = new Thread(() -> {
@@ -75,7 +82,7 @@ public class InProcessResolver implements Resolver {
                     switch (storageStateChange.getStorageState()) {
                         case OK:
                             onConnectionEvent.accept(new ConnectionEvent(
-                                    true,
+                                    ConnectionState.CONNECTED,
                                     storageStateChange.getChangedFlagsKeys(),
                                     storageStateChange.getSyncMetadata()));
                             break;
@@ -109,27 +116,37 @@ public class InProcessResolver implements Resolver {
         onConnectionEvent.accept(new ConnectionEvent(false));
     }
 
-    /** Resolve a boolean flag. */
+    /**
+     * Resolve a boolean flag.
+     */
     public ProviderEvaluation<Boolean> booleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
         return resolve(Boolean.class, key, ctx);
     }
 
-    /** Resolve a string flag. */
+    /**
+     * Resolve a string flag.
+     */
     public ProviderEvaluation<String> stringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
         return resolve(String.class, key, ctx);
     }
 
-    /** Resolve a double flag. */
+    /**
+     * Resolve a double flag.
+     */
     public ProviderEvaluation<Double> doubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
         return resolve(Double.class, key, ctx);
     }
 
-    /** Resolve an integer flag. */
+    /**
+     * Resolve an integer flag.
+     */
     public ProviderEvaluation<Integer> integerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
         return resolve(Integer.class, key, ctx);
     }
 
-    /** Resolve an object flag. */
+    /**
+     * Resolve an object flag.
+     */
     public ProviderEvaluation<Value> objectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
         final ProviderEvaluation<Object> evaluation = resolve(Object.class, key, ctx);
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -1,8 +1,22 @@
 package dev.openfeature.contrib.providers.flagd;
 
-import static dev.openfeature.contrib.providers.flagd.Config.*;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_CACHE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_HOST;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_IN_PROCESS_PORT;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_MAX_CACHE_SIZE;
+import static dev.openfeature.contrib.providers.flagd.Config.DEFAULT_RPC_PORT;
+import static dev.openfeature.contrib.providers.flagd.Config.KEEP_ALIVE_MS_ENV_VAR_NAME;
+import static dev.openfeature.contrib.providers.flagd.Config.KEEP_ALIVE_MS_ENV_VAR_NAME_OLD;
+import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_ENV_VAR;
+import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_IN_PROCESS;
+import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_RPC;
+import static dev.openfeature.contrib.providers.flagd.Config.Resolver;
+import static dev.openfeature.contrib.providers.flagd.Config.TARGET_URI_ENV_VAR_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.MockConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
@@ -26,7 +40,6 @@ class FlagdOptionsTest {
         assertNull(builder.getSocketPath());
         assertEquals(DEFAULT_CACHE, builder.getCacheType());
         assertEquals(DEFAULT_MAX_CACHE_SIZE, builder.getMaxCacheSize());
-        assertEquals(DEFAULT_MAX_EVENT_STREAM_RETRIES, builder.getMaxEventStreamRetries());
         assertNull(builder.getSelector());
         assertNull(builder.getOpenTelemetry());
         assertNull(builder.getCustomConnector());
@@ -47,7 +60,6 @@ class FlagdOptionsTest {
                 .certPath("etc/cert/ca.crt")
                 .cacheType("lru")
                 .maxCacheSize(100)
-                .maxEventStreamRetries(1)
                 .selector("app=weatherApp")
                 .offlineFlagSourcePath("some-path")
                 .openTelemetry(openTelemetry)
@@ -63,7 +75,6 @@ class FlagdOptionsTest {
         assertEquals("etc/cert/ca.crt", flagdOptions.getCertPath());
         assertEquals("lru", flagdOptions.getCacheType());
         assertEquals(100, flagdOptions.getMaxCacheSize());
-        assertEquals(1, flagdOptions.getMaxEventStreamRetries());
         assertEquals("app=weatherApp", flagdOptions.getSelector());
         assertEquals("some-path", flagdOptions.getOfflineFlagSourcePath());
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
@@ -31,6 +31,7 @@ public class FlagdRpcSetup {
                 .resolverType(Config.Resolver.RPC)
                 .port(flagdContainer.getFirstMappedPort())
                 .deadline(1000)
+                .streamRetryGracePeriod(1)
                 .streamDeadlineMs(0) // this makes reconnect tests more predictable
                 .cacheType(CacheType.DISABLED.getValue())
                 .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/reconnect/rpc/FlagdRpcSetup.java
@@ -31,7 +31,7 @@ public class FlagdRpcSetup {
                 .resolverType(Config.Resolver.RPC)
                 .port(flagdContainer.getFirstMappedPort())
                 .deadline(1000)
-                .streamRetryGracePeriod(1)
+                .retryGracePeriod(1)
                 .streamDeadlineMs(0) // this makes reconnect tests more predictable
                 .cacheType(CacheType.DISABLED.getValue())
                 .build());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/config/ConfigSteps.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/config/ConfigSteps.java
@@ -27,7 +27,6 @@ public class ConfigSteps {
     public static final List<String> IGNORED_FOR_NOW = new ArrayList<String>() {
         {
             add("offlinePollIntervalMs");
-            add("retryGraceAttempts");
             add("retryBackoffMaxMs");
         }
     };

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
@@ -1,0 +1,159 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.openfeature.contrib.providers.flagd.FlagdOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.ssl.SslContextBuilder;
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLKeyException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+class ChannelBuilderTest {
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void testNettyChannel_withSocketPath() {
+        try (MockedStatic<Epoll> epollMock = mockStatic(Epoll.class);
+                MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
+
+            // Mocks
+            epollMock.when(Epoll::isAvailable).thenReturn(true);
+            NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
+            ManagedChannel mockChannel = mock(ManagedChannel.class);
+
+            nettyMock
+                    .when(() -> NettyChannelBuilder.forAddress(any(DomainSocketAddress.class)))
+                    .thenReturn(mockBuilder);
+
+            when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
+            when(mockBuilder.eventLoopGroup(any(EpollEventLoopGroup.class))).thenReturn(mockBuilder);
+            when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
+            when(mockBuilder.usePlaintext()).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(mockChannel);
+
+            // Input options
+            FlagdOptions options = FlagdOptions.builder()
+                    .socketPath("/path/to/socket")
+                    .keepAlive(1000)
+                    .build();
+
+            // Call method under test
+            ManagedChannel channel = ChannelBuilder.nettyChannel(options);
+
+            // Assertions
+            assertThat(channel).isEqualTo(mockChannel);
+            nettyMock.verify(() -> NettyChannelBuilder.forAddress(new DomainSocketAddress("/path/to/socket")));
+            verify(mockBuilder).keepAliveTime(1000, TimeUnit.MILLISECONDS);
+            verify(mockBuilder).eventLoopGroup(any(EpollEventLoopGroup.class));
+            verify(mockBuilder).channelType(EpollDomainSocketChannel.class);
+            verify(mockBuilder).usePlaintext();
+            verify(mockBuilder).build();
+        }
+    }
+
+    @Test
+    void testNettyChannel_withTlsAndCert() {
+        try (MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
+            // Mocks
+            NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
+            ManagedChannel mockChannel = mock(ManagedChannel.class);
+            nettyMock
+                    .when(() -> NettyChannelBuilder.forTarget("localhost:8080"))
+                    .thenReturn(mockBuilder);
+
+            when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
+            when(mockBuilder.sslContext(any())).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(mockChannel);
+
+            File mockCert = mock(File.class);
+            when(mockCert.exists()).thenReturn(true);
+            String path = "test-harness/ssl/custom-root-cert.crt";
+
+            File file = new File(path);
+            String absolutePath = file.getAbsolutePath();
+            // Input options
+            FlagdOptions options = FlagdOptions.builder()
+                    .host("localhost")
+                    .port(8080)
+                    .keepAlive(5000)
+                    .tls(true)
+                    .certPath(absolutePath)
+                    .build();
+
+            // Call method under test
+            ManagedChannel channel = ChannelBuilder.nettyChannel(options);
+
+            // Assertions
+            assertThat(channel).isEqualTo(mockChannel);
+            nettyMock.verify(() -> NettyChannelBuilder.forTarget("localhost:8080"));
+            verify(mockBuilder).keepAliveTime(5000, TimeUnit.MILLISECONDS);
+            verify(mockBuilder).sslContext(any());
+            verify(mockBuilder).build();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/incorrect/{uri}/;)"})
+    void testNettyChannel_withInvalidTargetUri(String uri) {
+        FlagdOptions options = FlagdOptions.builder().targetUri(uri).build();
+
+        assertThatThrownBy(() -> ChannelBuilder.nettyChannel(options))
+                .isInstanceOf(GenericConfigException.class)
+                .hasMessageContaining("Error with gRPC target string configuration");
+    }
+
+    @Test
+    void testNettyChannel_epollNotAvailable() {
+        try (MockedStatic<Epoll> epollMock = mockStatic(Epoll.class)) {
+            epollMock.when(Epoll::isAvailable).thenReturn(false);
+
+            FlagdOptions options =
+                    FlagdOptions.builder().socketPath("/path/to/socket").build();
+
+            assertThatThrownBy(() -> ChannelBuilder.nettyChannel(options))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("unix socket cannot be used");
+        }
+    }
+
+    @Test
+    void testNettyChannel_sslException() throws Exception {
+        try (MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
+            NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
+            nettyMock.when(() -> NettyChannelBuilder.forTarget(anyString())).thenReturn(mockBuilder);
+            try (MockedStatic<GrpcSslContexts> sslmock = mockStatic(GrpcSslContexts.class)) {
+                SslContextBuilder sslMockBuilder = mock(SslContextBuilder.class);
+                sslmock.when(GrpcSslContexts::forClient).thenReturn(sslMockBuilder);
+                when(sslMockBuilder.build()).thenThrow(new SSLKeyException("Test SSL error"));
+                when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
+
+                FlagdOptions options = FlagdOptions.builder().tls(true).build();
+
+                assertThatThrownBy(() -> ChannelBuilder.nettyChannel(options))
+                        .isInstanceOf(SslConfigException.class)
+                        .hasMessageContaining("Error with SSL configuration");
+            }
+        }
+    }
+}

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
@@ -1,13 +1,11 @@
 package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,12 +14,9 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,19 +31,14 @@ class EventStreamObserverTest {
         EventStreamObserver stream;
         Runnable reconnect;
         Object sync;
-        Supplier<Boolean> shouldRetrySilently;
 
         @BeforeEach
         void setUp() {
             states = new ArrayList<>();
-            sync = new Object();
             cache = mock(Cache.class);
             reconnect = mock(Runnable.class);
             when(cache.getEnabled()).thenReturn(true);
-            shouldRetrySilently = mock(Supplier.class);
-            when(shouldRetrySilently.get())
-                    .thenReturn(true, false); // 1st time we should retry silently, subsequent calls should not
-            stream = new EventStreamObserver(sync, cache, (state, changed) -> states.add(state), shouldRetrySilently);
+            stream = new EventStreamObserver(cache, (state, changed) -> states.add(state));
         }
 
         @Test
@@ -64,47 +54,6 @@ class EventStreamObserverTest {
             assertTrue(states.get(0));
             // we flush the cache
             verify(cache, atLeast(1)).clear();
-        }
-
-        @Test
-        public void ready() {
-            EventStreamResponse resp = mock(EventStreamResponse.class);
-            when(resp.getType()).thenReturn("provider_ready");
-            stream.onNext(resp);
-            // we notify that we are ready
-            assertEquals(1, states.size());
-            assertTrue(states.get(0));
-            // cache was cleaned
-            verify(cache, atLeast(1)).clear();
-        }
-
-        @Test
-        public void noReconnectionOnFirstError() {
-            stream.onError(new Throwable("error"));
-            // we flush the cache
-            verify(cache, never()).clear();
-            // we notify the error
-            assertEquals(0, states.size());
-        }
-
-        @Test
-        public void reconnections() {
-            stream.onError(new Throwable("error 1"));
-            stream.onError(new Throwable("error 2"));
-            // we flush the cache
-            verify(cache, atLeast(1)).clear();
-            // we notify the error
-            assertEquals(1, states.size());
-            assertFalse(states.get(0));
-        }
-
-        @Test
-        public void deadlineExceeded() {
-            stream.onError(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
-            // we flush the cache
-            verify(cache, never()).clear();
-            // we notify the error
-            assertEquals(0, states.size());
         }
 
         @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/GrpcConnectorTest.java
@@ -1,497 +1,132 @@
 package dev.openfeature.contrib.providers.flagd.resolver.grpc;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.*;
-
+import com.google.common.collect.Lists;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ConnectionEvent;
-import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
-import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
+import dev.openfeature.flagd.grpc.evaluation.Evaluation;
 import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc;
-import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceBlockingStub;
-import dev.openfeature.flagd.grpc.evaluation.ServiceGrpc.ServiceStub;
-import io.grpc.Channel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.unix.DomainSocketAddress;
-import java.lang.reflect.Field;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
-import org.mockito.invocation.InvocationOnMock;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 class GrpcConnectorTest {
 
-    public static final String HOST = "server.com";
-    public static final int PORT = 4321;
-    public static final String SOCKET_PATH = "/some/other/path";
+    private ManagedChannel testChannel;
+    private Server testServer;
+    private static final boolean CONNECTED = true;
+    private static final boolean DISCONNECTED = false;
 
-    @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3})
-    void validate_retry_calls(int retries) throws Exception {
-        final int backoffMs = 100;
+    @Mock
+    private EventStreamObserver mockEventStreamObserver;
 
-        final FlagdOptions options = FlagdOptions.builder()
-                // shorter backoff for testing
-                .retryBackoffMs(backoffMs)
-                .maxEventStreamRetries(retries)
-                .build();
+    private final ServiceGrpc.ServiceImplBase testServiceImpl = new ServiceGrpc.ServiceImplBase() {
+        @Override
+        public void eventStream(
+                Evaluation.EventStreamRequest request,
+                StreamObserver<Evaluation.EventStreamResponse> responseObserver) {
+            // noop
+        }
+    };
 
-        final Cache cache = new Cache("disabled", 0);
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        setupTestGrpcServer();
+    }
 
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        doAnswer(invocation -> null).when(mockStub).eventStream(any(), any());
+    private void setupTestGrpcServer() throws IOException {
+        testServer =
+                NettyServerBuilder.forPort(8080).addService(testServiceImpl).build();
+        testServer.start();
 
-        final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, (connectionEvent) -> {});
+        if (testChannel == null) {
+            testChannel = ManagedChannelBuilder.forAddress("localhost", 8080)
+                    .usePlaintext()
+                    .build();
+        }
+    }
 
-        Field serviceStubField = GrpcConnector.class.getDeclaredField("serviceStub");
-        serviceStubField.setAccessible(true);
-        serviceStubField.set(connector, mockStub);
+    @AfterEach
+    void tearDown() throws Exception {
+        tearDownGrpcServer();
+    }
 
-        final Object syncObject = new Object();
-
-        Field syncField = GrpcConnector.class.getDeclaredField("sync");
-        syncField.setAccessible(true);
-        syncField.set(connector, syncObject);
-
-        assertDoesNotThrow(connector::initialize);
-
-        for (int i = 1; i < retries; i++) {
-            // verify invocation with enough timeout value
-            verify(mockStub, timeout(2L * i * backoffMs).times(i)).eventStream(any(), any());
-
-            synchronized (syncObject) {
-                syncObject.notify();
-            }
+    private void tearDownGrpcServer() throws InterruptedException {
+        if (testServer != null) {
+            testServer.shutdownNow();
+            testServer.awaitTermination();
         }
     }
 
     @Test
-    void initialization_succeed_with_connected_status() {
-        final Cache cache = new Cache("disabled", 0);
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        Consumer<ConnectionEvent> onConnectionEvent = mock(Consumer.class);
-        doAnswer((InvocationOnMock invocation) -> {
-                    EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
-                    eventStreamObserver.onNext(EventStreamResponse.newBuilder()
-                            .setType(Constants.PROVIDER_READY)
-                            .build());
-                    return null;
-                })
-                .when(mockStub)
-                .eventStream(any(), any());
+    void whenShuttingDownAndRestartingGrpcServer_ConsumerReceivesDisconnectedAndConnectedEvent() throws Exception {
+        CountDownLatch sync = new CountDownLatch(2);
+        ArrayList<Boolean> connectionStateChanges = Lists.newArrayList();
+        Consumer<ConnectionEvent> testConsumer = event -> {
+            connectionStateChanges.add(event.isConnected());
+            sync.countDown();
+        };
 
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
+        GrpcConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance = new GrpcConnector<>(
+                FlagdOptions.builder().build(),
+                ServiceGrpc::newStub,
+                ServiceGrpc::newBlockingStub,
+                testConsumer,
+                stub -> stub.eventStream(Evaluation.EventStreamRequest.getDefaultInstance(), mockEventStreamObserver),
+                testChannel);
 
-            // pass true in connected lambda
-            final GrpcConnector connector = new GrpcConnector(
-                    FlagdOptions.builder().build(),
-                    cache,
-                    () -> {
-                        try {
-                            Thread.sleep(100);
-                            return true;
-                        } catch (Exception e) {
-                        }
-                        return false;
-                    },
-                    onConnectionEvent);
+        instance.initialize();
 
-            assertDoesNotThrow(connector::initialize);
-            // assert that onConnectionEvent is connected
-            verify(onConnectionEvent).accept(argThat(arg -> arg.isConnected()));
-        }
+        // when shutting down server
+        testServer.shutdown();
+        testServer.awaitTermination(1, TimeUnit.SECONDS);
+
+        // when restarting server
+        setupTestGrpcServer();
+
+        // then consumer received DISCONNECTED and CONNECTED event
+        boolean finished = sync.await(10, TimeUnit.SECONDS);
+        Assertions.assertTrue(finished);
+        Assertions.assertEquals(Lists.newArrayList(DISCONNECTED, CONNECTED), connectionStateChanges);
     }
 
     @Test
-    void stream_does_not_fail_on_first_error() {
-        final Cache cache = new Cache("disabled", 0);
-        final ServiceStub mockStub = createServiceStubMock();
-        Consumer<ConnectionEvent> onConnectionEvent = mock(Consumer.class);
-        doAnswer((InvocationOnMock invocation) -> {
-                    EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
-                    eventStreamObserver.onError(new Exception("fake"));
-                    return null;
-                })
-                .when(mockStub)
-                .eventStream(any(), any());
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            // pass true in connected lambda
-            final GrpcConnector connector = new GrpcConnector(
-                    FlagdOptions.builder().build(),
-                    cache,
-                    () -> {
-                        try {
-                            Thread.sleep(100);
-                            return true;
-                        } catch (Exception e) {
-                        }
-                        return false;
-                    },
-                    onConnectionEvent);
-
-            assertDoesNotThrow(connector::initialize);
-            // assert that onConnectionEvent is connected gets not called
-            verify(onConnectionEvent, timeout(300).times(0)).accept(any());
-        }
-    }
-
-    @Test
-    void stream_fails_on_second_error_in_a_row() throws Exception {
-        final FlagdOptions options = FlagdOptions.builder()
-                // shorter backoff for testing
-                .retryBackoffMs(0)
-                .build();
-
-        final Cache cache = new Cache("disabled", 0);
-        Consumer<ConnectionEvent> onConnectionEvent = mock(Consumer.class);
-
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        doAnswer((InvocationOnMock invocation) -> {
-                    EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
-                    eventStreamObserver.onError(new Exception("fake"));
-                    return null;
-                })
-                .when(mockStub)
-                .eventStream(any(), any());
-
-        final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, onConnectionEvent);
-
-        Field serviceStubField = GrpcConnector.class.getDeclaredField("serviceStub");
-        serviceStubField.setAccessible(true);
-        serviceStubField.set(connector, mockStub);
-
-        final Object syncObject = new Object();
-
-        Field syncField = GrpcConnector.class.getDeclaredField("sync");
-        syncField.setAccessible(true);
-        syncField.set(connector, syncObject);
-
-        assertDoesNotThrow(connector::initialize);
-
-        // 1st try
-        verify(mockStub, timeout(300).times(1)).eventStream(any(), any());
-        verify(onConnectionEvent, timeout(300).times(0)).accept(any());
-        synchronized (syncObject) {
-            syncObject.notify();
-        }
-
-        // 2nd try
-        verify(mockStub, timeout(300).times(2)).eventStream(any(), any());
-        verify(onConnectionEvent, timeout(300).times(1)).accept(argThat(arg -> !arg.isConnected()));
-    }
-
-    @Test
-    void stream_does_not_fail_when_message_between_errors() throws Exception {
-        final FlagdOptions options = FlagdOptions.builder()
-                // shorter backoff for testing
-                .retryBackoffMs(0)
-                .build();
-
-        final Cache cache = new Cache("disabled", 0);
-        Consumer<ConnectionEvent> onConnectionEvent = mock(Consumer.class);
-
-        final AtomicBoolean successMessage = new AtomicBoolean(false);
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        doAnswer((InvocationOnMock invocation) -> {
-                    EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
-
-                    if (successMessage.get()) {
-                        eventStreamObserver.onNext(EventStreamResponse.newBuilder()
-                                .setType(Constants.PROVIDER_READY)
-                                .build());
-                    } else {
-                        eventStreamObserver.onError(new Exception("fake"));
-                    }
-                    return null;
-                })
-                .when(mockStub)
-                .eventStream(any(), any());
-
-        final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, onConnectionEvent);
-
-        Field serviceStubField = GrpcConnector.class.getDeclaredField("serviceStub");
-        serviceStubField.setAccessible(true);
-        serviceStubField.set(connector, mockStub);
-
-        final Object syncObject = new Object();
-
-        Field syncField = GrpcConnector.class.getDeclaredField("sync");
-        syncField.setAccessible(true);
-        syncField.set(connector, syncObject);
-
-        assertDoesNotThrow(connector::initialize);
-
-        // 1st message with error
-        verify(mockStub, timeout(300).times(1)).eventStream(any(), any());
-        verify(onConnectionEvent, timeout(300).times(0)).accept(any());
-
-        synchronized (syncObject) {
-            successMessage.set(true);
-            syncObject.notify();
-        }
-
-        // 2nd message with provider ready
-        verify(mockStub, timeout(300).times(2)).eventStream(any(), any());
-        verify(onConnectionEvent, timeout(300).times(1)).accept(argThat(arg -> arg.isConnected()));
-        synchronized (syncObject) {
-            successMessage.set(false);
-            syncObject.notify();
-        }
-
-        // 3nd message with error
-        verify(mockStub, timeout(300).times(2)).eventStream(any(), any());
-        verify(onConnectionEvent, timeout(300).times(0)).accept(argThat(arg -> !arg.isConnected()));
-    }
-
-    @Test
-    void stream_does_not_fail_with_deadline_error() throws Exception {
-        final Cache cache = new Cache("disabled", 0);
-        final ServiceStub mockStub = createServiceStubMock();
-        Consumer<ConnectionEvent> onConnectionEvent = mock(Consumer.class);
-        doAnswer((InvocationOnMock invocation) -> {
-                    EventStreamObserver eventStreamObserver = (EventStreamObserver) invocation.getArgument(1);
-                    eventStreamObserver.onError(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
-                    return null;
-                })
-                .when(mockStub)
-                .eventStream(any(), any());
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            // pass true in connected lambda
-            final GrpcConnector connector = new GrpcConnector(
-                    FlagdOptions.builder().build(),
-                    cache,
-                    () -> {
-                        try {
-                            Thread.sleep(100);
-                            return true;
-                        } catch (Exception e) {
-                        }
-                        return false;
-                    },
-                    onConnectionEvent);
-
-            assertDoesNotThrow(connector::initialize);
-            // this should not call the connection event
-            verify(onConnectionEvent, never()).accept(any());
-        }
-    }
-
-    @Test
-    void host_and_port_arg_should_build_tcp_socket() {
-        final String host = "host.com";
-        final int port = 1234;
-        final String targetUri = String.format("%s:%s", host, port);
-
-        ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
-        ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService
-                    .when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(mockBlockingStub);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
-
-                mockStaticChannelBuilder
-                        .when(() -> NettyChannelBuilder.forTarget(anyString()))
-                        .thenReturn(mockChannelBuilder);
-
-                final FlagdOptions flagdOptions =
-                        FlagdOptions.builder().host(host).port(port).tls(false).build();
-                new GrpcConnector(flagdOptions, null, null, null);
-
-                // verify host/port matches
-                mockStaticChannelBuilder.verify(
-                        () -> NettyChannelBuilder.forTarget(String.format(targetUri)), times(1));
-            }
-        }
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "FLAGD_HOST", value = HOST)
-    @SetEnvironmentVariable(key = "FLAGD_PORT", value = "" + PORT)
-    void no_args_host_and_port_env_set_should_build_tcp_socket() throws Exception {
-        final String targetUri = String.format("%s:%s", HOST, PORT);
-
-        ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
-        ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService
-                    .when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(mockBlockingStub);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
-
-                mockStaticChannelBuilder
-                        .when(() -> NettyChannelBuilder.forTarget(anyString()))
-                        .thenReturn(mockChannelBuilder);
-
-                new GrpcConnector(FlagdOptions.builder().build(), null, null, null);
-
-                // verify host/port matches & called times(= 1 as we rely on reusable channel)
-                mockStaticChannelBuilder.verify(() -> NettyChannelBuilder.forTarget(targetUri), times(1));
-            }
-        }
-    }
-
-    /**
-     * OS Specific test - This test is valid only on Linux system as it rely on
-     * epoll availability
-     */
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    void path_arg_should_build_domain_socket_with_correct_path() {
-        final String path = "/some/path";
-
-        ServiceGrpc.ServiceBlockingStub mockBlockingStub = mock(ServiceGrpc.ServiceBlockingStub.class);
-        ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService
-                    .when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(mockBlockingStub);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
-
-                try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup =
-                        mockConstruction(EpollEventLoopGroup.class, (mock, context) -> {})) {
-                    when(NettyChannelBuilder.forAddress(any(DomainSocketAddress.class)))
-                            .thenReturn(mockChannelBuilder);
-
-                    new GrpcConnector(FlagdOptions.builder().socketPath(path).build(), null, null, null);
-
-                    // verify path matches
-                    mockStaticChannelBuilder.verify(
-                            () -> NettyChannelBuilder.forAddress(argThat((DomainSocketAddress d) -> {
-                                assertEquals(path, d.path()); // path should match
-                                return true;
-                            })),
-                            times(1));
-                }
-            }
-        }
-    }
-
-    /**
-     * OS Specific test - This test is valid only on Linux system as it rely on
-     * epoll availability
-     */
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    @SetEnvironmentVariable(key = "FLAGD_SOCKET_PATH", value = SOCKET_PATH)
-    void no_args_socket_env_should_build_domain_socket_with_correct_path() throws Exception {
-
-        ServiceBlockingStub mockBlockingStub = mock(ServiceBlockingStub.class);
-        ServiceStub mockStub = mock(ServiceStub.class);
-        NettyChannelBuilder mockChannelBuilder = getMockChannelBuilderSocket();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService
-                    .when(() -> ServiceGrpc.newBlockingStub(any(Channel.class)))
-                    .thenReturn(mockBlockingStub);
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            try (MockedStatic<NettyChannelBuilder> mockStaticChannelBuilder = mockStatic(NettyChannelBuilder.class)) {
-
-                try (MockedConstruction<EpollEventLoopGroup> mockEpollEventLoopGroup =
-                        mockConstruction(EpollEventLoopGroup.class, (mock, context) -> {})) {
-                    mockStaticChannelBuilder
-                            .when(() -> NettyChannelBuilder.forAddress(any(DomainSocketAddress.class)))
-                            .thenReturn(mockChannelBuilder);
-
-                    new GrpcConnector(FlagdOptions.builder().build(), null, null, null);
-
-                    // verify path matches & called times(= 1 as we rely on reusable channel)
-                    mockStaticChannelBuilder.verify(
-                            () -> NettyChannelBuilder.forAddress(argThat((DomainSocketAddress d) -> {
-                                assertEquals(SOCKET_PATH, d.path()); // path should match
-                                return true;
-                            })),
-                            times(1));
-                }
-            }
-        }
-    }
-
-    @Test
-    void initialization_with_stream_deadline() throws NoSuchFieldException, IllegalAccessException {
-        final FlagdOptions options =
-                FlagdOptions.builder().streamDeadlineMs(16983).build();
-
-        final Cache cache = new Cache("disabled", 0);
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, null);
-
-            assertDoesNotThrow(connector::initialize);
-            verify(mockStub).withDeadlineAfter(16983, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    @Test
-    void initialization_without_stream_deadline() throws NoSuchFieldException, IllegalAccessException {
-        final FlagdOptions options = FlagdOptions.builder().streamDeadlineMs(0).build();
-
-        final Cache cache = new Cache("disabled", 0);
-        final ServiceGrpc.ServiceStub mockStub = createServiceStubMock();
-
-        try (MockedStatic<ServiceGrpc> mockStaticService = mockStatic(ServiceGrpc.class)) {
-            mockStaticService.when(() -> ServiceGrpc.newStub(any())).thenReturn(mockStub);
-
-            final GrpcConnector connector = new GrpcConnector(options, cache, () -> true, null);
-
-            assertDoesNotThrow(connector::initialize);
-            verify(mockStub, never()).withDeadlineAfter(16983, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    private static ServiceStub createServiceStubMock() {
-        final ServiceStub mockStub = mock(ServiceStub.class);
-        when(mockStub.withDeadlineAfter(anyLong(), any())).thenReturn(mockStub);
-        return mockStub;
-    }
-
-    private NettyChannelBuilder getMockChannelBuilderSocket() {
-        NettyChannelBuilder mockChannelBuilder = mock(NettyChannelBuilder.class);
-        when(mockChannelBuilder.eventLoopGroup(any(EventLoopGroup.class))).thenReturn(mockChannelBuilder);
-        when(mockChannelBuilder.channelType(any(Class.class))).thenReturn(mockChannelBuilder);
-        when(mockChannelBuilder.usePlaintext()).thenReturn(mockChannelBuilder);
-        when(mockChannelBuilder.keepAliveTime(anyLong(), any())).thenReturn(mockChannelBuilder);
-        when(mockChannelBuilder.build()).thenReturn(null);
-        return mockChannelBuilder;
+    void whenShuttingDownGrpcConnector_ConsumerReceivesDisconnectedEvent() throws Exception {
+        CountDownLatch sync = new CountDownLatch(1);
+        ArrayList<Boolean> connectionStateChanges = Lists.newArrayList();
+        Consumer<ConnectionEvent> testConsumer = event -> {
+            connectionStateChanges.add(event.isConnected());
+            sync.countDown();
+        };
+
+        GrpcConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance = new GrpcConnector<>(
+                FlagdOptions.builder().build(),
+                ServiceGrpc::newStub,
+                ServiceGrpc::newBlockingStub,
+                testConsumer,
+                stub -> stub.eventStream(Evaluation.EventStreamRequest.getDefaultInstance(), mockEventStreamObserver),
+                testChannel);
+
+        instance.initialize();
+        // when shutting grpc connector
+        instance.shutdown();
+
+        // then consumer received DISCONNECTED and CONNECTED event
+        boolean finished = sync.await(10, TimeUnit.SECONDS);
+        Assertions.assertTrue(finished);
+        Assertions.assertEquals(Lists.newArrayList(DISCONNECTED), connectionStateChanges);
     }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

* Updates the reconnection behavior of the flagd provider in RPC mode.
* **Breaking Change**: If the provider loses connection, it will emit a STALE event. If the connection is successfully reestablished within the `FLAGD_RETRY_GRACE_PERIOD`, the provider will emit a READY event and resume full operation. If reconnection is not achieved within this time frame, an ERROR event will be emitted. The default value for `FLAGD_RETRY_GRACE_PERIOD` is set to `5`.


This PR marks the initial step in phasing out our custom gRPC backoff and reconnect logic. Instead, we are transitioning to fully rely on the default behaviour provided by the gRPC library.
This change is currently limited to the RPC mode of the provider (specifically the `dev.openfeature.contrib.providers.flagd.resolver.grpc` package). In this first phase, the `GrpcConnector` within this package has been refactored to operate independently of custom backoff logic, leveraging only gRPC internals to maintain a reliable connection.

In the next phase/PR, the refactored GrpcConnector should be reused within the`dev.openfeature.contrib.providers.flagd.resolver.process` package, enabling the removal of custom reconnect logic from that implementation as well.




