### PR TITLE
build: utilizing new java version, but still building with language level 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  push:
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,23 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-
+    strategy:
+        matrix:
+            build:
+                - java: 17
+                  profile: codequality
+                - java: 11
+                  profile: java11
+                - java: 8
+                  profile: java8
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.build.java }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
         with:
-          java-version: '8'
+          java-version: ${{ matrix.build.java }}
           distribution: 'temurin'
           cache: maven
 
@@ -27,9 +35,9 @@ jobs:
         uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}${{ matrix.build.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}${{ matrix.build.java }}-maven-
 
       - name: Maven Verify
-        run: mvn --batch-mode --activate-profiles e2e clean verify
+        run: mvn --batch-mode --activate-profiles e2e,${{ matrix.build.profile }} clean verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  push:
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           build:
               - java: 17
                 profile: codequality
-              - java: 11
-                profile: java11
               - java: 8
                 profile: java8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,19 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
     strategy:
         matrix:
-            build:
-                - java: 17
-                  profile: codequality
-                - java: 11
-                  profile: java11
-                - java: 8
-                  profile: java8
+          os: [ubuntu-latest]
+          build:
+              - java: 17
+                profile: codequality
+              - java: 11
+                profile: java11
+              - java: 8
+                profile: java8
+
+    name: with Java ${{ matrix.build.java }}
+    runs-on: ${{ matrix.os}}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,11 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
           server-id: ossrh

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -28,19 +28,23 @@
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
-    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+
+    <module name="SuppressWarningsFilter"/>
+
+    <!-- https://checkstyle.org/filters/suppressionfilter.html -->
     <module name="SuppressionFilter">
-        <property name="file" value="checkstyle-suppressions.xml" />
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
         <property name="optional" value="true"/>
     </module>
 
     <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
-    <!--<module name="SuppressWithNearbyTextFilter">
+    <module name="SuppressWithNearbyTextFilter">
         <property name="nearbyTextPattern"
                   value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
         <property name="checkPattern" value="$1"/>
         <property name="lineRange" value="$2"/>
-    </module>-->
+    </module>
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.org/checks/whitespace/index.html -->
@@ -51,27 +55,11 @@
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <property name="ignorePattern"
+                  value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
     </module>
 
-    <module name="SuppressWarningsFilter" />
-
     <module name="TreeWalker">
-        <!-- needed for SuppressWarningsFilter -->
-        <module name="SuppressWarningsHolder" />
-
-        <module name="SuppressWarnings">
-            <property name="id" value="checkstyle:suppresswarnings"/>
-        </module>
-
-        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
-        <module name="SuppressionXpathFilter">
-            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-                      default="checkstyle-xpath-suppressions.xml" />
-            <property name="optional" value="true"/>
-        </module>
-
-        <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -98,26 +86,26 @@
             <property name="id" value="LeftCurlyEol"/>
             <property name="tokens"
                       value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
-                    INTERFACE_DEF,  LITERAL_CATCH,
-                    LITERAL_DO, LITERAL_ELSE,  LITERAL_FOR, LITERAL_IF,
-                     LITERAL_WHILE, METHOD_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
                     OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
         </module>
         <module name="LeftCurly">
             <property name="id" value="LeftCurlyNl"/>
             <property name="option" value="nl"/>
             <property name="tokens"
-                      value=" LITERAL_DEFAULT"/>
+                      value="LITERAL_CASE, LITERAL_DEFAULT"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <!--  LITERAL_DEFAULT are reused in SWITCH_RULE  -->
+            <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
             <property name="id" value="LeftCurlyNl"/>
             <property name="query" value="//SWITCH_RULE/SLIST"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens"
-                      value="LITERAL_IF, LITERAL_ELSE,
+                      value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_DO"/>
         </module>
         <module name="RightCurly">
@@ -126,7 +114,7 @@
             <property name="tokens"
                       value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
             <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
@@ -136,8 +124,10 @@
         </module>
         <module name="WhitespaceAfter">
             <property name="tokens"
-                      value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
-                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR,  DO_WHILE"/>
+                      value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE, LITERAL_WHEN"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
@@ -145,17 +135,17 @@
             <property name="allowEmptyMethods" value="true"/>
             <property name="allowEmptyTypes" value="true"/>
             <property name="allowEmptyLoops" value="true"/>
-            <!--<property name="allowEmptySwitchBlockStatements" value="true"/>-->
+            <property name="allowEmptySwitchBlockStatements" value="true"/>
             <property name="ignoreEnhancedForColon" value="false"/>
             <property name="tokens"
                       value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
-                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT,  LAND,
-                    LCURLY, LE, LITERAL_DO, LITERAL_ELSE,
-                    LITERAL_FOR, LITERAL_IF,
-                    LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT,
-                    TYPE_EXTENSION_AND"/>
+                    TYPE_EXTENSION_AND, LITERAL_WHEN"/>
             <message key="ws.notFollowed"
                      value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
                may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
@@ -319,7 +309,7 @@
         </module>
         <module name="NoWhitespaceBeforeCaseDefaultColon"/>
         <module name="OverloadMethodsDeclarationOrder"/>
-        <!--<module name="ConstructorsDeclarationGrouping"/>-->
+        <module name="ConstructorsDeclarationGrouping"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
@@ -329,8 +319,8 @@
         </module>
         <module name="MethodParamPad">
             <property name="tokens"
-                      value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
-                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF"/>
+                      value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF, RECORD_PATTERN_DEF"/>
         </module>
         <module name="NoWhitespaceBefore">
             <property name="tokens"
@@ -340,10 +330,11 @@
         </module>
         <module name="ParenPad">
             <property name="tokens"
-                      value="ANNOTATION, ANNOTATION_FIELD_DEF,  CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
-                    EXPR, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
-                     LITERAL_WHILE, METHOD_CALL,
-                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL"/>
+                      value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF, RECORD_PATTERN_DEF"/>
         </module>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
@@ -371,6 +362,7 @@
                       value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
         <module name="JavadocParagraph">
+            <property name="allowNewlineParagraph" value="false"/>
         </module>
         <module name="RequireEmptyLineBeforeBlockTagGroup"/>
         <module name="AtclauseOrder">

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,7 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <toolchain.jdk.version>[17,)</toolchain.jdk.version>
         <junit.jupiter.version>5.11.4</junit.jupiter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -59,7 +58,10 @@
         <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
         <!--  This is required for later correct replacement of surefireArgLine -->
         <!-- see surefire-java8 and surefire-java9+ profiles -->
-        <surefireArgLine/>
+        <surefireArgLine>
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.lang=ALL-UNNAMED
+        </surefireArgLine>
     </properties>
 
     <dependencies>
@@ -220,89 +222,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>select-jdk-toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
-            </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.6.0</version>
                 <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                    <excludeGeneratedSources>true</excludeGeneratedSources>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>9.3</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.26.0</version>
-                <configuration>
-                    <excludeRoots>${basedir}/target/generated-sources/</excludeRoots>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>run-pmd</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.6.6</version>
-                <configuration>
-                    <excludeFilterFile>spotbugs-exclusions.xml</excludeFilterFile>
-                    <plugins>
-                        <plugin>
-                            <groupId>com.h3xstream.findsecbugs</groupId>
-                            <artifactId>findsecbugs-plugin</artifactId>
-                            <version>1.13.0</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
-                <dependencies>
-                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-                    <dependency>
-                        <groupId>com.github.spotbugs</groupId>
-                        <artifactId>spotbugs</artifactId>
-                        <version>4.8.6</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>run-spotbugs</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- automatically derive a module name from the groupId and artifactId -->
@@ -367,6 +305,8 @@
                     </excludePackageNames>
                     <doclint>all,-missing
                     </doclint>  <!-- ignore missing javadoc, these are enforced with more customizability in the checkstyle plugin -->
+
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>
@@ -438,69 +378,189 @@
                     <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
-            <!-- End publish to maven central -->
             <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.30.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
                 <configuration>
-                    <!-- optional: limit format enforcement to just the files changed by this feature branch -->
-                    <!--                <ratchetFrom>origin/main</ratchetFrom>-->
-                    <formats>
-                        <!-- you can define as many formats as you want, each is independent -->
-                        <format>
-                            <!-- define the files to apply to -->
-                            <includes>
-                                <include>.gitattributes</include>
-                                <include>.gitignore</include>
-                            </includes>
-                            <!-- define the steps to apply to those files -->
-                            <trimTrailingWhitespace/>
-                            <endWithNewline/>
-                            <indent>
-                                <spaces>true</spaces>
-                                <spacesPerTab>4</spacesPerTab>
-                            </indent>
-                        </format>
-                    </formats>
-                    <!-- define a language-specific format -->
-                    <java>
-                        <palantirJavaFormat />
-
-                        <indent>
-                            <spaces>true</spaces>
-                            <spacesPerTab>4</spacesPerTab>
-                        </indent>
-                        <importOrder/>
-
-                        <removeUnusedImports/>
-                        <formatAnnotations/>
-
-                    </java>
+                    <excludes>
+                        <!-- tests to exclude -->
+                        <exclude>${testExclusions}</exclude>
+                    </excludes>
+                    <argLine>
+                        @{surefireArgLine}
+                    </argLine>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+            <!-- End publish to maven central -->
         </plugins>
-
     </build>
 
     <profiles>
-        <!-- profile for running tests under java 8 (used mostly in CI) -->
-        <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
         <profile>
-            <id>surefire-java8</id>
+            <id>codequality</id>
             <activation>
-                <!-- JDK 1.8 -->
-                <jdk>1.8</jdk>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>
+                    <!-- CODE QUALITY TOOLS -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <linkXRef>false</linkXRef>
+                            <excludeGeneratedSources>true</excludeGeneratedSources>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>10.21.2</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>validate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <version>3.26.0</version>
+                        <configuration>
+                            <excludeRoots>${basedir}/target/generated-sources/</excludeRoots>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>run-pmd</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- SpotBugs -->
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>4.8.6.6</version>
+                        <configuration>
+                            <excludeFilterFile>spotbugs-exclusions.xml</excludeFilterFile>
+                            <plugins>
+                                <plugin>
+                                    <groupId>com.h3xstream.findsecbugs</groupId>
+                                    <artifactId>findsecbugs-plugin</artifactId>
+                                    <version>1.13.0</version>
+                                </plugin>
+                            </plugins>
+                        </configuration>
+                        <dependencies>
+                            <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                            <dependency>
+                                <groupId>com.github.spotbugs</groupId>
+                                <artifactId>spotbugs</artifactId>
+                                <version>4.8.6</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>run-spotbugs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Spotless -->
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <version>2.43.0</version>
+                        <configuration>
+                            <!-- optional: limit format enforcement to just the files changed by this feature branch -->
+                            <!--                <ratchetFrom>origin/main</ratchetFrom>-->
+                            <formats>
+                                <!-- you can define as many formats as you want, each is independent -->
+                                <format>
+                                    <!-- define the files to apply to -->
+                                    <includes>
+                                        <include>.gitattributes</include>
+                                        <include>.gitignore</include>
+                                    </includes>
+                                    <!-- define the steps to apply to those files -->
+                                    <trimTrailingWhitespace/>
+                                    <endWithNewline/>
+                                    <indent>
+                                        <spaces>true</spaces>
+                                        <spacesPerTab>4</spacesPerTab>
+                                    </indent>
+                                </format>
+                            </formats>
+                            <!-- define a language-specific format -->
+                            <java>
+                                <palantirJavaFormat/>
+
+                                <indent>
+                                    <spaces>true</spaces>
+                                    <spacesPerTab>4</spacesPerTab>
+                                </indent>
+                                <importOrder/>
+
+                                <removeUnusedImports/>
+                                <formatAnnotations/>
+
+                            </java>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- profile for running tests under java 8 (used mostly in CI) -->
+        <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
+        <profile>
+            <id>java8</id>
+            <properties>
+                <toolchain.jdk.version>(1.8,9)</toolchain.jdk.version>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-toolchains-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>select-jdk-toolchain</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -510,7 +570,7 @@
                                 <!-- tests to exclude -->
                                 <exclude>${testExclusions}</exclude>
                             </excludes>
-                            <argLine>@{surefireArgLine}</argLine>
+                            <argLine>""</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -520,11 +580,11 @@
         <!-- profile for running tests under java 9+ (used for dev environments where people don't want to be locked to Java 8) -->
         <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
         <profile>
-            <id>surefire-java9+</id>
-            <activation>
-                <!-- JDK 1.9+ -->
-                <jdk>[1.9,)</jdk>
-            </activation>
+            <id>java11</id>
+
+            <properties>
+                <toolchain.jdk.version>(11,12)</toolchain.jdk.version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -536,8 +596,7 @@
                                 <!-- tests to exclude -->
                                 <exclude>${testExclusions}</exclude>
                             </excludes>
-                            <argLine>@{surefireArgLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens
-                                java.base/java.lang=ALL-UNNAMED
+                            <argLine>@{surefireArgLine}
                             </argLine>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -591,33 +591,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- profile for running tests under java 9+ (used for dev environments where people don't want to be locked to Java 8) -->
-        <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
-        <profile>
-            <id>java11</id>
-
-            <properties>
-                <toolchain.jdk.version>(11,12)</toolchain.jdk.version>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.5.2</version>
-                        <configuration>
-                            <excludes>
-                                <!-- tests to exclude -->
-                                <exclude>${testExclusions}</exclude>
-                            </excludes>
-                            <argLine>@{surefireArgLine}
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -566,11 +566,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>3.5.2</version>
                         <configuration>
-                            <excludes>
-                                <!-- tests to exclude -->
-                                <exclude>${testExclusions}</exclude>
-                            </excludes>
-                            <argLine>""</argLine>
+                            <skipTests>true</skipTests>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             --add-opens java.base/java.lang=ALL-UNNAMED
         </surefireArgLine>
         <skip.tests>false</skip.tests>
-        <!-- this will throw an error if we use wrong apis -->
+        <!-- this will throw an error if we use APIs not available in the specified version -->
        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
             --add-opens java.base/java.util=ALL-UNNAMED
             --add-opens java.base/java.lang=ALL-UNNAMED
         </surefireArgLine>
+        <skip.tests>false</skip.tests>
+        <!-- this will throw an error if we use wrong apis -->
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -97,7 +100,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -236,11 +239,6 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
-
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
             </plugin>
 
             <!-- automatically derive a module name from the groupId and artifactId -->
@@ -545,6 +543,7 @@
             <id>java8</id>
             <properties>
                 <toolchain.jdk.version>(1.8,9)</toolchain.jdk.version>
+                <skip.tests>true</skip.tests>
             </properties>
 
             <build>
@@ -566,8 +565,25 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>3.5.2</version>
                         <configuration>
-                            <skipTests>true</skipTests>
+                            <skipTests>${skip.tests}</skipTests>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.13.0</version>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <module-name>${groupId}.${artifactId}</module-name>
         <io.cucumber.version>7.21.1</io.cucumber.version>
+        <org.mockito.version>5.2.0</org.mockito.version>
         <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
         <!--  This is required for later correct replacement of surefireArgLine -->
         <!-- see surefire-java8 and surefire-java9+ profiles -->
@@ -64,7 +65,7 @@
         </surefireArgLine>
         <skip.tests>false</skip.tests>
         <!-- this will throw an error if we use wrong apis -->
-        <maven.compiler.release>8</maven.compiler.release>
+       <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -100,7 +101,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.2.0</version>
+            <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -174,21 +175,21 @@
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
-            <version>1.9.1</version>
+            <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.11.0</version>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -471,7 +472,7 @@
                             <dependency>
                                 <groupId>com.github.spotbugs</groupId>
                                 <artifactId>spotbugs</artifactId>
-                                <version>4.8.6</version>
+                                <version>4.9.0</version>
                             </dependency>
                         </dependencies>
                         <executions>
@@ -541,6 +542,8 @@
         <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
         <profile>
             <id>java8</id>
+            <!-- with the next block we can define a set of sdks which still support java 8, if any of the sdks is not supporting java 8 anymore -->
+            <!--<modules><module></module></modules>-->
             <properties>
                 <toolchain.jdk.version>(1.8,9)</toolchain.jdk.version>
                 <skip.tests>true</skip.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
         <!-- selected automatically by JDK activeation (see https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit-profile-activation) -->
         <profile>
             <id>java8</id>
-            <!-- with the next block we can define a set of sdks which still support java 8, if any of the sdks is not supporting java 8 anymore -->
+            <!-- with the next block we can define a set of artifacts which still support java 8, if any of the artifacts is not supporting java 8 anymore -->
             <!--<modules><module></module></modules>-->
             <properties>
                 <toolchain.jdk.version>(1.8,9)</toolchain.jdk.version>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
@@ -162,7 +163,7 @@
             <scope>test</scope>
         </dependency>
         <!-- uncomment for logoutput during test runs -->
-         <dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.16</version>
@@ -219,14 +220,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.6.6</version>
-                <configuration>
-                    <onlyAnalyze>dev.openfeature.contrib.-</onlyAnalyze>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.1</version>
                 <executions>
@@ -275,6 +268,24 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>codequality</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>4.8.6.6</version>
+                        <configuration>
+                            <onlyAnalyze>dev.openfeature.contrib.-</onlyAnalyze>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <!-- this profile handles running the flagd e2e tests -->
             <id>e2e</id>

--- a/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
+++ b/providers/go-feature-flag/src/main/java/dev/openfeature/contrib/providers/gofeatureflag/GoFeatureFlagProviderOptions.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class GoFeatureFlagProviderOptions {
 
     /**
-     * (mandatory) endpoint contains the DNS of your GO Feature Flag relay proxy example:
+     * (mandatory) endpoint contains the DNS of your GO Feature Flag relay proxy. example:
      * https://mydomain.com/gofeatureflagproxy/
      */
     private String endpoint;


### PR DESCRIPTION
build runs on 2 different java versions:
- 17: all tests and code quality tools
- 8: all tests

build target is version 8, but we use java 17 to generate the packages.

We can at least update checkstyle, spotless, pmd, spotbugs to newer versions, ~~but junit, mockito, assertj, cucumber, can not be updated as we are still running the tests with java 8.~~ Tests are not compiled on java8 so we could update all our test dependencies too. eg. i update mockito to version 5 within this pr

Theoretically, we could not run tests with java8 and only build, to ensure api compatibility :)

as the build is strangely not working now in here - see https://github.com/open-feature-forking/java-sdk-contrib/actions/runs/13217059965 of my fork

## how to test:

```shell
# java 17 and above
mvn verify

#java8 
mvn verify -Pjava8
```

if you want to test, that this wont build successfully on java 8 with newer features, use eg. `String.isBlank()` (java 11) on any string and try to build with java8 :) it will even fail with the default build, informing you, that this is not supported by the language level 8.

## Additional findings:

With this approach we could build everything with Java 17, but target with the release option the desired java version. This would allow different providers to have different baselines. Eg. some providers might want to upgrade to java 11 already. Giving our providers more flexibility overall.

## Todos:

- [x] adapt release please config