### PR TITLE
feat(flagd): Adjust to disable-sync-metadata toggle in flagd

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -8,7 +8,6 @@ import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.ParsingResult;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueueSource;
-import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ImmutableStructure;
 import dev.openfeature.sdk.Structure;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -2,12 +2,12 @@ package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 
 import static dev.openfeature.contrib.providers.flagd.resolver.common.Convert.convertProtobufMapToStructure;
 
+import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFlag;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser;
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.ParsingResult;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueueSource;
-import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import dev.openfeature.sdk.ImmutableStructure;
 import dev.openfeature.sdk.Structure;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -114,7 +114,7 @@ public class FlagStore implements Storage {
                         Map<String, FeatureFlag> flagMap = parsingResult.getFlags();
                         Map<String, Object> flagSetMetadataMap = parsingResult.getFlagSetMetadata();
 
-                        Structure metadata = parseSyncMetadata(payload.getMetadataResponse());
+                        Structure metadata = parseSyncContextOrMetadata(payload.getSyncContext());
                         writeLock.lock();
                         try {
                             changedFlagsKeys = getChangedFlagsKeys(flagMap);
@@ -150,9 +150,9 @@ public class FlagStore implements Storage {
         log.info("Shutting down store stream listener");
     }
 
-    private Structure parseSyncMetadata(GetMetadataResponse metadataResponse) {
+    private Structure parseSyncContextOrMetadata(Struct syncContext) {
         try {
-            return convertProtobufMapToStructure(metadataResponse.getMetadata().getFieldsMap());
+            return convertProtobufMapToStructure(syncContext.getFieldsMap());
         } catch (Exception exception) {
             log.error("Failed to parse metadataResponse, provider metadata may not be up-to-date");
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueuePayload.java
@@ -1,6 +1,6 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector;
 
-import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
+import com.google.protobuf.Struct;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,9 +10,9 @@ import lombok.Getter;
 public class QueuePayload {
     private final QueuePayloadType type;
     private final String flagData;
-    private final GetMetadataResponse metadataResponse;
+    private final Struct syncContext;
 
     public QueuePayload(QueuePayloadType type, String flagData) {
-        this(type, flagData, GetMetadataResponse.getDefaultInstance());
+        this(type, flagData, null);
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -1,5 +1,6 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.sync;
 
+import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.common.FlagdProviderEvent;
@@ -123,7 +124,7 @@ public class SyncStreamQueueSource implements QueueSource {
 
             log.debug("Initializing sync stream request");
             final GetMetadataRequest.Builder metadataRequest = GetMetadataRequest.newBuilder();
-            GetMetadataResponse metadataResponse = GetMetadataResponse.getDefaultInstance();
+            GetMetadataResponse metadataResponse = null;
 
             // create a context which exists to track and cancel the stream
             try (CancellableContext context = Context.current().withCancellation()) {
@@ -162,8 +163,7 @@ public class SyncStreamQueueSource implements QueueSource {
                         log.debug("Exception in stream RPC, streamException {}, will restart", streamException);
                         if (!outgoingQueue.offer(new QueuePayload(
                                 QueuePayloadType.ERROR,
-                                String.format("Error from stream: %s", streamException.getMessage()),
-                                metadataResponse))) {
+                                String.format("Error from stream: %s", streamException.getMessage())))) {
                             log.error("Failed to convey ERROR status, queue is full");
                         }
                         break;
@@ -173,7 +173,14 @@ public class SyncStreamQueueSource implements QueueSource {
                     final String data = flagsResponse.getFlagConfiguration();
                     log.debug("Got stream response: {}", data);
 
-                    if (!outgoingQueue.offer(new QueuePayload(QueuePayloadType.DATA, data, metadataResponse))) {
+                    Struct syncContext;
+                    if (flagsResponse.hasSyncContext()) {
+                        syncContext = flagsResponse.getSyncContext();
+                    } else {
+                        syncContext = metadataResponse.getMetadata();
+                    }
+
+                    if (!outgoingQueue.offer(new QueuePayload(QueuePayloadType.DATA, data, syncContext))) {
                         log.error("Stream writing failed");
                     }
                 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -173,10 +173,10 @@ public class SyncStreamQueueSource implements QueueSource {
                     final String data = flagsResponse.getFlagConfiguration();
                     log.debug("Got stream response: {}", data);
 
-                    Struct syncContext;
+                    Struct syncContext = null;
                     if (flagsResponse.hasSyncContext()) {
                         syncContext = flagsResponse.getSyncContext();
-                    } else {
+                    } else if (metadataResponse != null) {
                         syncContext = metadataResponse.getMetadata();
                     }
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/ProviderSteps.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/e2e/steps/ProviderSteps.java
@@ -120,7 +120,11 @@ public class ProviderSteps extends AbstractSteps {
                     state.builder.port(container.getPort(State.resolverType));
                 }
                 break;
-            default:
+            case "syncpayload":
+                flagdConfig = "sync-payload";
+                state.builder.port(container.getPort(State.resolverType));
+                break;
+            case "stable":
                 this.state.providerType = ProviderType.DEFAULT;
                 if (State.resolverType == Config.Resolver.FILE) {
 
@@ -134,6 +138,8 @@ public class ProviderSteps extends AbstractSteps {
                     state.builder.port(container.getPort(State.resolverType));
                 }
                 break;
+            default:
+                throw new IllegalStateException();
         }
         when().post("http://" + container.getLaunchpadUrl() + "/start?config={config}", flagdConfig)
                 .then()

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStoreTest.java
@@ -11,7 +11,6 @@ import dev.openfeature.contrib.providers.flagd.resolver.process.model.FeatureFla
 import dev.openfeature.contrib.providers.flagd.resolver.process.model.FlagParser;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
-import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
@@ -35,10 +34,7 @@ class FlagStoreTest {
 
         // OK for simple flag
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(
-                    QueuePayloadType.DATA,
-                    getFlagsFromResource(VALID_SIMPLE),
-                    GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE)));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
@@ -47,10 +43,7 @@ class FlagStoreTest {
 
         // STALE for invalid flag
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(
-                    QueuePayloadType.DATA,
-                    getFlagsFromResource(INVALID_FLAG),
-                    GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(INVALID_FLAG)));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
@@ -59,8 +52,7 @@ class FlagStoreTest {
 
         // OK again for next payload
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(
-                    QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG)));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
@@ -69,7 +61,7 @@ class FlagStoreTest {
 
         // ERROR is propagated correctly
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(QueuePayloadType.ERROR, null, GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.ERROR, null));
         });
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
@@ -93,10 +85,7 @@ class FlagStoreTest {
         final BlockingQueue<StorageStateChange> storageStateDTOS = store.getStateQueue();
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(
-                    QueuePayloadType.DATA,
-                    getFlagsFromResource(VALID_SIMPLE),
-                    GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_SIMPLE)));
         });
         // flags changed for first time
         assertEquals(
@@ -105,8 +94,7 @@ class FlagStoreTest {
                 storageStateDTOS.take().getChangedFlagsKeys());
 
         assertTimeoutPreemptively(Duration.ofMillis(maxDelay), () -> {
-            payload.offer(new QueuePayload(
-                    QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG), GetMetadataResponse.getDefaultInstance()));
+            payload.offer(new QueuePayload(QueuePayloadType.DATA, getFlagsFromResource(VALID_LONG)));
         });
         Map<String, FeatureFlag> expectedChangedFlags =
                 FlagParser.parseString(getFlagsFromResource(VALID_LONG), true).getFlags();

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/MockConnector.java
@@ -3,7 +3,6 @@ package dev.openfeature.contrib.providers.flagd.resolver.process.storage;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueueSource;
-import dev.openfeature.flagd.grpc.sync.Sync.GetMetadataResponse;
 import java.util.concurrent.BlockingQueue;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,8 +25,7 @@ public class MockConnector implements QueueSource {
 
     public void shutdown() {
         // Emit error mocking closed connection scenario
-        if (!mockQueue.offer(new QueuePayload(
-                QueuePayloadType.ERROR, "shutdown invoked", GetMetadataResponse.getDefaultInstance()))) {
+        if (!mockQueue.offer(new QueuePayload(QueuePayloadType.ERROR, "shutdown invoked"))) {
             log.warn("Failed to offer shutdown status");
         }
     }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -108,15 +108,16 @@ class SyncStreamQueueSourceTest {
     @Test
     void onNextEnqueuesDataPayloadWithSyncContext() throws Exception {
         // disable GetMetadata call
-        SyncStreamQueueSource connector = new SyncStreamQueueSource(
-                FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
+        SyncStreamQueueSource connector =
+                new SyncStreamQueueSource(FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
         latch = new CountDownLatch(1);
         connector.init();
         latch.await();
 
         // fire onNext (data) event
         Struct syncContext = Struct.newBuilder().build();
-        observer.onNext(SyncFlagsResponse.newBuilder().setSyncContext(syncContext).build());
+        observer.onNext(
+                SyncFlagsResponse.newBuilder().setSyncContext(syncContext).build());
 
         // should enqueue data payload
         BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.sync;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.common.QueueingStreamObserver;
@@ -73,6 +75,7 @@ class SyncStreamQueueSourceTest {
         BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();
         QueuePayload payload = streamQueue.poll(1000, TimeUnit.MILLISECONDS);
         assertNotNull(payload);
+        assertNotNull(payload.getSyncContext());
         assertEquals(QueuePayloadType.DATA, payload.getType());
         // should NOT have restarted the stream (1 call)
         verify(stub, times(1)).syncFlags(any(), any());
@@ -94,11 +97,35 @@ class SyncStreamQueueSourceTest {
         BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();
         QueuePayload payload = streamQueue.poll(1000, TimeUnit.MILLISECONDS);
         assertNotNull(payload);
+        assertNull(payload.getSyncContext());
         assertEquals(QueuePayloadType.DATA, payload.getType());
         // should NOT have restarted the stream (1 call)
         verify(stub, times(1)).syncFlags(any(), any());
         // should NOT have called getMetadata
         verify(blockingStub, times(0)).getMetadata(any());
+    }
+
+    @Test
+    void onNextEnqueuesDataPayloadWithSyncContext() throws Exception {
+        // disable GetMetadata call
+        SyncStreamQueueSource connector = new SyncStreamQueueSource(
+                FlagdOptions.builder().build(), mockConnector, stub, blockingStub);
+        latch = new CountDownLatch(1);
+        connector.init();
+        latch.await();
+
+        // fire onNext (data) event
+        Struct syncContext = Struct.newBuilder().build();
+        observer.onNext(SyncFlagsResponse.newBuilder().setSyncContext(syncContext).build());
+
+        // should enqueue data payload
+        BlockingQueue<QueuePayload> streamQueue = connector.getStreamQueue();
+        QueuePayload payload = streamQueue.poll(1000, TimeUnit.MILLISECONDS);
+        assertNotNull(payload);
+        assertEquals(syncContext, payload.getSyncContext());
+        assertEquals(QueuePayloadType.DATA, payload.getType());
+        // should NOT have restarted the stream (1 call)
+        verify(stub, times(1)).syncFlags(any(), any());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adjusts the implementation to handle both paths that the `disable-sync-metadata` toggle introduces

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

relates: [#1584](https://github.com/open-feature/flagd/issues/1584)
closes: https://github.com/open-feature/java-sdk-contrib/issues/1509
