### PR TITLE
feat(go-feature-flag): Support Exporter Metadata

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import dev.openfeature.sdk.ProviderEvaluation;
 import lombok.Builder;
 import lombok.Getter;
+import java.util.Map;
 
 /** GoFeatureFlagProviderOptions contains the options to initialise the provider. */
 @Builder
@@ -90,4 +91,13 @@ public class GoFeatureFlagProviderOptions {
      * retrieved in the cache. default: false
      */
     private boolean disableDataCollection;
+
+    /**
+     * (optional) exporterMetadata is the metadata we send to the GO Feature Flag relay proxy when we report the
+     * evaluation data usage.
+     *
+     * ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information of this
+     * field will not be added to your feature events.
+     */
+    private Map<String, Object> exporterMetadata;
 }

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -2,9 +2,9 @@ package dev.openfeature.contrib.providers.gofeatureflag;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
-import java.util.Map;
 
 /** GoFeatureFlagProviderOptions contains the options to initialise the provider. */
 @Builder
@@ -95,7 +95,6 @@ public class GoFeatureFlagProviderOptions {
     /**
      * (optional) exporterMetadata is the metadata we send to the GO Feature Flag relay proxy when we report the
      * evaluation data usage.
-     *
      * ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information of this
      * field will not be added to your feature events.
      */

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
@@ -31,7 +31,10 @@ import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +72,9 @@ public class GoFeatureFlagController {
 
     private final HttpUrl parsedEndpoint;
 
+    /** exporterMetadata contains the metadata to send to the collector API. */
+    private Map<String, Object> exporterMetadata = new HashMap<>();
+
     /**
      * etag contains the etag of the configuration, if null, it means that the configuration has never
      * been retrieved.
@@ -85,6 +91,7 @@ public class GoFeatureFlagController {
     @Builder
     private GoFeatureFlagController(final GoFeatureFlagProviderOptions options) throws InvalidOptions {
         this.apiKey = options.getApiKey();
+        this.exporterMetadata = options.getExporterMetadata();
 
         this.parsedEndpoint = HttpUrl.parse(options.getEndpoint());
         if (this.parsedEndpoint == null) {
@@ -218,7 +225,7 @@ public class GoFeatureFlagController {
      */
     public void sendEventToDataCollector(List<Event> eventsList) {
         try {
-            Events events = new Events(eventsList);
+            Events events = new Events(eventsList, this.exporterMetadata);
             HttpUrl url = this.parsedEndpoint
                     .newBuilder()
                     .addEncodedPathSegment("v1")

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/controller/GoFeatureFlagController.java
@@ -31,7 +31,6 @@ import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/events/Events.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/events/Events.java
@@ -9,9 +9,22 @@ import lombok.Getter;
 /** Events data. */
 @Getter
 public class Events {
+    /**
+     * meta contains the metadata of the events to be sent along the events.
+     */
     private final Map<String, Object> meta = new HashMap<>();
+
+    /**
+     * list of events to be sent to the data collector to collect the evaluation data.
+     */
     private final List<Event> events;
 
+    /**
+     * Constructor.
+     *
+     * @param events - list of events to be sent to the data collector to collect the evaluation data.
+     * @param exporterMetadata - metadata of the events to be sent along the events.
+     */
     public Events(List<Event> events, Map<String, Object> exporterMetadata) {
         this.events = new ArrayList<>(events);
         this.meta.put("provider", "java");

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/events/Events.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/events/Events.java
@@ -9,16 +9,15 @@ import lombok.Getter;
 /** Events data. */
 @Getter
 public class Events {
-    private static final Map<String, String> meta = new HashMap<>();
-
-    static {
-        meta.put("provider", "java");
-        meta.put("openfeature", "true");
-    }
-
+    private final Map<String, Object> meta = new HashMap<>();
     private final List<Event> events;
 
-    public Events(List<Event> events) {
+    public Events(List<Event> events, Map<String, Object> exporterMetadata) {
         this.events = new ArrayList<>(events);
+        this.meta.put("provider", "java");
+        this.meta.put("openfeature", true);
+        if (exporterMetadata != null) {
+            this.meta.putAll(exporterMetadata);
+        }
     }
 }

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderTest.java
@@ -979,9 +979,11 @@ class GoFeatureFlagProviderTest {
         want.put("version", "1.0.0");
         want.put("intTest", 1234567890);
         want.put("doubleTest", 12345.6789);
-        want.put("openfeature",true);
+        want.put("openfeature", true);
         want.put("provider", "java");
-        assertEquals(want, this.exporterMetadata,
+        assertEquals(
+                want,
+                this.exporterMetadata,
                 "we should have the exporter metadata in the last event sent to the data collector");
     }
 


### PR DESCRIPTION
## This PR
GO Feature Flag exporter is now supporting adding extra parameters as metadata.
Those parameters are static informations provided during the initialisation to be added in the meta field when calling the exporter.

In the GO Feature Flag we will have those information available in the exporter.

See https://github.com/thomaspoignant/go-feature-flag/issues/2936 for more information.

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/2938
