### PR TITLE
feat: flagd provider creates named daemon threads for error executor

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -91,7 +91,7 @@ public class FlagdProvider extends EventProvider {
         }
         hooks.add(new SyncMetadataHook(this::getEnrichedContext));
         contextEnricher = options.getContextEnricher();
-        errorExecutor = Executors.newSingleThreadScheduledExecutor();
+        errorExecutor = Executors.newSingleThreadScheduledExecutor(new FlagdThreadFactory("flagd-provider-thread"));
         gracePeriod = options.getRetryGracePeriod();
         deadline = options.getDeadline();
     }
@@ -105,7 +105,7 @@ public class FlagdProvider extends EventProvider {
         deadline = Config.DEFAULT_DEADLINE;
         gracePeriod = Config.DEFAULT_STREAM_RETRY_GRACE_PERIOD;
         hooks.add(new SyncMetadataHook(this::getEnrichedContext));
-        errorExecutor = Executors.newSingleThreadScheduledExecutor();
+        errorExecutor = Executors.newSingleThreadScheduledExecutor(new FlagdThreadFactory("flagd-provider-thread"));
         if (initialized) {
             this.syncResources.initialize();
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
@@ -1,5 +1,6 @@
 package dev.openfeature.contrib.providers.flagd;
 
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -17,7 +18,7 @@ class FlagdThreadFactory implements ThreadFactory {
      * @param namePrefix    Prefix used for setting the new thread's name.
      */
     FlagdThreadFactory(String namePrefix) {
-        this.namePrefix = namePrefix;
+        this.namePrefix = Objects.requireNonNull(namePrefix, "namePrefix must not be null");
     }
 
     @Override

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Thread factory for the Flagd provider to allow named daemon threads to be created.
  */
-public final class FlagdThreadFactory implements ThreadFactory {
+class FlagdThreadFactory implements ThreadFactory {
 
     private final AtomicInteger counter = new AtomicInteger();
     private final String namePrefix;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactory.java
@@ -1,0 +1,30 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread factory for the Flagd provider to allow named daemon threads to be created.
+ */
+public final class FlagdThreadFactory implements ThreadFactory {
+
+    private final AtomicInteger counter = new AtomicInteger();
+    private final String namePrefix;
+
+    /**
+     * {@link FlagdThreadFactory}'s constructor.
+     *
+     * @param namePrefix    Prefix used for setting the new thread's name.
+     */
+    FlagdThreadFactory(String namePrefix) {
+        this.namePrefix = namePrefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        final Thread thread = new Thread(runnable);
+        thread.setDaemon(true);
+        thread.setName(namePrefix + "-" + counter.incrementAndGet());
+        return thread;
+    }
+}

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactoryTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactoryTest.java
@@ -1,0 +1,34 @@
+package dev.openfeature.contrib.providers.flagd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FlagdThreadFactoryTest {
+
+    private static final String THREAD_NAME = "testthread";
+    private final Runnable runnable = () -> {};
+
+    @Test
+    void verifyNewThreadHasNamePrefix() {
+
+        var flagdThreadFactory = new FlagdThreadFactory(THREAD_NAME);
+        var thread = flagdThreadFactory.newThread(runnable);
+
+        assertThat(thread.getName()).isEqualTo(THREAD_NAME + "-1");
+        assertThat(thread.isDaemon()).isTrue();
+    }
+
+    @Test
+    void verifyNewThreadHasNamePrefixWithIncrement() {
+
+        var flagdThreadFactory = new FlagdThreadFactory(THREAD_NAME);
+        var threadOne = flagdThreadFactory.newThread(runnable);
+        var threadTwo = flagdThreadFactory.newThread(runnable);
+
+        assertThat(threadOne.getName()).isEqualTo(THREAD_NAME + "-1");
+        assertThat(threadOne.isDaemon()).isTrue();
+        assertThat(threadTwo.getName()).isEqualTo(THREAD_NAME + "-2");
+        assertThat(threadTwo.isDaemon()).isTrue();
+    }
+}

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactoryTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdThreadFactoryTest.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.flagd;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,17 @@ class FlagdThreadFactoryTest {
 
     private static final String THREAD_NAME = "testthread";
     private final Runnable runnable = () -> {};
+
+    @Test
+    void verifyThreadFactoryThrowsNullPointerExceptionWhenNamePrefixIsNull() {
+
+        // Then
+        var exception = assertThrows(NullPointerException.class, () -> {
+            // When
+            new FlagdThreadFactory(null);
+        });
+        assertThat(exception.toString()).contains("namePrefix must not be null");
+    }
 
     @Test
     void verifyNewThreadHasNamePrefix() {


### PR DESCRIPTION

## This PR
Enables the flagd provider to create descriptively named daemon threads, similar to the changes made in https://github.com/open-feature/java-sdk/issues/1633

### Related Issues

Resolves #1599 

