### PR TITLE
fix: stateBlockingQueue size increase to fix missed/delayed messages

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -34,7 +34,7 @@ public class FlagStore implements Storage {
     private final WriteLock writeLock = sync.writeLock();
 
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
-    private final BlockingQueue<StorageStateChange> stateBlockingQueue = new LinkedBlockingQueue<>(1);
+    private final BlockingQueue<StorageStateChange> stateBlockingQueue = new LinkedBlockingQueue<>(4);
     private final Map<String, FeatureFlag> flags = new HashMap<>();
     private final Map<String, Object> flagSetMetadata = new HashMap<>();
 


### PR DESCRIPTION
## This PR
Increases the capacity of the stateBlockingQueue. Currently, we are dropping state changes in some specific cases, and thereby sometimes miss when we enter an error or ready state.

Please comment if you believe the queue should have another capacity.