### PR TITLE
feat(flagd): Support supplying providerID for in-process resolver as an option

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -116,7 +116,7 @@ Given below are the supported configurations:
 | streamDeadlineMs      | FLAGD_STREAM_DEADLINE_MS       | int                      | 600000    | rpc & in-process        |
 | keepAliveTime         | FLAGD_KEEP_ALIVE_TIME_MS       | long                     | 0         | rpc & in-process        |
 | selector              | FLAGD_SOURCE_SELECTOR          | String                   | null      | in-process              |
-| providerId            | FLAGD_SOURCE_PROVIDER_ID       | String                   | null      | in-process              |
+| providerID            | FLAGD_SOURCE_PROVIDER_ID       | String                   | null      | in-process              |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled   | lru       | rpc                     |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                      | 1000      | rpc                     |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                      | 5         | rpc                     |

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -116,6 +116,7 @@ Given below are the supported configurations:
 | streamDeadlineMs      | FLAGD_STREAM_DEADLINE_MS       | int                      | 600000    | rpc & in-process        |
 | keepAliveTime         | FLAGD_KEEP_ALIVE_TIME_MS       | long                     | 0         | rpc & in-process        |
 | selector              | FLAGD_SOURCE_SELECTOR          | String                   | null      | in-process              |
+| providerId            | FLAGD_SOURCE_PROVIDER_ID       | String                   | null      | in-process              |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled   | lru       | rpc                     |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                      | 1000      | rpc                     |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                      | 5         | rpc                     |

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -116,7 +116,7 @@ Given below are the supported configurations:
 | streamDeadlineMs      | FLAGD_STREAM_DEADLINE_MS       | int                      | 600000    | rpc & in-process        |
 | keepAliveTime         | FLAGD_KEEP_ALIVE_TIME_MS       | long                     | 0         | rpc & in-process        |
 | selector              | FLAGD_SOURCE_SELECTOR          | String                   | null      | in-process              |
