### PR TITLE
chore: add submodule checkout to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,8 @@ jobs:
       # The logic below handles the maven publication:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: recursive
 
       - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4


### PR DESCRIPTION
Fixes: https://github.com/open-feature/java-sdk-contrib/actions/runs/17212491907/job/48828134642