### PR TITLE
chore: add disable metadata option

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -40,6 +40,16 @@ public class FlagdOptions {
      */
     private int port;
 
+    // TODO: remove the metadata call entirely after https://github.com/open-feature/flagd/issues/1584
+    /**
+     * Disables call to sync.GetMetadata (see: https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata).
+     * Disabling will prevent static context from flagd being used in evaluations.
+     * GetMetadata and this option will be removed.
+     */
+    @Deprecated
+    @Builder.Default
+    private boolean syncMetadataDisabled = false;
+
     /**
      * Use TLS connectivity.
      */


### PR DESCRIPTION
Adds option which disables `GetMetadata` call in in-process mode.

This is a temporarily stop-gap for implementations that don't support metadata, and it will be removed when metadata is deprecated with the completion of: https://github.com/open-feature/flagd/issues/1584

There's no need to implement this in all languages, we'll do it at maintainer discretion according to user need.

cc @cupofcat 