### PR TITLE
feat: Add dedicated annotations for boolean, String, int and double flags in Junit5 extension

### DIFF
--- a/tools/junit-openfeature/pom.xml
+++ b/tools/junit-openfeature/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
             <version>2.3.0</version>

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlag.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlag.java
@@ -1,0 +1,28 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Repeatable annotation that allows you to define boolean feature flags for the default domain.
+ * Can be used as a standalone flag configuration but also within {@link OpenFeature}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(BooleanFlags.class)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface BooleanFlag {
+    /**
+     * The key of the FeatureFlag.
+     */
+    String name();
+
+    /**
+     * The value of the FeatureFlag.
+     */
+    boolean value();
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlags.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlags.java
@@ -1,0 +1,20 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Collection of {@link BooleanFlag} configurations.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface BooleanFlags {
+    /**
+     * Collection of {@link BooleanFlag} configurations.
+     */
+    BooleanFlag[] value() default {};
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlag.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlag.java
@@ -1,0 +1,27 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Repeatable annotation that allows you to define double feature flags for the default domain.
+ * Can be used as a standalone flag configuration but also within {@link OpenFeature}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(DoubleFlags.class)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface DoubleFlag {
+    /**
+     * The key of the FeatureFlag.
+     */
+    String name();
+    /**
+     * The value of the FeatureFlag.
+     */
+    double value();
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlags.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlags.java
@@ -1,0 +1,20 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Collection of {@link DoubleFlag} configurations.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface DoubleFlags {
+    /**
+     * Collection of {@link DoubleFlag} configurations.
+     */
+    DoubleFlag[] value() default {};
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlag.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlag.java
@@ -1,0 +1,27 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Repeatable annotation that allows you to define integer feature flags for the default domain.
+ * Can be used as a standalone flag configuration but also within {@link OpenFeature}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(IntegerFlags.class)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface IntegerFlag {
+    /**
+     * The key of the FeatureFlag.
+     */
+    String name();
+    /**
+     * The value of the FeatureFlag.
+     */
+    int value();
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlags.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlags.java
@@ -1,0 +1,20 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Collection of {@link IntegerFlag} configurations.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface IntegerFlags {
+    /**
+     * Collection of {@link IntegerFlag} configurations.
+     */
+    IntegerFlag[] value() default {};
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeature.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeature.java
@@ -10,6 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Annotation for generating an extended configuration for OpenFeature.
  * This annotation allows you to specify a list of flags for a specific domain.
+ * <p>
+ * Flags with duplicate names across different flag arrays
+ * (e.g., in {@link  OpenFeature#value()} and {@link  OpenFeature#booleanFlags()}
+ * or {@link  OpenFeature#booleanFlags()} and {@link  OpenFeature#stringFlags()})
+ * are not permitted and will result in an {@link IllegalArgumentException}.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
@@ -23,5 +28,21 @@ public @interface OpenFeature {
     /**
      * Collection of {@link Flag} configurations for this domain.
      */
-    Flag[] value();
+    Flag[] value() default {};
+    /**
+     * Collection of {@link BooleanFlag} configurations for this domain.
+     */
+    BooleanFlag[] booleanFlags() default {};
+    /**
+     * Collection of {@link StringFlag} configurations for this domain.
+     */
+    StringFlag[] stringFlags() default {};
+    /**
+     * Collection of {@link IntegerFlag} configurations for this domain.
+     */
+    IntegerFlag[] integerFlags() default {};
+    /**
+     * Collection of {@link DoubleFlag} configurations for this domain.
+     */
+    DoubleFlag[] doubleFlags() default {};
 }

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeatureExtension.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/OpenFeatureExtension.java
@@ -3,9 +3,15 @@ package dev.openfeature.contrib.tools.junitopenfeature;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.providers.memory.Flag;
 import java.lang.reflect.Method;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.BooleanUtils;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -23,19 +29,83 @@ public class OpenFeatureExtension implements BeforeEachCallback, AfterEachCallba
 
     private static Map<String, Map<String, Flag<?>>> handleExtendedConfiguration(
             ExtensionContext extensionContext, Map<String, Map<String, Flag<?>>> configuration) {
-        PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(extensionContext, OpenFeature.class)
-                .forEachOrdered(annotation -> {
-                    Map<String, Flag<?>> domainFlags = configuration.getOrDefault(annotation.domain(), new HashMap<>());
+        List<OpenFeature> openFeatureAnnotationList = PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(
+                        extensionContext, OpenFeature.class)
+                .collect(Collectors.toList());
+        Map<String, Set<String>> nonTypedFlagNamesByDomain = getFlagNamesByDomain(openFeatureAnnotationList);
+        openFeatureAnnotationList.forEach(annotation -> {
+            Map<String, Flag<?>> domainFlags = configuration.getOrDefault(annotation.domain(), new HashMap<>());
 
-                    Arrays.stream(annotation.value())
-                            .filter(flag -> !domainFlags.containsKey(flag.name()))
-                            .forEach(flag -> {
-                                Flag.FlagBuilder<?> builder = generateFlagBuilder(flag);
-                                domainFlags.put(flag.name(), builder.build());
-                            });
-                    configuration.put(annotation.domain(), domainFlags);
-                });
+            Arrays.stream(annotation.value())
+                    .filter(flag -> !domainFlags.containsKey(flag.name()))
+                    .forEach(flag -> {
+                        Flag.FlagBuilder<?> builder = generateFlagBuilder(flag);
+                        domainFlags.put(flag.name(), builder.build());
+                    });
+            addTypedFlags(
+                    annotation,
+                    domainFlags,
+                    nonTypedFlagNamesByDomain.getOrDefault(annotation.domain(), new HashSet<>()));
+            configuration.put(annotation.domain(), domainFlags);
+        });
         return configuration;
+    }
+
+    private static Map<String, Set<String>> getFlagNamesByDomain(List<OpenFeature> openFeatureList) {
+        return openFeatureList.stream()
+                .map(o -> {
+                    Set<String> flagNames = Arrays.stream(o.value())
+                            .map(dev.openfeature.contrib.tools.junitopenfeature.Flag::name)
+                            .collect(Collectors.toSet());
+                    return new AbstractMap.SimpleEntry<>(o.domain(), flagNames);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (t1, t2) -> {
+                    t1.addAll(t2);
+                    return t1;
+                }));
+    }
+
+    private static void addTypedFlags(OpenFeature annotation, Map<String, Flag<?>> domainFlags, Set<String> flagNames) {
+        addBooleanFlags(Arrays.stream(annotation.booleanFlags()), domainFlags, flagNames);
+        addStringFlags(Arrays.stream(annotation.stringFlags()), domainFlags, flagNames);
+        addIntegerFlags(Arrays.stream(annotation.integerFlags()), domainFlags, flagNames);
+        addDoubleFlags(Arrays.stream(annotation.doubleFlags()), domainFlags, flagNames);
+    }
+
+    private static void addBooleanFlags(
+            Stream<BooleanFlag> booleanFlags, Map<String, Flag<?>> domainFlags, Set<String> flagNames) {
+
+        booleanFlags.forEach(flag -> addFlag(domainFlags, flagNames, flag.name(), flag.value()));
+    }
+
+    private static void addStringFlags(
+            Stream<StringFlag> stringFlags, Map<String, Flag<?>> domainFlags, Set<String> flagNames) {
+        stringFlags.forEach(flag -> addFlag(domainFlags, flagNames, flag.name(), flag.value()));
+    }
+
+    private static void addIntegerFlags(
+            Stream<IntegerFlag> integerFlags, Map<String, Flag<?>> domainFlags, Set<String> flagNames) {
+        integerFlags.forEach(flag -> addFlag(domainFlags, flagNames, flag.name(), flag.value()));
+    }
+
+    private static void addDoubleFlags(
+            Stream<DoubleFlag> doubleFlags, Map<String, Flag<?>> domainFlags, Set<String> flagNames) {
+        doubleFlags.forEach(flag -> addFlag(domainFlags, flagNames, flag.name(), flag.value()));
+    }
+
+    private static <T> void addFlag(
+            Map<String, Flag<?>> domainFlags, Set<String> domainFlagNames, String flagName, T value) {
+        if (domainFlagNames.contains(flagName)) {
+            throw new IllegalArgumentException("Flag with name " + flagName + " already exists. "
+                    + "There shouldn't be @Flag and @" + value.getClass().getSimpleName() + "Flag with the same name!");
+        }
+
+        if (domainFlags.containsKey(flagName)) {
+            return;
+        }
+        Flag.FlagBuilder<Object> builder =
+                Flag.builder().variant(String.valueOf(value), value).defaultVariant(String.valueOf(value));
+        domainFlags.put(flagName, builder.build());
     }
 
     private static Map<String, Map<String, Flag<?>>> handleSimpleConfiguration(ExtensionContext extensionContext) {
@@ -44,16 +114,42 @@ public class OpenFeatureExtension implements BeforeEachCallback, AfterEachCallba
                         extensionContext, OpenFeatureDefaultDomain.class)
                 .map(OpenFeatureDefaultDomain::value)
                 .orElse("");
-        PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(
-                        extensionContext, dev.openfeature.contrib.tools.junitopenfeature.Flag.class)
-                .forEachOrdered(flag -> {
-                    Map<String, Flag<?>> domainFlags = configuration.getOrDefault(defaultDomain, new HashMap<>());
-                    if (!domainFlags.containsKey(flag.name())) {
-                        Flag.FlagBuilder<?> builder = generateFlagBuilder(flag);
-                        domainFlags.put(flag.name(), builder.build());
-                        configuration.put(defaultDomain, domainFlags);
-                    }
-                });
+        Map<String, Flag<?>> domainFlags = configuration.getOrDefault(defaultDomain, new HashMap<>());
+        List<dev.openfeature.contrib.tools.junitopenfeature.Flag> flagList =
+                PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(
+                                extensionContext, dev.openfeature.contrib.tools.junitopenfeature.Flag.class)
+                        .collect(Collectors.toList());
+        Set<String> flagNames = flagList.stream()
+                .map(dev.openfeature.contrib.tools.junitopenfeature.Flag::name)
+                .collect(Collectors.toSet());
+
+        flagList.forEach(flag -> {
+            if (!domainFlags.containsKey(flag.name())) {
+                Flag.FlagBuilder<?> builder = generateFlagBuilder(flag);
+                domainFlags.put(flag.name(), builder.build());
+                configuration.put(defaultDomain, domainFlags);
+            }
+        });
+
+        Stream<BooleanFlag> booleanFlags =
+                PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(extensionContext, BooleanFlag.class);
+        addBooleanFlags(booleanFlags, domainFlags, flagNames);
+
+        Stream<StringFlag> stringFlags =
+                PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(extensionContext, StringFlag.class);
+        addStringFlags(stringFlags, domainFlags, flagNames);
+
+        Stream<IntegerFlag> integerFlags =
+                PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(extensionContext, IntegerFlag.class);
+        addIntegerFlags(integerFlags, domainFlags, flagNames);
+
+        Stream<DoubleFlag> doubleFlags =
+                PioneerAnnotationUtils.findAllEnclosingRepeatableAnnotations(extensionContext, DoubleFlag.class);
+        addDoubleFlags(doubleFlags, domainFlags, flagNames);
+
+        if (!domainFlags.isEmpty()) {
+            configuration.put(defaultDomain, domainFlags);
+        }
 
         return configuration;
     }

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlag.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlag.java
@@ -1,0 +1,28 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Repeatable annotation that allows you to define String feature flags for the default domain.
+ * Can be used as a standalone flag configuration but also within {@link OpenFeature}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(StringFlags.class)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface StringFlag {
+    /**
+     * The key of the FeatureFlag.
+     */
+    String name();
+
+    /**
+     * The value of the FeatureFlag.
+     */
+    String value();
+}

--- a/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlags.java
+++ b/tools/junit-openfeature/src/main/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlags.java
@@ -1,0 +1,20 @@
+package dev.openfeature.contrib.tools.junitopenfeature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Collection of {@link StringFlag} configurations.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(OpenFeatureExtension.class)
+public @interface StringFlags {
+    /**
+     * Collection of {@link StringFlag} configurations.
+     */
+    StringFlag[] value() default {};
+}

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/BooleanFlagTest.java
@@ -1,13 +1,21 @@
 package dev.openfeature.contrib.tools.junitopenfeature;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
 
 class BooleanFlagTest {
 
@@ -20,6 +28,7 @@ class BooleanFlagTest {
         @Flag(name = FLAG, value = "true")
         @Flag(name = FLAG + "2", value = "true")
         @Flag(name = FLAG + "3", value = "true")
+        @BooleanFlag(name = FLAG + "4", value = true)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -27,12 +36,20 @@ class BooleanFlagTest {
                 assertThat(client.getBooleanValue(FLAG, false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
             }
         }
 
         @Test
         @Flag(name = FLAG, value = "true")
         void existingSimpleFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @Test
+        @BooleanFlag(name = FLAG, value = true)
+        void existingSimpleTypedFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
@@ -48,10 +65,48 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
         }
 
+        @Test
+        @BooleanFlag(name = FLAG, value = true)
+        @BooleanFlag(name = FLAG + "2", value = true)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
+        }
+
+        @Test
+        @BooleanFlag(name = FLAG, value = true)
+        @BooleanFlag(name = FLAG, value = false)
+        void duplicatedTypedFlagDoesntOverridePrevious() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @Test
+        @Flag(name = FLAG, value = "true")
+        @Flag(name = FLAG + "2", value = "true")
+        @Flag(name = FLAG + "3", value = "true")
+        @BooleanFlag(name = FLAG + "4", value = true)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = "true")
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @BooleanFlag(name = FLAG, value = true)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
@@ -64,6 +119,7 @@ class BooleanFlagTest {
         @Flag(name = FLAG, value = "true")
         @Flag(name = FLAG + "2", value = "true")
         @Flag(name = FLAG + "3", value = "true")
+        @BooleanFlag(name = FLAG + "4", value = true)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -71,12 +127,20 @@ class BooleanFlagTest {
                 assertThat(client.getBooleanValue(FLAG, false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
             }
         }
 
         @Test
         @Flag(name = FLAG, value = "true")
         void existingSimpleFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @Test
+        @BooleanFlag(name = FLAG, value = true)
+        void existingSimpleTypedFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
@@ -92,10 +156,40 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
         }
 
+        @Test
+        @BooleanFlag(name = FLAG, value = true)
+        @BooleanFlag(name = FLAG + "2", value = true)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
+        }
+
+        @Test
+        @Flag(name = FLAG, value = "true")
+        @Flag(name = FLAG + "2", value = "true")
+        @Flag(name = FLAG + "3", value = "true")
+        @BooleanFlag(name = FLAG + "4", value = true)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = "true")
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
+            assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @BooleanFlag(name = FLAG, value = true)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient("testSpecific");
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
@@ -108,6 +202,13 @@ class BooleanFlagTest {
         void existingFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
+        }
+
+        @Test
+        @OpenFeature(booleanFlags = {@BooleanFlag(name = FLAG + "4", value = true)})
+        void existingBooleanFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
         }
 
         @Test
@@ -125,6 +226,13 @@ class BooleanFlagTest {
         }
 
         @Test
+        @OpenFeature(booleanFlags = @BooleanFlag(name = FLAG, value = true))
+        void nonExistingTypedFlagIsFallbacked() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue("nonSetFlag", false)).isFalse();
+        }
+
+        @Test
         @OpenFeature({
             @Flag(name = FLAG, value = "true"),
             @Flag(name = FLAG + "2", value = "true"),
@@ -137,6 +245,18 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
         }
 
+        @Test
+        @OpenFeature(
+                booleanFlags = {
+                    @BooleanFlag(name = FLAG + "4", value = true),
+                    @BooleanFlag(name = FLAG + "5", value = true),
+                })
+        void multipleTypedFlags() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+            assertThat(client.getBooleanValue(FLAG + "5", false)).isTrue();
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @OpenFeature({@Flag(name = FLAG, value = "true")})
@@ -145,22 +265,43 @@ class BooleanFlagTest {
             assertThat(client.getBooleanValue(FLAG, false)).isTrue();
         }
 
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature(booleanFlags = {@BooleanFlag(name = FLAG + "4", value = true)})
+        void existingTypedFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+        }
+
         @Nested
-        @OpenFeature({
-            @Flag(name = FLAG, value = "true"),
-            @Flag(name = FLAG + "2", value = "false"),
-        })
+        @OpenFeature(
+                value = {
+                    @Flag(name = FLAG, value = "true"),
+                    @Flag(name = FLAG + "2", value = "false"),
+                },
+                booleanFlags = {
+                    @BooleanFlag(name = FLAG + "4", value = true),
+                    @BooleanFlag(name = FLAG + "5", value = false)
+                })
         class MultipleFlags {
             @Test
-            @OpenFeature({
-                @Flag(name = FLAG + "2", value = "true"),
-                @Flag(name = FLAG + "3", value = "true"),
-            })
+            @OpenFeature(
+                    value = {
+                        @Flag(name = FLAG + "2", value = "true"),
+                        @Flag(name = FLAG + "3", value = "true"),
+                    },
+                    booleanFlags = {
+                        @BooleanFlag(name = FLAG + "5", value = true),
+                        @BooleanFlag(name = FLAG + "6", value = true)
+                    })
             void multipleFlags() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getBooleanValue(FLAG, false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "2", false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "3", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "5", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "6", false)).isTrue();
             }
 
             @Test
@@ -169,17 +310,68 @@ class BooleanFlagTest {
                     value = {
                         @Flag(name = FLAG + "2", value = "true"),
                         @Flag(name = FLAG + "3", value = "true"),
+                    },
+                    booleanFlags = {
+                        @BooleanFlag(name = FLAG + "5", value = true),
+                        @BooleanFlag(name = FLAG + "6", value = true)
                     })
             void multipleFlagsOnMultipleDomains() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getBooleanValue(FLAG, false)).isTrue();
                 assertThat(client.getBooleanValue(FLAG + "2", true)).isFalse();
                 assertThat(client.getBooleanValue(FLAG + "3", false)).isFalse();
+                assertThat(client.getBooleanValue(FLAG + "4", false)).isTrue();
+                assertThat(client.getBooleanValue(FLAG + "5", false)).isFalse();
 
                 Client testSpecific = OpenFeatureAPI.getInstance().getClient("testSpecific");
                 assertThat(testSpecific.getBooleanValue(FLAG, false)).isFalse();
                 assertThat(testSpecific.getBooleanValue(FLAG + "2", false)).isTrue();
                 assertThat(testSpecific.getBooleanValue(FLAG + "3", false)).isTrue();
+                assertThat(testSpecific.getBooleanValue(FLAG + "4", false)).isFalse();
+                assertThat(testSpecific.getBooleanValue(FLAG + "5", false)).isTrue();
+                assertThat(testSpecific.getBooleanValue(FLAG + "6", false)).isTrue();
+            }
+        }
+    }
+
+    @Nested
+    class DifferentFlagsWithTheSameNameException {
+
+        @Test
+        void differentFlagTypesWithTheSameNameThrowsException() {
+            Events events = EngineTestKit.engine("junit-jupiter")
+                    .configurationParameter("junit.jupiter.conditions.deactivate", "org.junit.*DisabledCondition")
+                    .selectors(selectClass(ConfigWithException.class))
+                    .execute()
+                    .testEvents()
+                    .failed();
+
+            events.assertThatEvents()
+                    .haveExactly(
+                            2,
+                            event(finishedWithFailure(
+                                    instanceOf(IllegalArgumentException.class),
+                                    message("Flag with name boolean-flag already exists. "
+                                            + "There shouldn't be @Flag and @BooleanFlag with the same name!"))));
+        }
+
+        @Nested
+        @Disabled
+        class ConfigWithException {
+
+            @Test
+            @Flag(name = FLAG, value = "true")
+            @BooleanFlag(name = FLAG, value = true)
+            void simpleConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
+            }
+
+            @Test
+            @OpenFeature(
+                    value = {@Flag(name = FLAG, value = "true")},
+                    booleanFlags = {@BooleanFlag(name = FLAG, value = true)})
+            void extendedConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
             }
         }
     }

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/DoubleFlagTest.java
@@ -1,13 +1,21 @@
 package dev.openfeature.contrib.tools.junitopenfeature;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
 
 class DoubleFlagTest {
 
@@ -30,6 +38,13 @@ class DoubleFlagTest {
         }
 
         @Test
+        @DoubleFlag(name = FLAG, value = 1.d)
+        void existingSimpleTypedFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
@@ -40,10 +55,28 @@ class DoubleFlagTest {
             assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @DoubleFlag(name = FLAG, value = 1.d)
+        @DoubleFlag(name = FLAG + "2", value = 1.d)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @DoubleFlag(name = FLAG, value = 1.d)
+        @DoubleFlag(name = FLAG, value = 2.d)
+        void duplicatedTypedFlagDoesntOverridePrevious() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @DoubleFlag(name = FLAG + "4", value = 1.d)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -51,13 +84,35 @@ class DoubleFlagTest {
                 assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @DoubleFlag(name = FLAG + "4", value = 1.d)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @DoubleFlag(name = FLAG, value = 1.d)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -74,6 +129,13 @@ class DoubleFlagTest {
         }
 
         @Test
+        @DoubleFlag(name = FLAG, value = 1.d)
+        void existingSimpleTypedFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
@@ -84,10 +146,20 @@ class DoubleFlagTest {
             assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @DoubleFlag(name = FLAG, value = 1.d)
+        @DoubleFlag(name = FLAG + "2", value = 1.d)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @DoubleFlag(name = FLAG + "4", value = 1.d)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -95,13 +167,35 @@ class DoubleFlagTest {
                 assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class)
+        @DoubleFlag(name = FLAG + "4", value = 1.d)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @DoubleFlag(name = FLAG, value = 1.d)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
             assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -114,6 +208,13 @@ class DoubleFlagTest {
         void existingFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @OpenFeature(doubleFlags = {@DoubleFlag(name = FLAG + "4", value = 1.d)})
+        void existingDoubleFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Test
@@ -131,6 +232,13 @@ class DoubleFlagTest {
         }
 
         @Test
+        @OpenFeature(doubleFlags = @DoubleFlag(name = FLAG, value = 1.d))
+        void nonExistingTypedFlagIsFallbacked() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue("nonSetFlag", FALLBACK)).isEqualTo(FALLBACK);
+        }
+
+        @Test
         @OpenFeature({
             @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class),
             @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class),
@@ -143,6 +251,18 @@ class DoubleFlagTest {
             assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @OpenFeature(
+                doubleFlags = {
+                    @DoubleFlag(name = FLAG + "4", value = 1.d),
+                    @DoubleFlag(name = FLAG + "5", value = 1.d),
+                })
+        void multipleTypedFlags() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getDoubleValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @OpenFeature({@Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class)})
@@ -151,22 +271,41 @@ class DoubleFlagTest {
             assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature(doubleFlags = {@DoubleFlag(name = FLAG + "4", value = 1.d)})
+        void existingTypedFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
-        @OpenFeature({
-            @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class),
-            @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING_ALTERNATIVE, valueType = Double.class),
-        })
+        @OpenFeature(
+                value = {
+                    @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Double.class),
+                    @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING_ALTERNATIVE, valueType = Double.class),
+                },
+                doubleFlags = {@DoubleFlag(name = FLAG + "4", value = 1.d), @DoubleFlag(name = FLAG + "5", value = 0.0)
+                })
         class MultipleFlags {
             @Test
-            @OpenFeature({
-                @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class),
-                @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class),
-            })
+            @OpenFeature(
+                    value = {
+                        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class),
+                        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class),
+                    },
+                    doubleFlags = {
+                        @DoubleFlag(name = FLAG + "5", value = 1.d),
+                        @DoubleFlag(name = FLAG + "6", value = 1.0)
+                    })
             void multipleFlags() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
 
             @Test
