### PR TITLE
test(flagd): remove dependency and switch to other envvar utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,20 +187,6 @@
         </dependency>
 
         <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-core</artifactId>
-            <version>2.0.3</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-jupiter</artifactId>
-            <version>2.1.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <version>7.20.1</version>


### PR DESCRIPTION
We do have multiple tools in our build that can change env vars. I removed one and fixed the tests to use the other, as this one was only used in one place.