### PR TITLE
chore: adjust noisy log lines

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -193,7 +193,7 @@ public class FlagdProvider extends EventProvider {
 
     @SuppressWarnings("checkstyle:fallthrough")
     private void onProviderEvent(FlagdProviderEvent flagdProviderEvent) {
-        log.info("FlagdProviderEvent event {} ", flagdProviderEvent.getEvent());
+        log.debug("FlagdProviderEvent event {} ", flagdProviderEvent.getEvent());
         synchronized (syncResources) {
             /*
              * We only use Error and Ready as previous states.
@@ -231,7 +231,7 @@ public class FlagdProvider extends EventProvider {
                     break;
 
                 default:
-                    log.info("Unknown event {}", flagdProviderEvent.getEvent());
+                    log.warn("Unknown event {}", flagdProviderEvent.getEvent());
             }
         }
     }
@@ -245,7 +245,7 @@ public class FlagdProvider extends EventProvider {
 
     private void onReady() {
         if (syncResources.initialize()) {
-            log.info("initialized FlagdProvider");
+            log.info("Initialized FlagdProvider");
         }
         if (errorTask != null && !errorTask.isCancelled()) {
             errorTask.cancel(false);
@@ -256,7 +256,7 @@ public class FlagdProvider extends EventProvider {
     }
 
     private void onError() {
-        log.info("Connection lost. Emit STALE event...");
+        log.debug("Stream error. Emitting STALE event and scheduling ERROR event...");
         log.debug("Waiting {}s for connection to become available...", gracePeriod);
         this.emitProviderStale(ProviderEventDetails.builder()
                 .message("there has been an error")
@@ -271,7 +271,7 @@ public class FlagdProvider extends EventProvider {
                     () -> {
                         if (syncResources.getPreviousEvent() == ProviderEvent.PROVIDER_ERROR) {
                             log.debug(
-                                    "Provider did not reconnect successfully within {}s. Emit ERROR event...",
+                                    "Provider did not reconnect successfully within {}s. Emitting ERROR event...",
                                     gracePeriod);
                             flagResolver.onError();
                             this.emitProviderError(ProviderEventDetails.builder()

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -256,8 +256,9 @@ public class FlagdProvider extends EventProvider {
     }
 
     private void onError() {
-        log.debug("Stream error. Emitting STALE event and scheduling ERROR event...");
-        log.debug("Waiting {}s for connection to become available...", gracePeriod);
+        log.debug(
+                "Stream error. Emitting STALE, scheduling ERROR, and waiting {}s for connection to become available.",
+                gracePeriod);
         this.emitProviderStale(ProviderEventDetails.builder()
                 .message("there has been an error")
                 .build());

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -68,18 +68,18 @@ public class InProcessResolver implements Resolver {
                             flagStore.getStateQueue().take();
                     switch (storageStateChange.getStorageState()) {
                         case OK:
-                            log.info("onConnectionEvent.accept ProviderEvent.PROVIDER_CONFIGURATION_CHANGED");
+                            log.debug("onConnectionEvent.accept ProviderEvent.PROVIDER_CONFIGURATION_CHANGED");
                             onConnectionEvent.accept(new FlagdProviderEvent(
                                     ProviderEvent.PROVIDER_CONFIGURATION_CHANGED,
                                     storageStateChange.getChangedFlagsKeys(),
                                     storageStateChange.getSyncMetadata()));
-                            log.info("post onConnectionEvent.accept ProviderEvent.PROVIDER_CONFIGURATION_CHANGED");
+                            log.debug("post onConnectionEvent.accept ProviderEvent.PROVIDER_CONFIGURATION_CHANGED");
                             break;
                         case ERROR:
                             onConnectionEvent.accept(new FlagdProviderEvent(ProviderEvent.PROVIDER_ERROR));
                             break;
                         default:
-                            log.info(String.format(
+                            log.warn(String.format(
                                     "Storage emitted unhandled status: %s", storageStateChange.getStorageState()));
                     }
                 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -143,7 +143,7 @@ public class FlagStore implements Storage {
                     }
                     break;
                 default:
-                    log.info(String.format("Payload with unknown type: %s", payload.getType()));
+                    log.warn(String.format("Payload with unknown type: %s", payload.getType()));
             }
         }
 


### PR DESCRIPTION
Just tweaking some log lines.

My opinion is:

- anything log lines that are "normal" (expected at runtime) should be `debug`
  - stream ending (this is normal with deadlines)
  - change notifications
- startup/shutdown messages are OK at `info`
- unexpected errors (like disconnections) should be `error`
- "weird things" that should never happen, but aren't catastrophic should be `warn`.