### PR TITLE
fix: RPC mode does not honor timeout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "providers/flagd/test-harness"]
 	path = providers/flagd/test-harness
 	url = https://github.com/open-feature/test-harness.git
-	branch = v2.2.0
+	branch = v2.5.0
 [submodule "providers/flagd/spec"]
 	path = providers/flagd/spec
 	url = https://github.com/open-feature/spec.git


### PR DESCRIPTION
During the refactoring of the connection the timeout for unary calls got lost. This adds the timeout back into the mix.

TODO:
- [x] adapt gherkin tests for contextEnrichment to do handle stale separately for file and inprocess - https://github.com/open-feature/flagd-testbed/pull/229

## How to test:

currently one e2e test is failing, which should fail, as this one should actually not work for rpc.

blocked by https://github.com/open-feature/flagd-testbed/pull/229