-| providerID            | FLAGD_SOURCE_PROVIDER_ID       | String                   | null      | in-process              |
+| providerId            | FLAGD_SOURCE_PROVIDER_ID       | String                   | null      | in-process              |
 | cache                 | FLAGD_CACHE                    | String - lru, disabled   | lru       | rpc                     |
 | maxCacheSize          | FLAGD_MAX_CACHE_SIZE           | int                      | 1000      | rpc                     |
 | maxEventStreamRetries | FLAGD_MAX_EVENT_STREAM_RETRIES | int                      | 5         | rpc                     |

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -33,6 +33,7 @@ public final class Config {
     static final String DEADLINE_MS_ENV_VAR_NAME = "FLAGD_DEADLINE_MS";
     static final String STREAM_DEADLINE_MS_ENV_VAR_NAME = "FLAGD_STREAM_DEADLINE_MS";
     static final String SOURCE_SELECTOR_ENV_VAR_NAME = "FLAGD_SOURCE_SELECTOR";
+    static final String SOURCE_PROVIDER_ID_ENV_VAR_NAME = "FLAGD_SOURCE_PROVIDER_ID";
     static final String OFFLINE_SOURCE_PATH = "FLAGD_OFFLINE_FLAG_SOURCE_PATH";
     static final String OFFLINE_POLL_MS = "FLAGD_OFFLINE_POLL_MS";
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME_OLD = "FLAGD_KEEP_ALIVE_TIME";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -108,6 +108,12 @@ public class FlagdOptions {
     private String selector = fallBackToEnvOrDefault(Config.SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
     /**
+     * ProviderId to be used with flag sync gRPC contract.
+     **/
+    @Builder.Default
+    private String providerId = fallBackToEnvOrDefault(Config.SOURCE_PROVIDER_ID_ENV_VAR_NAME, null);
+
+    /**
      * gRPC client KeepAlive in milliseconds. Disabled with 0.
      * Defaults to 0 (disabled).
      **/

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -108,10 +108,10 @@ public class FlagdOptions {
     private String selector = fallBackToEnvOrDefault(Config.SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
     /**
-     * ProviderId to be used with flag sync gRPC contract.
+     * ProviderID to be used with flag sync gRPC contract.
      **/
     @Builder.Default
-    private String providerId = fallBackToEnvOrDefault(Config.SOURCE_PROVIDER_ID_ENV_VAR_NAME, null);
+    private String providerID = fallBackToEnvOrDefault(Config.SOURCE_PROVIDER_ID_ENV_VAR_NAME, null);
 
     /**
      * gRPC client KeepAlive in milliseconds. Disabled with 0.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -108,10 +108,10 @@ public class FlagdOptions {
     private String selector = fallBackToEnvOrDefault(Config.SOURCE_SELECTOR_ENV_VAR_NAME, null);
 
     /**
-     * ProviderID to be used with flag sync gRPC contract.
+     * ProviderId to be used with flag sync gRPC contract.
      **/
     @Builder.Default
-    private String providerID = fallBackToEnvOrDefault(Config.SOURCE_PROVIDER_ID_ENV_VAR_NAME, null);
+    private String providerId = fallBackToEnvOrDefault(Config.SOURCE_PROVIDER_ID_ENV_VAR_NAME, null);
 
     /**
      * gRPC client KeepAlive in milliseconds. Disabled with 0.

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
@@ -34,7 +34,7 @@ public class GrpcStreamConnector implements Connector {
     private final BlockingQueue<QueuePayload> blockingQueue = new LinkedBlockingQueue<>(QUEUE_SIZE);
     private final int deadline;
     private final String selector;
-    private final String providerId;
+    private final String providerID;
     private final GrpcConnector<
                     FlagSyncServiceGrpc.FlagSyncServiceStub, FlagSyncServiceGrpc.FlagSyncServiceBlockingStub>
             grpcConnector;
@@ -46,7 +46,7 @@ public class GrpcStreamConnector implements Connector {
     public GrpcStreamConnector(final FlagdOptions options, Consumer<FlagdProviderEvent> onConnectionEvent) {
         deadline = options.getDeadline();
         selector = options.getSelector();
-        providerId = options.getProviderId();
+        providerID = options.getProviderID();
         streamReceiver = new LinkedBlockingQueue<>(QUEUE_SIZE);
         grpcConnector = new GrpcConnector<>(
                 options,
@@ -55,14 +55,14 @@ public class GrpcStreamConnector implements Connector {
                 onConnectionEvent,
                 stub -> {
                     String localSelector = selector;
-                    String localProviderId = providerId;
+                    String localProviderID = providerID;
 
                     final SyncFlagsRequest.Builder syncRequest = SyncFlagsRequest.newBuilder();
                     if (localSelector != null) {
                         syncRequest.setSelector(localSelector);
                     }
-                    if (localProviderId != null) {
-                        syncRequest.setProviderId(localProviderId);
+                    if (localProviderID != null) {
+                        syncRequest.setProviderId(localProviderID);
                     }
 
                     stub.syncFlags(syncRequest.build(), new GrpcStreamHandler(streamReceiver));

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/grpc/GrpcStreamConnector.java
@@ -34,7 +34,7 @@ public class GrpcStreamConnector implements Connector {
     private final BlockingQueue<QueuePayload> blockingQueue = new LinkedBlockingQueue<>(QUEUE_SIZE);
     private final int deadline;
     private final String selector;
-    private final String providerID;
+    private final String providerId;
     private final GrpcConnector<
                     FlagSyncServiceGrpc.FlagSyncServiceStub, FlagSyncServiceGrpc.FlagSyncServiceBlockingStub>
             grpcConnector;
@@ -46,7 +46,7 @@ public class GrpcStreamConnector implements Connector {
     public GrpcStreamConnector(final FlagdOptions options, Consumer<FlagdProviderEvent> onConnectionEvent) {
         deadline = options.getDeadline();
         selector = options.getSelector();
-        providerID = options.getProviderID();
+        providerId = options.getProviderId();
         streamReceiver = new LinkedBlockingQueue<>(QUEUE_SIZE);
         grpcConnector = new GrpcConnector<>(
                 options,
@@ -55,14 +55,14 @@ public class GrpcStreamConnector implements Connector {
                 onConnectionEvent,
                 stub -> {
                     String localSelector = selector;
-                    String localProviderID = providerID;
+                    String localProviderId = providerId;
 
                     final SyncFlagsRequest.Builder syncRequest = SyncFlagsRequest.newBuilder();
                     if (localSelector != null) {
                         syncRequest.setSelector(localSelector);
                     }
-                    if (localProviderID != null) {
-                        syncRequest.setProviderId(localProviderID);
+                    if (localProviderId != null) {
+                        syncRequest.setProviderId(localProviderId);
                     }
 
                     stub.syncFlags(syncRequest.build(), new GrpcStreamHandler(streamReceiver));

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -10,7 +10,6 @@ import static dev.openfeature.contrib.providers.flagd.Config.KEEP_ALIVE_MS_ENV_V
 import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_ENV_VAR;
 import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_IN_PROCESS;
 import static dev.openfeature.contrib.providers.flagd.Config.RESOLVER_RPC;
-import static dev.openfeature.contrib.providers.flagd.Config.Resolver;
 import static dev.openfeature.contrib.providers.flagd.Config.TARGET_URI_ENV_VAR_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.openfeature.contrib.providers.flagd.Config.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.MockConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.Connector;
 import io.opentelemetry.api.OpenTelemetry;
@@ -41,6 +41,7 @@ class FlagdOptionsTest {
         assertEquals(DEFAULT_CACHE, builder.getCacheType());
         assertEquals(DEFAULT_MAX_CACHE_SIZE, builder.getMaxCacheSize());
         assertNull(builder.getSelector());
+        assertNull(builder.getProviderId());
         assertNull(builder.getOpenTelemetry());
         assertNull(builder.getCustomConnector());
         assertNull(builder.getOfflineFlagSourcePath());
@@ -61,6 +62,7 @@ class FlagdOptionsTest {
                 .cacheType("lru")
                 .maxCacheSize(100)
                 .selector("app=weatherApp")
+                .providerId("test/provider/id_1")
                 .openTelemetry(openTelemetry)
                 .customConnector(connector)
                 .resolverType(Resolver.IN_PROCESS)
@@ -75,6 +77,7 @@ class FlagdOptionsTest {
         assertEquals("lru", flagdOptions.getCacheType());
         assertEquals(100, flagdOptions.getMaxCacheSize());
         assertEquals("app=weatherApp", flagdOptions.getSelector());
+        assertEquals("test/provider/id_1", flagdOptions.getProviderId());
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());
         assertEquals(connector, flagdOptions.getCustomConnector());
         assertEquals(Resolver.IN_PROCESS, flagdOptions.getResolverType());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -41,7 +41,7 @@ class FlagdOptionsTest {
         assertEquals(DEFAULT_CACHE, builder.getCacheType());
         assertEquals(DEFAULT_MAX_CACHE_SIZE, builder.getMaxCacheSize());
         assertNull(builder.getSelector());
-        assertNull(builder.getProviderID());
+        assertNull(builder.getProviderId());
         assertNull(builder.getOpenTelemetry());
         assertNull(builder.getCustomConnector());
         assertNull(builder.getOfflineFlagSourcePath());
@@ -62,7 +62,7 @@ class FlagdOptionsTest {
                 .cacheType("lru")
                 .maxCacheSize(100)
                 .selector("app=weatherApp")
-                .providerID("test/provider/id_1")
+                .providerId("test/provider/id_1")
                 .openTelemetry(openTelemetry)
                 .customConnector(connector)
                 .resolverType(Resolver.IN_PROCESS)
@@ -77,7 +77,7 @@ class FlagdOptionsTest {
         assertEquals("lru", flagdOptions.getCacheType());
         assertEquals(100, flagdOptions.getMaxCacheSize());
         assertEquals("app=weatherApp", flagdOptions.getSelector());
-        assertEquals("test/provider/id_1", flagdOptions.getProviderID());
+        assertEquals("test/provider/id_1", flagdOptions.getProviderId());
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());
         assertEquals(connector, flagdOptions.getCustomConnector());
         assertEquals(Resolver.IN_PROCESS, flagdOptions.getResolverType());

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -41,7 +41,7 @@ class FlagdOptionsTest {
         assertEquals(DEFAULT_CACHE, builder.getCacheType());
         assertEquals(DEFAULT_MAX_CACHE_SIZE, builder.getMaxCacheSize());
         assertNull(builder.getSelector());
-        assertNull(builder.getProviderId());
+        assertNull(builder.getProviderID());
         assertNull(builder.getOpenTelemetry());
         assertNull(builder.getCustomConnector());
         assertNull(builder.getOfflineFlagSourcePath());
@@ -62,7 +62,7 @@ class FlagdOptionsTest {
                 .cacheType("lru")
                 .maxCacheSize(100)
                 .selector("app=weatherApp")
-                .providerId("test/provider/id_1")
+                .providerID("test/provider/id_1")
                 .openTelemetry(openTelemetry)
                 .customConnector(connector)
                 .resolverType(Resolver.IN_PROCESS)
@@ -77,7 +77,7 @@ class FlagdOptionsTest {
         assertEquals("lru", flagdOptions.getCacheType());
         assertEquals(100, flagdOptions.getMaxCacheSize());
         assertEquals("app=weatherApp", flagdOptions.getSelector());
-        assertEquals("test/provider/id_1", flagdOptions.getProviderId());
+        assertEquals("test/provider/id_1", flagdOptions.getProviderID());
         assertEquals(openTelemetry, flagdOptions.getOpenTelemetry());
         assertEquals(connector, flagdOptions.getCustomConnector());
         assertEquals(Resolver.IN_PROCESS, flagdOptions.getResolverType());


### PR DESCRIPTION
## This PR
- When the user is using in-process flagd, allows them to supply a providerID string to be in gRPC connections
- Adds tests and documentation for providerID