### PR TITLE
build: Ensure compatibility with newer Java versions by increasing our java build version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         matrix:
           os: [ubuntu-latest]
           build:
-              - java: 17
+              - java: 21
                 profile: codequality
               - java: 8
                 profile: java8

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,11 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
           server-id: ossrh

--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,10 @@
     </scm>
 
     <properties>
-        <toolchain.jdk.version>[17,)</toolchain.jdk.version>
-        <junit.jupiter.version>5.11.4</junit.jupiter.version>
+        <toolchain.jdk.version>[21,)</toolchain.jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <module-name>${groupId}.${artifactId}</module-name>
-        <io.cucumber.version>7.21.1</io.cucumber.version>
-        <org.mockito.version>5.2.0</org.mockito.version>
         <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
         <!--  This is required for later correct replacement of surefireArgLine -->
         <!-- see surefire-java8 and surefire-java9+ profiles -->
@@ -65,8 +62,34 @@
         </surefireArgLine>
         <skip.tests>false</skip.tests>
         <!-- this will throw an error if we use APIs not available in the specified version -->
-       <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.12.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>7.21.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>5.15.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -101,27 +124,8 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Start mockito workaround -->
-        <!-- https://github.com/mockito/mockito/issues/3121 -->
-        <!-- These are transitive dependencies of mockito we are forcing -->
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.17.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy-agent</artifactId>
-            <version>1.17.2</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- End mockito workaround-->
 
         <dependency>
             <groupId>uk.org.lidalia</groupId>
@@ -140,35 +144,30 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>1.11.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -182,35 +181,24 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.15.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>${io.cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit-platform-engine</artifactId>
-            <version>${io.cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-picocontainer</artifactId>
-            <version>${io.cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -401,6 +389,9 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <maven.compiler.proc>full</maven.compiler.proc>
+            </properties>
             <build>
                 <plugins>
                     <!-- CODE QUALITY TOOLS -->

--- a/tools/junit-openfeature/pom.xml
+++ b/tools/junit-openfeature/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
this pull request updates our build java version to 21 - to enable the compiler option `proc` which we need for lombok to be working with newer java versions, see details further below

Furthermore we changing junit to use the bom, rather then specifying a version per artifact.

Java changed the way how it processes annotations:

```
As of JDK 23, annotation processing is only run with some explicit configuration of annotation processing or with an explicit request to run annotation processing on the javac command line.
```

this messes with lombok, this compiler configuration will change the default behavior, so it works with java 23
