### PR TITLE
chore(unleash): update dependency io.getunleash:unleash-client-java to v11.0.2 (#1551)

### DIFF
--- a/providers/unleash/pom.xml
+++ b/providers/unleash/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>9.3.2</version>
+            <version>11.0.2</version>
         </dependency>
 
         <dependency>

--- a/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
+++ b/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashProvider.java
@@ -1,6 +1,6 @@
 package dev.openfeature.contrib.providers.unleash;
 
-import static io.getunleash.Variant.DISABLED_VARIANT;
+import static io.getunleash.variant.Variant.DISABLED_VARIANT;
 
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
@@ -12,8 +12,8 @@ import dev.openfeature.sdk.exceptions.GeneralError;
 import io.getunleash.DefaultUnleash;
 import io.getunleash.Unleash;
 import io.getunleash.UnleashContext;
-import io.getunleash.Variant;
 import io.getunleash.util.UnleashConfig;
+import io.getunleash.variant.Variant;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,13 +34,13 @@ public class UnleashProvider extends EventProvider {
     public static final String UNKNOWN_ERROR = "unknown error";
 
     @Getter(AccessLevel.PROTECTED)
-    private UnleashProviderConfig unleashProviderConfig;
+    private final UnleashProviderConfig unleashProviderConfig;
 
     @Setter(AccessLevel.PROTECTED)
     @Getter
     private Unleash unleash;
 
-    private AtomicBoolean isInitialized = new AtomicBoolean(false);
+    private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
     /**
      * Constructor.
@@ -160,8 +160,7 @@ public class UnleashProvider extends EventProvider {
                     .orElse(null);
         }
         ImmutableMetadata.ImmutableMetadataBuilder flagMetadataBuilder =
-                ImmutableMetadata.builder().addString("variant-stickiness", evaluatedVariant.getStickiness());
-        flagMetadataBuilder.addBoolean("enabled", evaluatedVariant.isEnabled());
+                ImmutableMetadata.builder().addBoolean("enabled", evaluatedVariant.isEnabled());
         if (evaluatedVariant.getPayload().isPresent()) {
             flagMetadataBuilder.addString(
                     "payload-type", evaluatedVariant.getPayload().get().getType());

--- a/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashSubscriberWrapper.java
+++ b/providers/unleash/src/main/java/dev/openfeature/contrib/providers/unleash/UnleashSubscriberWrapper.java
@@ -5,6 +5,8 @@ import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.ProviderEventDetails;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.getunleash.UnleashException;
+import io.getunleash.event.ClientFeaturesResponse;
+import io.getunleash.event.FeatureSet;
 import io.getunleash.event.ImpressionEvent;
 import io.getunleash.event.ToggleEvaluated;
 import io.getunleash.event.UnleashEvent;
@@ -12,9 +14,6 @@ import io.getunleash.event.UnleashReady;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.metric.ClientMetrics;
 import io.getunleash.metric.ClientRegistration;
-import io.getunleash.repository.FeatureCollection;
-import io.getunleash.repository.FeatureToggleResponse;
-import io.getunleash.repository.ToggleCollection;
 import javax.annotation.Nullable;
 import lombok.Generated;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 @Generated
 public class UnleashSubscriberWrapper implements UnleashSubscriber {
 
-    private UnleashSubscriber unleashSubscriber;
-    private EventProvider eventProvider;
+    private final UnleashSubscriber unleashSubscriber;
+    private final EventProvider eventProvider;
 
     /**
      * Constructor.
@@ -67,9 +66,9 @@ public class UnleashSubscriberWrapper implements UnleashSubscriber {
     }
 
     @Override
-    public void togglesFetched(FeatureToggleResponse toggleResponse) {
+    public void togglesFetched(ClientFeaturesResponse toggleResponse) {
         unleashSubscriber.togglesFetched(toggleResponse);
-        if (FeatureToggleResponse.Status.CHANGED.equals(toggleResponse.getStatus())) {
+        if (ClientFeaturesResponse.Status.CHANGED.equals(toggleResponse.getStatus())) {
             eventProvider.emitProviderConfigurationChanged(ProviderEventDetails.builder()
                     .eventMetadata(ImmutableMetadata.builder().build())
                     .build());
@@ -87,33 +86,18 @@ public class UnleashSubscriberWrapper implements UnleashSubscriber {
     }
 
     @Override
-    public void togglesBackedUp(ToggleCollection toggleCollection) {
-        unleashSubscriber.togglesBackedUp(toggleCollection);
+    public void featuresBackedUp(FeatureSet toggleCollection) {
+        unleashSubscriber.featuresBackedUp(toggleCollection);
     }
 
     @Override
-    public void toggleBackupRestored(ToggleCollection toggleCollection) {
-        unleashSubscriber.toggleBackupRestored(toggleCollection);
+    public void featuresBackupRestored(FeatureSet toggleCollection) {
+        unleashSubscriber.featuresBackupRestored(toggleCollection);
     }
 
     @Override
-    public void togglesBootstrapped(ToggleCollection toggleCollection) {
-        unleashSubscriber.togglesBootstrapped(toggleCollection);
-    }
-
-    @Override
-    public void featuresBootstrapped(FeatureCollection featureCollection) {
-        unleashSubscriber.featuresBootstrapped(featureCollection);
-    }
-
-    @Override
-    public void featuresBackedUp(FeatureCollection featureCollection) {
-        unleashSubscriber.featuresBackedUp(featureCollection);
-    }
-
-    @Override
-    public void featuresBackupRestored(FeatureCollection featureCollection) {
-        unleashSubscriber.featuresBackupRestored(featureCollection);
+    public void featuresBootstrapped(FeatureSet toggleCollection) {
+        unleashSubscriber.featuresBootstrapped(toggleCollection);
     }
 
     @Override

--- a/providers/unleash/src/test/java/dev/openfeature/contrib/providers/unleash/UnleashProviderTest.java
+++ b/providers/unleash/src/test/java/dev/openfeature/contrib/providers/unleash/UnleashProviderTest.java
@@ -21,10 +21,10 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
 import io.getunleash.UnleashContext;
 import io.getunleash.UnleashException;
+import io.getunleash.event.ClientFeaturesResponse;
 import io.getunleash.event.ToggleEvaluated;
 import io.getunleash.event.UnleashEvent;
 import io.getunleash.event.UnleashSubscriber;
-import io.getunleash.repository.FeatureToggleResponse;
 import io.getunleash.util.UnleashConfig;
 import java.net.URI;
 import java.net.URL;
@@ -230,7 +230,6 @@ class UnleashProviderTest {
         ProviderEvaluation<String> stringEvaluation =
                 unleashProvider.getStringEvaluation(VARIANT_FLAG_NAME, "", new ImmutableContext());
         ImmutableMetadata flagMetadata = stringEvaluation.getFlagMetadata();
-        assertEquals("default", flagMetadata.getString("variant-stickiness"));
         assertEquals("string", flagMetadata.getString("payload-type"));
         assertEquals(true, flagMetadata.getBoolean("enabled"));
         ProviderEvaluation<String> nonExistingFlagEvaluation =
@@ -286,16 +285,12 @@ class UnleashProviderTest {
         unleashSubscriberWrapper.featuresBootstrapped(null);
         unleashSubscriberWrapper.impression(null);
         unleashSubscriberWrapper.toggleEvaluated(new ToggleEvaluated("dummy", false));
-        unleashSubscriberWrapper.togglesFetched(
-                new FeatureToggleResponse(FeatureToggleResponse.Status.NOT_CHANGED, 200));
-        unleashSubscriberWrapper.toggleBackupRestored(null);
-        unleashSubscriberWrapper.togglesBackedUp(null);
-        unleashSubscriberWrapper.togglesBootstrapped(null);
+        unleashSubscriberWrapper.togglesFetched(ClientFeaturesResponse.notChanged());
     }
 
     private class TestSubscriber implements UnleashSubscriber {
 
-        private FeatureToggleResponse.Status status;
+        private ClientFeaturesResponse.Status status;
 
         private String toggleName;
         private boolean toggleEnabled;
@@ -320,7 +315,7 @@ class UnleashProviderTest {
         }
 
         @Override
-        public void togglesFetched(FeatureToggleResponse toggleResponse) {
+        public void togglesFetched(ClientFeaturesResponse toggleResponse) {
             this.status = toggleResponse.getStatus();
         }
     }

--- a/providers/unleash/src/test/resources/features.json
+++ b/providers/unleash/src/test/resources/features.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "features": [
     {
       "name": "variant-flag",


### PR DESCRIPTION
## This PR

- update the dependency to unleash-client-java to the latest v11.

### Related Issues

Fixes #1551

### Notes

As far as I can see, this is not a breaking change because the only thing from unleash-client-java exposed from the open-feature Unleash provider is the configuration builder and it does not seem to have changed since v9.
To be double checked though.

The main open questions now are:
- how to deal with the tests? apparently there is now a new schema for features.json (v2 while we test with v1) and
  - v1 is still supported but some things behave differently, see the one failing test (stickiness is not set in Variant anymore by Yggdrasil)
  - v2 would need to be tested maybe? at least a simple test
  - example of v2 config: https://github.com/Unleash/yggdrasil/blob/main/java-engine/src/test/resources/custom-strategy-tests.json
- we need to manually do a test (on all Yggdrasil supported arch) to validate that indeed, https://github.com/Unleash/unleash-client-java/issues/275 is really fixed as it seems to be
- someone much more familiar with Unleash than me should obviously double check that I didn't forget anything that is not just type errors :)

