### PR TITLE
fix: exclude incompatible sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
             <!-- this can be overriden in child POMs to support specific SDK requirements -->
             <groupId>dev.openfeature</groupId>
             <artifactId>sdk</artifactId>
-            <!-- 1.14.1 <= v < 2.0 (excluding 2.0 pre-releases)-->
-            <version>[1.14.1,1.99999)</version>
+            <!-- 1.14.1 <= v < 1.16 -->
+            <version>[1.14.1,1.16)</version>
             <!-- use the version provided at runtime -->
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This is a fix for already-released providers, which expresses a version incompatibility with SDK v1.16.0, which was released with some bytecode incompatibilities with existing providers.

Please note this is going to the `parentv0` support branch, which we can publish from, and then delete. It will help people not to install the incorrect combination.

Resolves: https://github.com/open-feature/java-sdk-contrib/issues/1484