### PR TITLE
fix: graceful flagsmith provider shutdown

### DIFF
--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProvider.java
@@ -244,4 +244,12 @@ public class FlagsmithProvider implements FeatureProvider {
                 .filter(e -> e.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> objectToValue(e.getValue()))));
     }
+
+    @Override
+    public void shutdown() {
+        log.info("Flagsmith Provider shutting down");
+        if (flagsmith != null) {
+            flagsmith.close();
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
Properly close the `FlagsmithClient` on shutdown of the provider to support graceful shutdown of OpenFeature.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1304

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