@@ -175,17 +314,68 @@ class DoubleFlagTest {
                     value = {
                         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Double.class),
                         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Double.class),
+                    },
+                    doubleFlags = {
+                        @DoubleFlag(name = FLAG + "5", value = 1.d),
+                        @DoubleFlag(name = FLAG + "6", value = 1.0)
                     })
             void multipleFlagsOnMultipleDomains() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
                 assertThat(client.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(client.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getDoubleValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
 
                 Client testSpecific = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
                 assertThat(testSpecific.getDoubleValue(FLAG, FALLBACK)).isEqualTo(FALLBACK);
                 assertThat(testSpecific.getDoubleValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(testSpecific.getDoubleValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getDoubleValue(FLAG + "4", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(testSpecific.getDoubleValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getDoubleValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
+            }
+        }
+    }
+
+    @Nested
+    class DifferentFlagsWithTheSameNameException {
+
+        @Test
+        void differentFlagTypesWithTheSameNameThrowsException() {
+            Events events = EngineTestKit.engine("junit-jupiter")
+                    .configurationParameter("junit.jupiter.conditions.deactivate", "org.junit.*DisabledCondition")
+                    .selectors(selectClass(ConfigWithException.class))
+                    .execute()
+                    .testEvents()
+                    .failed();
+
+            events.assertThatEvents()
+                    .haveExactly(
+                            2,
+                            event(finishedWithFailure(
+                                    instanceOf(IllegalArgumentException.class),
+                                    message("Flag with name double-flag already exists. "
+                                            + "There shouldn't be @Flag and @DoubleFlag with the same name!"))));
+        }
+
+        @Nested
+        @Disabled
+        class ConfigWithException {
+
+            @Test
+            @Flag(name = FLAG, value = FLAG_VALUE_STRING)
+            @DoubleFlag(name = FLAG, value = 1.0)
+            void simpleConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
+            }
+
+            @Test
+            @OpenFeature(
+                    value = {@Flag(name = FLAG, value = FLAG_VALUE_STRING)},
+                    doubleFlags = {@DoubleFlag(name = FLAG, value = 1.0)})
+            void extendedConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
             }
         }
     }

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/IntegerFlagTest.java
@@ -1,13 +1,21 @@
 package dev.openfeature.contrib.tools.junitopenfeature;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
 
 class IntegerFlagTest {
 
@@ -30,6 +38,13 @@ class IntegerFlagTest {
         }
 
         @Test
+        @IntegerFlag(name = FLAG, value = 1)
+        void existingSimpleTypedFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
@@ -40,10 +55,28 @@ class IntegerFlagTest {
             assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @IntegerFlag(name = FLAG, value = 1)
+        @IntegerFlag(name = FLAG + "2", value = 1)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @IntegerFlag(name = FLAG, value = 1)
+        @IntegerFlag(name = FLAG, value = 2)
+        void duplicatedTypedFlagDoesntOverridePrevious() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @IntegerFlag(name = FLAG + "4", value = 1)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -51,13 +84,35 @@ class IntegerFlagTest {
                 assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @IntegerFlag(name = FLAG + "4", value = 1)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @IntegerFlag(name = FLAG, value = 1)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -74,6 +129,13 @@ class IntegerFlagTest {
         }
 
         @Test
+        @IntegerFlag(name = FLAG, value = 1)
+        void existingSimpleTypedFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
@@ -84,10 +146,20 @@ class IntegerFlagTest {
             assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @IntegerFlag(name = FLAG, value = 1)
+        @IntegerFlag(name = FLAG + "2", value = 1)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @IntegerFlag(name = FLAG + "4", value = 1)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -95,13 +167,35 @@ class IntegerFlagTest {
                 assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class)
+        @IntegerFlag(name = FLAG + "4", value = 1)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @IntegerFlag(name = FLAG, value = 1)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -114,6 +208,13 @@ class IntegerFlagTest {
         void existingFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @OpenFeature(integerFlags = {@IntegerFlag(name = FLAG + "4", value = 1)})
+        void existingIntegerFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Test
@@ -131,16 +232,36 @@ class IntegerFlagTest {
         }
 
         @Test
-        @OpenFeature({
-            @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class),
-            @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class),
-            @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class),
-        })
+        @OpenFeature(integerFlags = @IntegerFlag(name = FLAG, value = 1))
+        void nonExistingTypedFlagIsFallbacked() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue("nonSetFlag", FALLBACK)).isEqualTo(FALLBACK);
+        }
+
+        @Test
+        @OpenFeature(
+                value = {
+                    @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class),
+                    @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class),
+                    @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class),
+                })
         void multipleFlags() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
             assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @OpenFeature(
+                integerFlags = {
+                    @IntegerFlag(name = FLAG + "4", value = 1),
+                    @IntegerFlag(name = FLAG + "5", value = 1),
+                })
+        void multipleTypedFlags() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getIntegerValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @ParameterizedTest
@@ -151,22 +272,40 @@ class IntegerFlagTest {
             assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature(integerFlags = {@IntegerFlag(name = FLAG + "4", value = 1)})
+        void existingTypedFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
-        @OpenFeature({
-            @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class),
-            @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING_ALTERNATIVE, valueType = Integer.class),
-        })
+        @OpenFeature(
+                value = {
+                    @Flag(name = FLAG, value = FLAG_VALUE_STRING, valueType = Integer.class),
+                    @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING_ALTERNATIVE, valueType = Integer.class),
+                },
+                integerFlags = {@IntegerFlag(name = FLAG + "4", value = 1), @IntegerFlag(name = FLAG + "5", value = 0)})
         class MultipleFlags {
             @Test
-            @OpenFeature({
-                @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class),
-                @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class),
-            })
+            @OpenFeature(
+                    value = {
+                        @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class),
+                        @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class),
+                    },
+                    integerFlags = {
+                        @IntegerFlag(name = FLAG + "5", value = 1),
+                        @IntegerFlag(name = FLAG + "6", value = 1)
+                    })
             void multipleFlags() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
 
             @Test
