### PR TITLE
fix: remove redundant metadata error logs within grace period

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -141,7 +141,7 @@ public class SyncStreamQueueSource implements QueueSource {
 
                         metadataResponse = localStub.getMetadata(metadataRequest.build());
                     } catch (Exception metaEx) {
-                        // cancel the stream if the getMetadata fails, but we can keep this log quiet since the stream is restarted with this exception
+                        // cancel the stream if the getMetadata fails, but we can keep this log quiet since the stream is cancelled/restarted with this exception
                         log.debug("Metadata exception: {}, cancelling stream", metaEx.getMessage(), metaEx);
                         context.cancel(metaEx);
                     }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -141,7 +141,8 @@ public class SyncStreamQueueSource implements QueueSource {
 
                         metadataResponse = localStub.getMetadata(metadataRequest.build());
                     } catch (Exception metaEx) {
-                        // cancel the stream if the getMetadata fails, but we can keep this log quiet since the stream is cancelled/restarted with this exception
+                        // cancel the stream if the getMetadata fails
+                        // we can keep this log quiet since the stream is cancelled/restarted with this exception
                         log.debug("Metadata exception: {}, cancelling stream", metaEx.getMessage(), metaEx);
                         context.cancel(metaEx);
                     }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -141,7 +141,8 @@ public class SyncStreamQueueSource implements QueueSource {
 
                         metadataResponse = localStub.getMetadata(metadataRequest.build());
                     } catch (Exception metaEx) {
-                        log.error("Metadata exception: {}, cancelling stream", metaEx.getMessage(), metaEx);
+                        // cancel the stream if the getMetadata fails, but we can keep this log quiet since the stream is restarted with this exception
+                        log.debug("Metadata exception: {}, cancelling stream", metaEx.getMessage(), metaEx);
                         context.cancel(metaEx);
                     }
                 }


### PR DESCRIPTION
For now (until https://github.com/open-feature/flagd/issues/1584) is done, we make the `getMetadata` request when the stream starts. If the `getMetadata` fails, we kill the stream and the normal reconnect loop executes.

This just changes a redundant error log to debug, since we don't want any errors until the grace period expires.