### PR TITLE
fix(gofeatureflag): fix etag in tests to be around quotes

### DIFF
--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/api/GoFeatureFlagApiTest.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/api/GoFeatureFlagApiTest.java
@@ -657,7 +657,7 @@ public class GoFeatureFlagApiTest {
             flags.put("TEST2", flag2);
             val want = FlagConfigResponse.builder()
                     .flags(flags)
-                    .etag("valid-flag-config.json")
+                    .etag("\"valid-flag-config.json\"")
                     .lastUpdated(new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz")
                             .parse("Wed, 21 Oct 2015 07:28:00 GMT"))
                     .evaluationContextEnrichment(evaluationContextEnrichment)
@@ -702,7 +702,7 @@ public class GoFeatureFlagApiTest {
             flags.put("TEST2", flag2);
             val want = FlagConfigResponse.builder()
                     .flags(flags)
-                    .etag("valid-flag-config.json")
+                    .etag("\"valid-flag-config.json\"")
                     .lastUpdated(null)
                     .evaluationContextEnrichment(evaluationContextEnrichment)
                     .build();

--- a/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/util/GoffApiMock.java
+++ b/providers/go-feature-flag/src/test/java/dev/openfeature/contrib/providers/gofeatureflag/util/GoffApiMock.java
@@ -132,7 +132,7 @@ public class GoffApiMock {
                     return new MockResponse()
                             .setResponseCode(200)
                             .setBody(TestUtils.readMockResponse("flag_config_responses/", configLocation))
-                            .addHeader(Const.HTTP_HEADER_ETAG, "different-etag")
+                            .addHeader(Const.HTTP_HEADER_ETAG, "\"different-etag\"")
                             .addHeader(Const.HTTP_HEADER_LAST_MODIFIED, "Wed, 21 Oct 2015 05:28:00 GMT");
                 }
                 break;
@@ -153,7 +153,7 @@ public class GoffApiMock {
             return new MockResponse()
                     .setResponseCode(200)
                     .setBody(TestUtils.readMockResponse("flag_config_responses/", configLocation))
-                    .addHeader(Const.HTTP_HEADER_ETAG, configLocation)
+                    .addHeader(Const.HTTP_HEADER_ETAG, "\"" + configLocation + "\"")
                     .addHeader(Const.HTTP_HEADER_LAST_MODIFIED, "Wed, 21 Oct 2015 07:28:00 GMT");
         }
         switch (etag) {
@@ -171,13 +171,13 @@ public class GoffApiMock {
                 return new MockResponse()
                         .setResponseCode(200)
                         .setBody(TestUtils.readMockResponse("flag_config_responses/", configLocation))
-                        .addHeader(Const.HTTP_HEADER_ETAG, configLocation)
+                        .addHeader(Const.HTTP_HEADER_ETAG, "\"" + configLocation + "\"")
                         .addHeader(Const.HTTP_HEADER_LAST_MODIFIED, "Wed, 21 Oct 2015 07:2 GMT");
             default:
                 return new MockResponse()
                         .setResponseCode(200)
                         .setBody(TestUtils.readMockResponse("flag_config_responses/", configLocation))
-                        .addHeader(Const.HTTP_HEADER_ETAG, configLocation)
+                        .addHeader(Const.HTTP_HEADER_ETAG, "\"" + configLocation + "\"")
                         .addHeader(Const.HTTP_HEADER_LAST_MODIFIED, "Wed, 21 Oct 2015 07:28:00 GMT");
         }
     }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
fix etag in tests to be around quotes