@@ -175,17 +314,68 @@ class IntegerFlagTest {
                     value = {
                         @Flag(name = FLAG + "2", value = FLAG_VALUE_STRING, valueType = Integer.class),
                         @Flag(name = FLAG + "3", value = FLAG_VALUE_STRING, valueType = Integer.class),
+                    },
+                    integerFlags = {
+                        @IntegerFlag(name = FLAG + "5", value = 1),
+                        @IntegerFlag(name = FLAG + "6", value = 1)
                     })
             void multipleFlagsOnMultipleDomains() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
                 assertThat(client.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(client.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getIntegerValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
 
                 Client testSpecific = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
                 assertThat(testSpecific.getIntegerValue(FLAG, FALLBACK)).isEqualTo(FALLBACK);
                 assertThat(testSpecific.getIntegerValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(testSpecific.getIntegerValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getIntegerValue(FLAG + "4", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(testSpecific.getIntegerValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getIntegerValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
+            }
+        }
+    }
+
+    @Nested
+    class DifferentFlagsWithTheSameNameException {
+
+        @Test
+        void differentFlagTypesWithTheSameNameThrowsException() {
+            Events events = EngineTestKit.engine("junit-jupiter")
+                    .configurationParameter("junit.jupiter.conditions.deactivate", "org.junit.*DisabledCondition")
+                    .selectors(selectClass(ConfigWithException.class))
+                    .execute()
+                    .testEvents()
+                    .failed();
+
+            events.assertThatEvents()
+                    .haveExactly(
+                            2,
+                            event(finishedWithFailure(
+                                    instanceOf(IllegalArgumentException.class),
+                                    message("Flag with name integer-flag already exists. "
+                                            + "There shouldn't be @Flag and @IntegerFlag with the same name!"))));
+        }
+
+        @Nested
+        @Disabled
+        class ConfigWithException {
+
+            @Test
+            @Flag(name = FLAG, value = FLAG_VALUE_STRING)
+            @IntegerFlag(name = FLAG, value = 1)
+            void simpleConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
+            }
+
+            @Test
+            @OpenFeature(
+                    value = {@Flag(name = FLAG, value = FLAG_VALUE_STRING)},
+                    integerFlags = {@IntegerFlag(name = FLAG, value = 1)})
+            void extendedConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
             }
         }
     }

--- a/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlagTest.java
+++ b/tools/junit-openfeature/src/test/java/dev/openfeature/contrib/tools/junitopenfeature/StringFlagTest.java
@@ -1,13 +1,21 @@
 package dev.openfeature.contrib.tools.junitopenfeature;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.OpenFeatureAPI;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
 
 class StringFlagTest {
 
@@ -24,6 +32,7 @@ class StringFlagTest {
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class)
+        @StringFlag(name = FLAG + "4", value = FLAG_VALUE)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -31,12 +40,20 @@ class StringFlagTest {
                 assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
         }
 
         @Test
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         void existingSimpleFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        void existingSimpleTypedFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -52,10 +69,48 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        @StringFlag(name = FLAG + "2", value = FLAG_VALUE)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        @StringFlag(name = FLAG, value = FLAG_VALUE_ALTERNATIVE)
+        void duplicatedTypedFlagDoesntOverridePrevious() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class)
+        @StringFlag(name = FLAG + "4", value = FLAG_VALUE)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -68,6 +123,7 @@ class StringFlagTest {
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class)
         @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class)
