### PR TITLE
fix(go-feature-flag): Fix javadoc generation blocking release please

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,11 +307,8 @@
                         <version>3.11.3</version>
                         <configuration>
                             <failOnWarnings>${javadoc.failOnWarnings}</failOnWarnings>
-                            <sourceFileExcludes>
-                                <sourceFileExclude>**/GoFeatureFlagProviderOptions.java</sourceFileExclude>
-                            </sourceFileExcludes>
                             <excludePackageNames>
-                                dev.openfeature.flagd.grpc,dev.openfeature.contrib.providers.gofeatureflag.exception,dev.openfeature.contrib.providers.gofeatureflag.bean
+                                dev.openfeature.flagd.grpc
                             </excludePackageNames>
                             <doclint>all,-missing
                             </doclint>  <!-- ignore missing javadoc, these are enforced with more customizability in the checkstyle plugin -->


### PR DESCRIPTION
The release of the GOFF java provider did not succeed because of the javadoc generation.
See https://github.com/open-feature/java-sdk-contrib/actions/runs/17834482866/job/50708225137

I've spotted some configuration in the `pom.xml` excluding some GOFF files _(not sure why)_.
In this PR we remove the exclusions.

Those exclusion have been introduced in this PR https://github.com/open-feature/java-sdk-contrib/pull/1387 and I don't really understand the reason why.
@aepfli if you can help me to understand this would be really great.