### PR TITLE
chore: downgrade flagd for flagd http connector to resolve build issues

### DIFF
--- a/tools/flagd-http-connector/pom.xml
+++ b/tools/flagd-http-connector/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.openfeature.contrib.providers</groupId>
             <artifactId>flagd</artifactId>
-            <version>0.11.9</version>
+            <version>0.11.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We need to downgrade the flagd within the HTTP connector, due to a dependency issue. After the next version of flagd, this should be resolved



