### PR TITLE
build(renovate): Utilize default OpenFeature Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,7 @@
 
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    }
-  ],
+  "extends": ["github>open-feature/community-tooling"],
   "regexManagers": [
     {
       "fileMatch": ["^README.md$", "^.github/workflows/pullrequest.yml$"],


### PR DESCRIPTION
We do have a default OpenFeature Renovate configuration within our community-tooling repository. (https://github.com/open-feature/community-tooling/blob/main/renovate.json)

To reduce maintenance efforts, we should stick to the general one.



