### PR TITLE
fix: enriched context lost on some events

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -10,7 +10,6 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.ImmutableContext;
-import dev.openfeature.sdk.ImmutableStructure;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEvent;
@@ -216,7 +215,10 @@ public class FlagdProvider extends EventProvider {
                     }
                     // intentional fall through, a not-ready change will trigger a ready.
                 case PROVIDER_READY:
-                    // sync metadata is used to enrich the context, and is immutable in flagd, so only need to be fetched onces at READY
+                    /*
+                     * sync metadata is used to enrich the context, and is immutable in flagd,
+                     * so only need to be fetched onces at READY
+                     */
                     if (flagdProviderEvent.getSyncMetadata() != null) {
                         eventsLock.enrichedContext = contextEnricher.apply(flagdProviderEvent.getSyncMetadata());
                     }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -185,19 +185,6 @@ public class FlagdProvider extends EventProvider {
     }
 
     /**
-     * An unmodifiable view of a Structure representing the latest result of the
-     * SyncMetadata.
-     * Set on initial connection and updated with every reconnection.
-     * see:
-     * https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata
-     *
-     * @return Object map representing sync metadata
-     */
-    protected Structure getSyncMetadata() {
-        return new ImmutableStructure(eventsLock.syncMetadata.asMap());
-    }
-
-    /**
      * The updated context mixed into all evaluations based on the sync-metadata.
      *
      * @return context
@@ -211,10 +198,6 @@ public class FlagdProvider extends EventProvider {
 
         synchronized (eventsLock) {
             log.info("FlagdProviderEvent: {}", flagdProviderEvent.getEvent());
-            eventsLock.syncMetadata = flagdProviderEvent.getSyncMetadata();
-            if (flagdProviderEvent.getSyncMetadata() != null) {
-                eventsLock.enrichedContext = contextEnricher.apply(flagdProviderEvent.getSyncMetadata());
-            }
 
             /*
              * We only use Error and Ready as previous states.
@@ -233,6 +216,10 @@ public class FlagdProvider extends EventProvider {
                     }
                     // intentional fall through, a not-ready change will trigger a ready.
                 case PROVIDER_READY:
+                    // sync metadata is used to enrich the context, and is immutable in flagd, so only need to be fetched onces at READY
+                    if (flagdProviderEvent.getSyncMetadata() != null) {
+                        eventsLock.enrichedContext = contextEnricher.apply(flagdProviderEvent.getSyncMetadata());
+                    }
                     onReady();
                     eventsLock.previousEvent = ProviderEvent.PROVIDER_READY;
                     break;
@@ -304,7 +291,6 @@ public class FlagdProvider extends EventProvider {
      */
     static class EventsLock {
         volatile ProviderEvent previousEvent = null;
-        volatile Structure syncMetadata = new ImmutableStructure();
         volatile boolean initialized = false;
         volatile EvaluationContext enrichedContext = new ImmutableContext();
     }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -216,8 +216,8 @@ public class FlagdProvider extends EventProvider {
                     // intentional fall through, a not-ready change will trigger a ready.
                 case PROVIDER_READY:
                     /*
-                     * sync metadata is used to enrich the context, and is immutable in flagd,
-                     * so only need to be fetched onces at READY
+                     * Sync metadata is used to enrich the context, and is immutable in flagd,
+                     * so we only need it to be fetched once at READY.
                      */
                     if (flagdProviderEvent.getSyncMetadata() != null) {
                         eventsLock.enrichedContext = contextEnricher.apply(flagdProviderEvent.getSyncMetadata());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdProviderTest.java
@@ -669,7 +669,6 @@ class FlagdProviderTest {
             provider.initialize(ctx);
 
             // the onConnectionEvent should have updated the sync metadata and the
-            assertEquals(val, provider.getSyncMetadata().getValue(key).asString());
             assertEquals(val, provider.getEnrichedContext().getValue(key).asString());
 
             // call the hook manually and make sure the enriched context is returned

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/RunFileTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/RunFileTest.java
@@ -28,7 +28,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "dev.openfeature.contrib.providers.flagd.e2e.steps")
 @ConfigurationParameter(key = OBJECT_FACTORY_PROPERTY_NAME, value = "io.cucumber.picocontainer.PicoFactory")
 @IncludeTags("file")
-@ExcludeTags({"unixsocket", "targetURI", "reconnect", "customCert", "events", "flagdcontext"})
+@ExcludeTags({"unixsocket", "targetURI", "reconnect", "customCert", "events", "contextEnrichment"})
 @Testcontainers
 public class RunFileTest {
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/EventSteps.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/EventSteps.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.parallel.Isolated;
 @Slf4j
 public class EventSteps extends AbstractSteps {
 
+    private static final int EVENT_TIMEOUT_MS = 12_000;
+
     public EventSteps(State state) {
         super(state);
         state.events = new LinkedList<>();
@@ -47,12 +49,12 @@ public class EventSteps extends AbstractSteps {
 
     @When("a {} event was fired")
     public void eventWasFired(String eventType) throws InterruptedException {
-        eventHandlerShouldBeExecutedWithin(eventType, 8000);
+        eventHandlerShouldBeExecutedWithin(eventType, EVENT_TIMEOUT_MS);
     }
 
     @Then("the {} event handler should have been executed")
     public void eventHandlerShouldBeExecuted(String eventType) {
-        eventHandlerShouldBeExecutedWithin(eventType, 10000);
+        eventHandlerShouldBeExecutedWithin(eventType, EVENT_TIMEOUT_MS);
     }
 
     @Then("the {} event handler should have been executed within {int}ms")


### PR DESCRIPTION
Fixes an issue where automatically injected context (from flagd or other server impls) is lost with the emission of events other than READY. Implements the new e2e test [here](https://github.com/open-feature/flagd-testbed/pull/227/files#diff-b0a030e02c700b22c3a835e8b3ef8e80e58eee676c2130109073a8d72e0ea1efR153) (which failed before the change).