+        @StringFlag(name = FLAG + "4", value = FLAG_VALUE)
         class onClass {
             @Test
             void multipleFlagsSimple() {
@@ -75,12 +131,20 @@ class StringFlagTest {
                 assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
         }
 
         @Test
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         void existingSimpleFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        void existingSimpleTypedFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -96,10 +160,40 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        @StringFlag(name = FLAG + "2", value = FLAG_VALUE)
+        void multipleTypedFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
+        @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class)
+        @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class)
+        @StringFlag(name = FLAG + "4", value = FLAG_VALUE)
+        void multipleDifferentFlagsSimple() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)
         void existingSimpleFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
+            assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @StringFlag(name = FLAG, value = FLAG_VALUE)
+        void existingSimpleTypedFlagIsRetrievedOnParameterizedTest() {
             Client client = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
@@ -112,6 +206,13 @@ class StringFlagTest {
         void existingFlagIsRetrieved() {
             Client client = OpenFeatureAPI.getInstance().getClient();
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
+        @Test
+        @OpenFeature(stringFlags = {@StringFlag(name = FLAG + "4", value = FLAG_VALUE)})
+        void existingStringFlagIsRetrieved() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
         @Test
@@ -129,6 +230,13 @@ class StringFlagTest {
         }
 
         @Test
+        @OpenFeature(stringFlags = @StringFlag(name = FLAG, value = FLAG_VALUE))
+        void nonExistingTypedFlagIsFallbacked() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue("nonSetFlag", FALLBACK)).isEqualTo(FALLBACK);
+        }
+
+        @Test
         @OpenFeature({
             @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class),
             @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class),
@@ -141,6 +249,18 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @Test
+        @OpenFeature(
+                stringFlags = {
+                    @StringFlag(name = FLAG + "4", value = FLAG_VALUE),
+                    @StringFlag(name = FLAG + "5", value = FLAG_VALUE),
+                })
+        void multipleTypedFlags() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+            assertThat(client.getStringValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {1, 2})
         @OpenFeature({@Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class)})
