### PR TITLE
fix: transient error log-spam, add retry policy

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -271,7 +271,7 @@ public class FlagdProvider extends EventProvider {
             errorTask = errorExecutor.schedule(
                     () -> {
                         if (syncResources.getPreviousEvent() == ProviderEvent.PROVIDER_ERROR) {
-                            log.debug(
+                            log.error(
                                     "Provider did not reconnect successfully within {}s. Emitting ERROR event...",
                                     gracePeriod);
                             flagResolver.onError();

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -5,6 +5,7 @@ import dev.openfeature.contrib.providers.flagd.resolver.common.nameresolvers.Env
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.NameResolverRegistry;
+import io.grpc.Status.Code;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.epoll.Epoll;
@@ -15,11 +16,75 @@ import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 
 /** gRPC channel builder helper. */
 public class ChannelBuilder {
+
+    static final int MAX_RETRY_ATTEMPTS = 3;
+
+    /**
+     * Controls retry (not-reconnection) policy for failed RPCs.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static final Map<String, ?> SERVICE_CONFIG_WITH_RETRY = new HashMap() {
+        {
+            put("methodConfig", Arrays.asList(new HashMap() {
+                {
+                    put(
+                            "name",
+                            Arrays.asList(
+                                    new HashMap() {
+                                        {
+                                            put("service", "flagd.sync.v1.FlagSyncService");
+                                        }
+                                    },
+                                    new HashMap() {
+                                        {
+                                            put("service", "flagd.evaluation.v1.Service");
+                                        }
+                                    }));
+                    put("retryPolicy", new HashMap() {
+                        {
+                            // 1 + 2 + 4
+                            put("maxAttempts", (double) MAX_RETRY_ATTEMPTS);
+                            put("initialBackoff", "1s");
+                            put("maxBackoff", "5s");
+                            put("backoffMultiplier", 2.0);
+                            // status codes to retry on:
+                            put(
+                                    "retryableStatusCodes",
+                                    Arrays.asList(
+                                            /*
+                                             * All codes are retryable except OK or CANCELLED, since anything
+                                             * not listed here causes a very tight loop of retries.
+                                             * CANCELLED is not retryable because it is a client-side termination.
+                                             */
+                                            Code.UNKNOWN.toString(),
+                                            Code.INVALID_ARGUMENT.toString(),
+                                            Code.DEADLINE_EXCEEDED.toString(),
+                                            Code.NOT_FOUND.toString(),
+                                            Code.ALREADY_EXISTS.toString(),
+                                            Code.PERMISSION_DENIED.toString(),
+                                            Code.RESOURCE_EXHAUSTED.toString(),
+                                            Code.FAILED_PRECONDITION.toString(),
+                                            Code.ABORTED.toString(),
+                                            Code.OUT_OF_RANGE.toString(),
+                                            Code.UNIMPLEMENTED.toString(),
+                                            Code.INTERNAL.toString(),
+                                            Code.UNAVAILABLE.toString(),
+                                            Code.DATA_LOSS.toString(),
+                                            Code.UNAUTHENTICATED.toString()));
+                        }
+                    });
+                }
+            }));
+        }
+    };
 
     private ChannelBuilder() {}
 
@@ -45,6 +110,9 @@ public class ChannelBuilder {
                     .eventLoopGroup(new EpollEventLoopGroup())
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()
+                    .defaultServiceConfig(SERVICE_CONFIG_WITH_RETRY)
+                    .maxRetryAttempts(MAX_RETRY_ATTEMPTS)
+                    .enableRetry()
                     .build();
         }
 
@@ -89,7 +157,10 @@ public class ChannelBuilder {
                 builder.intercept(new FlagdGrpcInterceptor(options.getOpenTelemetry()));
             }
 
