### PR TITLE
fix: flagsmith string to double conversion issue(#1557)

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -210,7 +210,7 @@ public class FlagdProvider extends EventProvider {
                         onConfigurationChanged(flagdProviderEvent);
                         break;
                     }
-                // intentional fall through
+                    // intentional fall through
                 case PROVIDER_READY:
                     /*
                      * Sync metadata is used to enrich the context, and is immutable in flagd,

--- a/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
+++ b/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
@@ -159,6 +159,53 @@ public class FlagsmithProviderTest {
         mockFlagsmithErrorServer.shutdown();
     }
 
+    @ParameterizedTest
+    @MethodSource("convertValueArguments")
+    void testConvertValue(Object input, Class<?> expectedType, Object expected) throws Exception {
+        var method = flagsmithProvider.getClass().getDeclaredMethod("convertValue", Object.class, Class.class);
+        method.setAccessible(true);
+        Object result = method.invoke(flagsmithProvider, input, expectedType);
+        assertEquals(expected, result);
+    }
+
+    private static Stream<Arguments> convertValueArguments() {
+        return Stream.of(
+                Arguments.of(true, Boolean.class, true),
+                Arguments.of("test", String.class, "test"),
+                Arguments.of(123, Integer.class, 123),
+                Arguments.of("123", Integer.class, 123),
+                Arguments.of(3.14, Double.class, 3.14),
+                Arguments.of("3.14", Double.class, 3.14));
+    }
+
+    @Test
+    void testConvertValueThrowsTypeMismatchErrorForInvalidInteger() throws Exception {
+        var method = flagsmithProvider.getClass().getDeclaredMethod("convertValue", Object.class, Class.class);
+        method.setAccessible(true);
+        assertThrows(dev.openfeature.sdk.exceptions.TypeMismatchError.class, () -> {
+            try {
+                method.invoke(flagsmithProvider, "abc", Integer.class);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                // Rethrow the actual exception thrown by convertValue
+                throw e.getCause();
+            }
+        });
+    }
+
+    @Test
+    void testConvertValueThrowsTypeMismatchErrorForInvalidDouble() throws Exception {
+        var method = flagsmithProvider.getClass().getDeclaredMethod("convertValue", Object.class, Class.class);
+        method.setAccessible(true);
+        assertThrows(dev.openfeature.sdk.exceptions.TypeMismatchError.class, () -> {
+            try {
+                method.invoke(flagsmithProvider, "abc", Double.class);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                // Rethrow the actual exception thrown by convertValue
+                throw e.getCause();
+            }
+        });
+    }
+
     @Test
     void shouldInitializeProviderWhenAllOptionsSet() {
         HashMap<String, String> headers = new HashMap<String, String>() {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This PR fixes the issue where FlagsmithProvider.getDoubleDetails fails to parse flag values returned as strings (e.g., "42.42") from Flagsmith. Previously, the provider expected a java.lang.Double and returned an error if the value was a string. With this change, the provider will attempt to parse string values to Double when evaluating double flags, ensuring compatibility with Flagsmith environments that store numeric values as strings. Similar case is handled for Integer as well.



### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1557 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