@@ -149,22 +269,43 @@ class StringFlagTest {
             assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
         }
 
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2})
+        @OpenFeature(stringFlags = {@StringFlag(name = FLAG + "4", value = FLAG_VALUE)})
+        void existingTypedFlagIsRetrievedOnParameterizedTest() {
+            Client client = OpenFeatureAPI.getInstance().getClient();
+            assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+        }
+
         @Nested
-        @OpenFeature({
-            @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class),
-            @Flag(name = FLAG + "2", value = FLAG_VALUE_ALTERNATIVE, valueType = String.class),
-        })
+        @OpenFeature(
+                value = {
+                    @Flag(name = FLAG, value = FLAG_VALUE, valueType = String.class),
+                    @Flag(name = FLAG + "2", value = FLAG_VALUE_ALTERNATIVE, valueType = String.class),
+                },
+                stringFlags = {
+                    @StringFlag(name = FLAG + "4", value = FLAG_VALUE),
+                    @StringFlag(name = FLAG + "5", value = FLAG_VALUE_ALTERNATIVE)
+                })
         class MultipleFlags {
             @Test
-            @OpenFeature({
-                @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class),
-                @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class),
-            })
+            @OpenFeature(
+                    value = {
+                        @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class),
+                        @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class),
+                    },
+                    stringFlags = {
+                        @StringFlag(name = FLAG + "5", value = FLAG_VALUE),
+                        @StringFlag(name = FLAG + "6", value = FLAG_VALUE)
+                    })
             void multipleFlags() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
             }
 
             @Test