-            return builder.build();
+            return builder.defaultServiceConfig(SERVICE_CONFIG_WITH_RETRY)
+                    .maxRetryAttempts(MAX_RETRY_ATTEMPTS)
+                    .enableRetry()
+                    .build();
         } catch (SSLException ssle) {
             SslConfigException sslConfigException = new SslConfigException("Error with SSL configuration.");
             sslConfigException.initCause(ssle);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -60,13 +60,14 @@ public class ChannelBuilder {
                                     "retryableStatusCodes",
                                     Arrays.asList(
                                             /*
-                                             * All codes are retryable except OK or CANCELLED, since anything
-                                             * not listed here causes a very tight loop of retries.
+                                             * All codes are retryable except OK, CANCELLED and DEADLINE_EXCEEDED since
+                                             * any others not listed here cause a very tight loop of retries.
                                              * CANCELLED is not retryable because it is a client-side termination.
+                                             * DEADLINE_EXCEEDED is typically a result of a client specified deadline,
+                                             * and definitionally should not result in a tight loop (it's a timeout).
                                              */
                                             Code.UNKNOWN.toString(),
                                             Code.INVALID_ARGUMENT.toString(),
-                                            Code.DEADLINE_EXCEEDED.toString(),
                                             Code.NOT_FOUND.toString(),
                                             Code.ALREADY_EXISTS.toString(),
                                             Code.PERMISSION_DENIED.toString(),

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -25,8 +25,6 @@ import javax.net.ssl.SSLException;
 /** gRPC channel builder helper. */
 public class ChannelBuilder {
 
-    static final int MAX_RETRY_ATTEMPTS = 3;
-
     /**
      * Controls retry (not-reconnection) policy for failed RPCs.
      */
@@ -51,7 +49,7 @@ public class ChannelBuilder {
                     put("retryPolicy", new HashMap() {
                         {
                             // 1 + 2 + 4
-                            put("maxAttempts", (double) MAX_RETRY_ATTEMPTS);
+                            put("maxAttempts", 3.0); // types used here are important, need to be doubles
                             put("initialBackoff", "1s");
                             put("maxBackoff", "5s");
                             put("backoffMultiplier", 2.0);
@@ -112,7 +110,6 @@ public class ChannelBuilder {
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()
                     .defaultServiceConfig(SERVICE_CONFIG_WITH_RETRY)
-                    .maxRetryAttempts(MAX_RETRY_ATTEMPTS)
                     .enableRetry()
                     .build();
         }
@@ -159,7 +156,6 @@ public class ChannelBuilder {
             }
 
             return builder.defaultServiceConfig(SERVICE_CONFIG_WITH_RETRY)
-                    .maxRetryAttempts(MAX_RETRY_ATTEMPTS)
                     .enableRetry()
                     .build();
         } catch (SSLException ssle) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -127,19 +127,19 @@ public class FlagStore implements Storage {
                         }
                         if (!stateBlockingQueue.offer(
                                 new StorageStateChange(StorageState.OK, changedFlagsKeys, metadata))) {
-                            log.warn("Failed to convey OK satus, queue is full");
+                            log.warn("Failed to convey OK status, queue is full");
                         }
                     } catch (Throwable e) {
                         // catch all exceptions and avoid stream listener interruptions
                         log.warn("Invalid flag sync payload from connector", e);
                         if (!stateBlockingQueue.offer(new StorageStateChange(StorageState.STALE))) {
-                            log.warn("Failed to convey STALE satus, queue is full");
+                            log.warn("Failed to convey STALE status, queue is full");
                         }
                     }
                     break;
                 case ERROR:
                     if (!stateBlockingQueue.offer(new StorageStateChange(StorageState.ERROR))) {
-                        log.warn("Failed to convey ERROR satus, queue is full");
+                        log.warn("Failed to convey ERROR status, queue is full");
                     }
                     break;
                 default:

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/SyncMetadataHookTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/SyncMetadataHookTest.java
@@ -23,7 +23,6 @@ public class SyncMetadataHookTest {
 
         suppliedContext.add(key1, val1);
 
-        // when(contextSupplier.get()).thenReturn(new ImmutableContext("some-key"));
         SyncMetadataHook hook = new SyncMetadataHook(contextSupplier);
         Optional<EvaluationContext> context = hook.before(
                 HookContext.builder()

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
@@ -104,8 +104,6 @@ class ChannelBuilderTest {
             when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
             when(mockBuilder.defaultServiceConfig(ChannelBuilder.SERVICE_CONFIG_WITH_RETRY))
                     .thenReturn(mockBuilder);
-            when(mockBuilder.maxRetryAttempts(ChannelBuilder.MAX_RETRY_ATTEMPTS))
-                    .thenReturn(mockBuilder);
             doReturn(mockBuilder).when(mockBuilder).enableRetry();
             when(mockBuilder.usePlaintext()).thenReturn(mockBuilder);
             when(mockBuilder.build()).thenReturn(mockChannel);
@@ -125,6 +123,7 @@ class ChannelBuilderTest {
             verify(mockBuilder).keepAliveTime(1000, TimeUnit.MILLISECONDS);
             verify(mockBuilder).eventLoopGroup(any(EpollEventLoopGroup.class));
             verify(mockBuilder).channelType(EpollDomainSocketChannel.class);
+            verify(mockBuilder).defaultServiceConfig(ChannelBuilder.SERVICE_CONFIG_WITH_RETRY);
             verify(mockBuilder).usePlaintext();
             verify(mockBuilder).build();
         }
@@ -160,7 +159,6 @@ class ChannelBuilderTest {
             nettyMock.verify(() -> NettyChannelBuilder.forTarget("localhost:8080"));
             verify(mockBuilder).defaultServiceConfig(ChannelBuilder.SERVICE_CONFIG_WITH_RETRY);
             verify(mockBuilder).enableRetry();
-            verify(mockBuilder).maxRetryAttempts(ChannelBuilder.MAX_RETRY_ATTEMPTS);
             verify(mockBuilder).build();
         }
     }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
@@ -2,10 +2,15 @@ package dev.openfeature.contrib.providers.flagd.resolver.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -53,6 +58,9 @@ class ChannelBuilderTest {
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
             when(mockBuilder.eventLoopGroup(any(EpollEventLoopGroup.class))).thenReturn(mockBuilder);
             when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
             when(mockBuilder.usePlaintext()).thenReturn(mockBuilder);
             when(mockBuilder.build()).thenReturn(mockChannel);
 
@@ -77,6 +85,87 @@ class ChannelBuilderTest {
     }
 
     @Test
+    @EnabledOnOs(OS.LINUX)
+    void testNettyChannel_withSocketPath_withRetryPolicy() {
+        try (MockedStatic<Epoll> epollMock = mockStatic(Epoll.class);
+                MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
+
+            // Mocks
+            epollMock.when(Epoll::isAvailable).thenReturn(true);
+            NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
+            ManagedChannel mockChannel = mock(ManagedChannel.class);
+
+            nettyMock
+                    .when(() -> NettyChannelBuilder.forAddress(any(DomainSocketAddress.class)))
+                    .thenReturn(mockBuilder);
+
+            when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
+            when(mockBuilder.eventLoopGroup(any(EpollEventLoopGroup.class))).thenReturn(mockBuilder);
+            when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(ChannelBuilder.SERVICE_CONFIG_WITH_RETRY))
+                    .thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(ChannelBuilder.MAX_RETRY_ATTEMPTS))
+                    .thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
+            when(mockBuilder.usePlaintext()).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(mockChannel);
+
+            // Input options
+            FlagdOptions options = FlagdOptions.builder()
+                    .socketPath("/path/to/socket")
+                    .keepAlive(1000)
+                    .build();
+
+            // Call method under test
+            ManagedChannel channel = ChannelBuilder.nettyChannel(options);
+
+            // Assertions
+            assertThat(channel).isEqualTo(mockChannel);
+            nettyMock.verify(() -> NettyChannelBuilder.forAddress(new DomainSocketAddress("/path/to/socket")));
+            verify(mockBuilder).keepAliveTime(1000, TimeUnit.MILLISECONDS);
+            verify(mockBuilder).eventLoopGroup(any(EpollEventLoopGroup.class));
+            verify(mockBuilder).channelType(EpollDomainSocketChannel.class);
+            verify(mockBuilder).usePlaintext();
+            verify(mockBuilder).build();
+        }
+    }
+
+    @Test
+    void testNettyChannel_withRetryPolicy() {
+        try (MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
+            // Mocks
+            NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
+            ManagedChannel mockChannel = mock(ManagedChannel.class);
+            nettyMock
+                    .when(() -> NettyChannelBuilder.forTarget("localhost:8080"))
+                    .thenReturn(mockBuilder);
+
+            when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
+            when(mockBuilder.sslContext(any())).thenReturn(mockBuilder);
+            when(mockBuilder.overrideAuthority(anyString())).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
+            when(mockBuilder.build()).thenReturn(mockChannel);
+
+            // Input options
+            FlagdOptions options =
+                    FlagdOptions.builder().host("localhost").port(8080).build();
+
+            // Call method under test
+            ManagedChannel channel = ChannelBuilder.nettyChannel(options);
+
+            // Assertions
+            assertThat(channel).isEqualTo(mockChannel);
+            nettyMock.verify(() -> NettyChannelBuilder.forTarget("localhost:8080"));
+            verify(mockBuilder).defaultServiceConfig(ChannelBuilder.SERVICE_CONFIG_WITH_RETRY);
+            verify(mockBuilder).enableRetry();
+            verify(mockBuilder).maxRetryAttempts(ChannelBuilder.MAX_RETRY_ATTEMPTS);
+            verify(mockBuilder).build();
+        }
+    }
+
+    @Test
     void testNettyChannel_withTlsAndCert() {
         try (MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
             // Mocks
@@ -88,6 +177,9 @@ class ChannelBuilderTest {
 
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
             when(mockBuilder.sslContext(any())).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
             when(mockBuilder.build()).thenReturn(mockChannel);
 
             File mockCert = mock(File.class);
@@ -130,6 +222,9 @@ class ChannelBuilderTest {
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
             when(mockBuilder.sslContext(any())).thenReturn(mockBuilder);
             when(mockBuilder.overrideAuthority(anyString())).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
             when(mockBuilder.build()).thenReturn(mockChannel);
 
             // Input options
@@ -167,6 +262,9 @@ class ChannelBuilderTest {
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
             when(mockBuilder.sslContext(any())).thenReturn(mockBuilder);
             when(mockBuilder.intercept(anyList())).thenReturn(mockBuilder);
+            when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
+            when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
+            doReturn(mockBuilder).when(mockBuilder).enableRetry();
             when(mockBuilder.build()).thenReturn(mockChannel);
 
             List<ClientInterceptor> clientInterceptors = new ArrayList<ClientInterceptor>();

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelConnectorTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelConnectorTest.java
@@ -89,8 +89,8 @@ class ChannelConnectorTest {
             sync.countDown();
         };
 
-        ChannelConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance = new ChannelConnector<>(
-                FlagdOptions.builder().build(), ServiceGrpc::newBlockingStub, testConsumer, testChannel);
+        ChannelConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance =
+                new ChannelConnector<>(FlagdOptions.builder().build(), testConsumer, testChannel);
 
         instance.initialize();
         // when shutting grpc connector
@@ -117,8 +117,8 @@ class ChannelConnectorTest {
 
         Consumer<FlagdProviderEvent> testConsumer = spy(Consumer.class);
 
-        ChannelConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance = new ChannelConnector<>(
-                FlagdOptions.builder().build(), ServiceGrpc::newBlockingStub, testConsumer, channel);
+        ChannelConnector<ServiceGrpc.ServiceStub, ServiceGrpc.ServiceBlockingStub> instance =
+                new ChannelConnector<>(FlagdOptions.builder().build(), testConsumer, channel);
 
         instance.initialize();
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -43,7 +43,6 @@ class SyncStreamQueueSourceTest {
         when(blockingStub.getMetadata(any())).thenReturn(GetMetadataResponse.getDefaultInstance());
 
         mockConnector = mock(ChannelConnector.class);
-        when(mockConnector.getBlockingStub()).thenReturn(blockingStub);
         doNothing().when(mockConnector).initialize(); // Mock the initialize method
 
         stub = mock(FlagSyncServiceStub.class);
@@ -64,7 +63,7 @@ class SyncStreamQueueSourceTest {
     @Test
     void onNextEnqueuesDataPayload() throws Exception {
         SyncStreamQueueSource connector =
-                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub);
+                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
         connector.init();
         latch = new CountDownLatch(1);
         latch.await();
@@ -85,7 +84,7 @@ class SyncStreamQueueSourceTest {
     void onNextEnqueuesDataPayloadMetadataDisabled() throws Exception {
         // disable GetMetadata call
         SyncStreamQueueSource connector = new SyncStreamQueueSource(
-                FlagdOptions.builder().syncMetadataDisabled(true).build(), mockConnector, stub);
+                FlagdOptions.builder().syncMetadataDisabled(true).build(), mockConnector, stub, blockingStub);
         connector.init();
         latch = new CountDownLatch(1);
         latch.await();
@@ -107,7 +106,7 @@ class SyncStreamQueueSourceTest {
     @Test
     void onErrorEnqueuesDataPayload() throws Exception {
         SyncStreamQueueSource connector =
-                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub);
+                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
         latch = new CountDownLatch(1);
         connector.init();
         latch.await();
@@ -129,7 +128,7 @@ class SyncStreamQueueSourceTest {
     @Test
     void onCompletedEnqueuesDataPayload() throws Exception {
         SyncStreamQueueSource connector =
-                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub);
+                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
         latch = new CountDownLatch(1);
         connector.init();
         latch.await();

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -112,8 +112,8 @@ class SyncStreamQueueSourceTest {
         latch.await();
 
         // fire onError event and reset latch
-        observer.onError(new Exception("fake exception"));
         latch = new CountDownLatch(1);
+        observer.onError(new Exception("fake exception"));
 
         // should enqueue error payload
         BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();
@@ -134,8 +134,8 @@ class SyncStreamQueueSourceTest {
         latch.await();
 
         // fire onCompleted event (graceful stream end) and reset latch
-        observer.onCompleted();
         latch = new CountDownLatch(1);
+        observer.onCompleted();
 
         // should enqueue error payload
         BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -64,8 +64,8 @@ class SyncStreamQueueSourceTest {
     void onNextEnqueuesDataPayload() throws Exception {
         SyncStreamQueueSource connector =
                 new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
-        connector.init();
         latch = new CountDownLatch(1);
+        connector.init();
         latch.await();
 
         // fire onNext (data) event
@@ -85,8 +85,8 @@ class SyncStreamQueueSourceTest {
         // disable GetMetadata call
         SyncStreamQueueSource connector = new SyncStreamQueueSource(
                 FlagdOptions.builder().syncMetadataDisabled(true).build(), mockConnector, stub, blockingStub);
-        connector.init();
         latch = new CountDownLatch(1);
+        connector.init();
         latch.await();
 
         // fire onNext (data) event

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
@@ -44,7 +44,6 @@ class RpcResolverTest {
         blockingStub = mock(ServiceBlockingStub.class);
 
         mockConnector = mock(ChannelConnector.class);
-        when(mockConnector.getBlockingStub()).thenReturn(blockingStub);
         doNothing().when(mockConnector).initialize(); // Mock the initialize method
 
         stub = mock(ServiceStub.class);
@@ -65,7 +64,8 @@ class RpcResolverTest {
 
     @Test
     void onNextWithReadyRunsConsumerWithReady() throws Exception {
-        RpcResolver resolver = new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, mockConnector);
+        RpcResolver resolver =
+                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
         resolver.init();
         latch.await();
 
@@ -83,7 +83,8 @@ class RpcResolverTest {
 
     @Test
     void onNextWithChangedRunsConsumerWithChanged() throws Exception {
-        RpcResolver resolver = new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, mockConnector);
+        RpcResolver resolver =
+                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
         resolver.init();
         latch.await();
 
@@ -101,7 +102,8 @@ class RpcResolverTest {
 
     @Test
     void onCompletedRerunsStreamWithError() throws Exception {
-        RpcResolver resolver = new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, mockConnector);
+        RpcResolver resolver =
+                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
         resolver.init();
         latch.await();
 
@@ -117,7 +119,8 @@ class RpcResolverTest {
 
     @Test
     void onErrorRunsConsumerWithError() throws Exception {
-        RpcResolver resolver = new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, mockConnector);
+        RpcResolver resolver =
+                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
         resolver.init();
         latch.await();
 


### PR DESCRIPTION
Fixes an issue observed when intervening proxies are used (like Istio), where the proxy's upstream is disconnected, resulting in immediate error responses from the proxy (which we still have a healthy TCP connection to) which causes a tight loop in our retry logic for a brief time until the upstream is available. 

This PR adds a retry policy to retry such problematic requests, which also slows down our retry loop. In general this will make the provider more robust to transient errors in streams and unary calls. I will be adding something similar to the flagd spec.

Other minor refactors as well.

There is one possible enhancement we could consider as a separate issue, mentioned [here](https://github.com/open-feature/java-sdk-contrib/pull/1273/files#r1990354285).