### PR TITLE
fix: Use seconds instead of milliseconds

### DIFF
--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/DataCollectorHook.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/hook/DataCollectorHook.java
@@ -62,7 +62,7 @@ public class DataCollectorHook implements Hook<HookContext<String>> {
                 .variation(details.getVariant())
                 .value(details.getValue())
                 .userKey(ctx.getCtx().getTargetingKey())
-                .creationDate(System.currentTimeMillis())
+                .creationDate(System.currentTimeMillis() / 1000L)
                 .build();
         eventsPublisher.add(event);
     }
@@ -73,7 +73,7 @@ public class DataCollectorHook implements Hook<HookContext<String>> {
                 .key(ctx.getFlagKey())
                 .kind("feature")
                 .contextKind(GoFeatureFlagUser.isAnonymousUser(ctx.getCtx()) ? "anonymousUser" : "user")
-                .creationDate(System.currentTimeMillis())
+                .creationDate(System.currentTimeMillis() / 1000L)
                 .defaultValue(true)
                 .variation("SdkDefault")
                 .value(ctx.getDefaultValue())


### PR DESCRIPTION
Use seconds instead of milliseconds, since version 1.40.0 relay proxy logs a warning about this.

[https://github.com/thomaspoignant/go-feature-flag/releases/tag/v1.40.0](https://github.com/thomaspoignant/go-feature-flag/releases/tag/v1.40.0)