@@ -173,17 +314,68 @@ class StringFlagTest {
                     value = {
                         @Flag(name = FLAG + "2", value = FLAG_VALUE, valueType = String.class),
                         @Flag(name = FLAG + "3", value = FLAG_VALUE, valueType = String.class),
+                    },
+                    stringFlags = {
+                        @StringFlag(name = FLAG + "5", value = FLAG_VALUE),
+                        @StringFlag(name = FLAG + "6", value = FLAG_VALUE)
                     })
             void multipleFlagsOnMultipleDomains() {
                 Client client = OpenFeatureAPI.getInstance().getClient();
                 assertThat(client.getStringValue(FLAG, FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(client.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
                 assertThat(client.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(client.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(client.getStringValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE_ALTERNATIVE);
 
                 Client testSpecific = OpenFeatureAPI.getInstance().getClient(SPECIFIC_DOMAIN);
                 assertThat(testSpecific.getStringValue(FLAG, FALLBACK)).isEqualTo(FALLBACK);
                 assertThat(testSpecific.getStringValue(FLAG + "2", FALLBACK)).isEqualTo(FLAG_VALUE);
                 assertThat(testSpecific.getStringValue(FLAG + "3", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getStringValue(FLAG + "4", FALLBACK)).isEqualTo(FALLBACK);
+                assertThat(testSpecific.getStringValue(FLAG + "5", FALLBACK)).isEqualTo(FLAG_VALUE);
+                assertThat(testSpecific.getStringValue(FLAG + "6", FALLBACK)).isEqualTo(FLAG_VALUE);
+            }
+        }
+    }
+
+    @Nested
+    class DifferentFlagsWithTheSameNameException {
+
+        @Test
+        void differentFlagTypesWithTheSameNameThrowsException() {
+            Events events = EngineTestKit.engine("junit-jupiter")
+                    .configurationParameter("junit.jupiter.conditions.deactivate", "org.junit.*DisabledCondition")
+                    .selectors(selectClass(ConfigWithException.class))
+                    .execute()
+                    .testEvents()
+                    .failed();
+
+            events.assertThatEvents()
+                    .haveExactly(
+                            2,
+                            event(finishedWithFailure(
+                                    instanceOf(IllegalArgumentException.class),
+                                    message("Flag with name string-flag already exists. "
+                                            + "There shouldn't be @Flag and @StringFlag with the same name!"))));
+        }
+
+        @Nested
+        @Disabled
+        class ConfigWithException {
+
+            @Test
+            @Flag(name = FLAG, value = FLAG_VALUE)
+            @StringFlag(name = FLAG, value = FLAG_VALUE)
+            void simpleConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
+            }
+
+            @Test
+            @OpenFeature(
+                    value = {@Flag(name = FLAG, value = FLAG_VALUE)},
+                    stringFlags = {@StringFlag(name = FLAG, value = FLAG_VALUE)})
+            void extendedConfigDuplicateFlags() {
+                // expect exception in OpenFeatureExtension
             }
         }
     }


### PR DESCRIPTION
## This PR

- adds dedicated annotations `BooleanFlag`, `StringFlag`, `IntegerFlag`, and `DoubleFlag` for more specific and type-safe flag definitions in JUnit tests

### Related Issues

Fixes #923

### Notes
Not sure about tests, feedback on the test coverage is very welcome!

