### PR TITLE
chore: added upper bound to parent pom range

### DIFF
--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.hooks</groupId>

--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.hooks</groupId>

--- a/providers/configcat/pom.xml
+++ b/providers/configcat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/configcat/pom.xml
+++ b/providers/configcat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/env-var/pom.xml
+++ b/providers/env-var/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/env-var/pom.xml
+++ b/providers/env-var/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flagsmith/pom.xml
+++ b/providers/flagsmith/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flagsmith/pom.xml
+++ b/providers/flagsmith/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flipt/pom.xml
+++ b/providers/flipt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/flipt/pom.xml
+++ b/providers/flipt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/jsonlogic-eval-provider/pom.xml
+++ b/providers/jsonlogic-eval-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- The group id MUST start with dev.openfeature, or publishing will fail. OpenFeature has verified ownership of this (reversed) domain. -->

--- a/providers/jsonlogic-eval-provider/pom.xml
+++ b/providers/jsonlogic-eval-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- The group id MUST start with dev.openfeature, or publishing will fail. OpenFeature has verified ownership of this (reversed) domain. -->

--- a/providers/multiprovider/pom.xml
+++ b/providers/multiprovider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/multiprovider/pom.xml
+++ b/providers/multiprovider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/statsig/pom.xml
+++ b/providers/statsig/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/statsig/pom.xml
+++ b/providers/statsig/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/unleash/pom.xml
+++ b/providers/unleash/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/providers/unleash/pom.xml
+++ b/providers/unleash/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.providers</groupId>

--- a/tools/flagd-http-connector/pom.xml
+++ b/tools/flagd-http-connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.tools</groupId>

--- a/tools/flagd-http-connector/pom.xml
+++ b/tools/flagd-http-connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.tools</groupId>

--- a/tools/junit-openfeature/pom.xml
+++ b/tools/junit-openfeature/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,)</version>
+        <version>[0.2,0.3)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.tools</groupId>

--- a/tools/junit-openfeature/pom.xml
+++ b/tools/junit-openfeature/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.openfeature.contrib</groupId>
         <artifactId>parent</artifactId>
-        <version>[0.2,0.3)</version>
+        <version>[0.2,1.0)</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>dev.openfeature.contrib.tools</groupId>


### PR DESCRIPTION

## This PR
adds upper bound version for the parent pom

- adds this new feature

### Related Issues

Fixes #1417 

### Notes
see https://maven.apache.org/docs/3.2.2/release-notes.html

```
Support version ranges in parent elements ([MNG-2199](https://issues.apache.org/jira/browse/MNG-2199))
Parent elements can now use bounded ranges in the version specification. You can now consistently use ranges for all intra-project dependencies, of which parents are a special case but still considered a dependency of projects that inherit from them. The following is now permissible:

<project>
  <modelVersion>4.0.0</modelVersion>
  <parent>
    <groupId>org.apache</groupId>
    <artifactId>apache</artifactId>
    <version>[3.0,4.0)</version>
  </parent>
  <groupId>org.apache.maven.its.mng2199</groupId>
  <artifactId>valid</artifactId>
  <version>1</version>
  <packaging>pom</packaging>
</project>

Note this requires Maven 3.2.2 so if you use this new feature it is encouraged you add a Maven Enforcer rule to your build to ensure the use of Maven 3.2.2+.
```

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

