### PR TITLE
chore: update component owners and flagd readme

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -37,6 +37,8 @@ components:
     - liran2000
   providers/multiprovider:
     - liran2000
+  tools/flagd-http-connector:
+    - liran2000
 
 ignored-authors:
   - renovate-bot

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,6 @@
   "providers/statsig": "0.1.0",
   "providers/multiprovider": "0.0.1",
   "tools/junit-openfeature": "0.1.2",
+  "tools/flagd-http-connector": "0.0.1",
   ".": "0.2.2"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -129,13 +129,6 @@
         </dependency>
 
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
-            <artifactId>slf4j-test</artifactId>
-            <version>1.2.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.27.3</version>

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -94,6 +94,9 @@ FlagdProvider flagdProvider = new FlagdProvider(options);
 >   2. Offline file
 >   3. gRPC
 
+A custom connector implementation example is available at 
+[HTTP Connector](https://github.com/open-feature/java-sdk-contrib/tree/main/tools/flagd-http-connector#http-connector).
+
 ### Configuration options
 
 Most options can be defined in the constructor or as environment variables, with constructor options having the highest

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -81,5 +81,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.4.8-jre</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -134,6 +134,17 @@
         "README.md"
       ]
     },
+    "tools/flagd-http-connector": {
+      "package-name": "dev.openfeature.contrib.tools.flagdhttpconnector",
+      "release-type": "simple",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default",
+      "extra-files": [
+        "pom.xml",
+        "README.md"
+      ]
+    },
     ".": {
       "package-name": "dev.openfeature.contrib.parent",
       "release-type": "simple",


### PR DESCRIPTION
- add _flagd-http-connector_ component owner
- add note on the flagd Java Provider readme per [comment](https://github.com/open-feature/java-sdk-contrib/pull/1299#pullrequestreview-2833338443) by @beeme1mr .
- remove very old _slf4j-test_ dependency from parent pom.
- add _com.google.guava_ dependency to _go-feature-flag_ as it was using it, and CI build failed without it.

@toddbaert _flagd-http-connector_ release-please PR was not created, can you possibly [re-run](https://github.com/googleapis/release-please?tab=readme-ov-file#release-please-bot-does-not-create-a-release-pr-why) release please or something to check it ?