### PR TITLE
build: improve checkstyle build times by ignoring generated sources

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -30,8 +30,7 @@
     </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
     <module name="SuppressionFilter">
-        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-                  default="checkstyle-suppressions.xml" />
+        <property name="file" value="checkstyle-suppressions.xml" />
         <property name="optional" value="true"/>
     </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,7 @@
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>
+                    <excludeGeneratedSources>true</excludeGeneratedSources>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
It seems like there is a regression with the spotless integration pr. Suddenly, the generated sources are checked by checkstyle, increasing the build times heavily. This pr should remove the generated sources from the checkstyle check