### PR TITLE
fix: missing common lang dep

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -114,6 +114,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
             <version>1.47.0</version>


### PR DESCRIPTION
This is used in flagd but not in the pom. It seems like this wasn't caught before because of dumb luck, it was coming in transitively from some other dep that has now dropped it.