### PR TITLE
fix(flagd): improve error messages for validation, if there are multiple errors

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParser.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParser.java
@@ -14,9 +14,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 /** flagd feature flag configuration parser. */
@@ -59,7 +61,11 @@ public class FlagParser {
                 Set<ValidationMessage> validationMessages = SCHEMA_VALIDATOR.validate(parser.readValueAsTree());
 
                 if (!validationMessages.isEmpty()) {
-                    String message = String.format("Invalid flag configuration: %s", validationMessages.toArray());
+                    List<String> distinctMessages = validationMessages.stream()
+                            .map(ValidationMessage::toString)
+                            .distinct()
+                            .collect(Collectors.toList());
+                    String message = String.format("Invalid flag configuration: %s", distinctMessages);
                     log.warn(message);
                     if (throwIfInvalid) {
                         throw new IllegalArgumentException(message);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/TestUtils.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/TestUtils.java
@@ -18,6 +18,7 @@ public class TestUtils {
     public static final String INVALID_FLAG_SET_METADATA = "flagConfigurations/invalid-flag-set-metadata.json";
     public static final String VALID_FLAG_SET_METADATA = "flagConfigurations/valid-flag-set-metadata.json";
     public static final String INVALID_CFG = "flagConfigurations/invalid-configuration.json";
+    public static final String INVALID_FLAG_MULTIPLE_ERRORS = "flagConfigurations/invalid-flag-multiple-errors.json";
     public static final String UPDATABLE_FILE = "flagConfigurations/updatableFlags.json";
 
     public static String getFlagsFromResource(final String file) throws IOException {

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParserTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParserTest.java
@@ -3,17 +3,18 @@ package dev.openfeature.contrib.providers.flagd.resolver.process.model;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_CFG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG_METADATA;
+import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG_MULTIPLE_ERRORS;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.INVALID_FLAG_SET_METADATA;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_FLAG_SET_METADATA;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_LONG;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_SIMPLE;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.VALID_SIMPLE_EXTRA_FIELD;
 import static dev.openfeature.contrib.providers.flagd.resolver.process.TestUtils.getFlagsFromResource;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Map;
@@ -135,24 +136,36 @@ class FlagParserTest {
     @Test
     void invalidFlagThrowsError() throws IOException {
         String flagString = getFlagsFromResource(INVALID_FLAG);
-        assertThrows(IllegalArgumentException.class, () -> FlagParser.parseString(flagString, true));
+        assertThatThrownBy(() -> FlagParser.parseString(flagString, true)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void invalidFlagMetadataThrowsError() throws IOException {
         String flagString = getFlagsFromResource(INVALID_FLAG_METADATA);
-        assertThrows(IllegalArgumentException.class, () -> FlagParser.parseString(flagString, true));
+        assertThatThrownBy(() -> FlagParser.parseString(flagString, true)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void invalidFlagSetMetadataThrowsError() throws IOException {
         String flagString = getFlagsFromResource(INVALID_FLAG_SET_METADATA);
-        assertThrows(IllegalArgumentException.class, () -> FlagParser.parseString(flagString, true));
+        assertThatThrownBy(() -> FlagParser.parseString(flagString, true)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void invalidConfigurationsThrowsError() throws IOException {
         String flagString = getFlagsFromResource(INVALID_CFG);
-        assertThrows(IllegalArgumentException.class, () -> FlagParser.parseString(flagString, true));
+        assertThatThrownBy(() -> FlagParser.parseString(flagString, true)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void invalidWithMulipleErrorsConfigurationsThrowsError() throws IOException {
+        String flagString = getFlagsFromResource(INVALID_FLAG_MULTIPLE_ERRORS);
+        assertThatThrownBy(() -> FlagParser.parseString(flagString, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be valid to one and only one schema")
+                .hasMessageContaining("$.flags.myBoolFlag: required property 'defaultVariant' not found")
+                .hasMessageContaining("$.flags.myBoolFlag: required property 'state' not found")
+                .hasMessageContaining(
+                        "$.flags.myBoolFlag.metadata.invalid: object found, [string, number, boolean] expected");
     }
 }

--- a/providers/flagd/src/test/resources/flagConfigurations/invalid-flag-multiple-errors.json
+++ b/providers/flagd/src/test/resources/flagConfigurations/invalid-flag-multiple-errors.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../main/resources/flagd/schemas/flags.json",
+  "flags": {
+    "myBoolFlag": {
+      "metadata": {
+        "string": "string",
+        "boolean": true,
+        "float": 1.234,
+        "invalid": {
+          "a": "a"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
we are currently only returning the first error in the list of our validation violations. this makes debugging and fixing easy. with this pr we are adding more information to the log

```
 WARN dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser - Invalid flag configuration: [$.flags.myBoolFlag: must be valid to one and only one schema, but 0 are valid, $.flags.myBoolFlag: required property 'defaultVariant' not found, $.flags.myBoolFlag: required property 'defaultVariant' not found, $.flags.myBoolFlag: required property 'defaultVariant' not found, $.flags.myBoolFlag: required property 'defaultVariant' not found]
```


