### PR TITLE
chore: update min SDK version

### DIFF
--- a/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
+++ b/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java
@@ -134,7 +134,7 @@ public class MetricsHook implements Hook {
     }
 
     @Override
-    public void finallyAfter(HookContext ctx, Map hints) {
+    public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
         activeFlagEvaluationsCounter.add(-1, Attributes.of(flagKeyAttributeKey, ctx.getFlagKey()));
     }
 

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/MetricsHookTest.java
@@ -188,7 +188,7 @@ class MetricsHookTest {
         final MetricsHook metricHook = new MetricsHook(telemetryExtension.getOpenTelemetry());
 
         // when
-        metricHook.finallyAfter(commonHookContext, null);
+        metricHook.finallyAfter(commonHookContext, null, null);
         List<MetricData> metrics = telemetryExtension.getMetrics();
 
         // then

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
             <!-- this can be overriden in child POMs to support specific SDK requirements -->
             <groupId>dev.openfeature</groupId>
             <artifactId>sdk</artifactId>
-            <!-- 1.12 <= v < 2.0 -->
-            <version>[1.12,2.0)</version>
+            <!-- 1.14 <= v < 2.0 (excluding 2.0 pre-releases)-->
+            <version>[1.14,1.99999)</version>
             <!-- use the version provided at runtime -->
             <scope>provided</scope>
         </dependency>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -24,7 +24,6 @@ import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -24,6 +24,7 @@ import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.ParseError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
Updates min SDK version to 1.14.0. At next release all artifacts will require [SDK v1.14.0](https://github.com/open-feature/java-sdk/releases/tag/v1.14.0) which has some significant changes.