### PR TITLE
chore: update testbed

### DIFF
--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/RunFileTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/RunFileTest.java
@@ -28,7 +28,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "dev.openfeature.contrib.providers.flagd.e2e.steps")
 @ConfigurationParameter(key = OBJECT_FACTORY_PROPERTY_NAME, value = "io.cucumber.picocontainer.PicoFactory")
 @IncludeTags("file")
-@ExcludeTags({"unixsocket", "targetURI", "reconnect", "customCert", "events"})
+@ExcludeTags({"unixsocket", "targetURI", "reconnect", "customCert", "events", "flagdcontext"})
 @Testcontainers
 public class RunFileTest {
 


### PR DESCRIPTION
updates test bed and excludes new `flagdcontext` in file mode.