### PR TITLE
fix: possible tight busy loop on certain connection errors

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -38,6 +38,7 @@ public class SyncStreamQueueSource implements QueueSource {
     private static final int QUEUE_SIZE = 5;
 
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
+    private final AtomicBoolean shouldThrottle = new AtomicBoolean(false);
     private final int streamDeadline;
     private final int deadline;
     private final int maxBackoffMs;
@@ -102,7 +103,10 @@ public class SyncStreamQueueSource implements QueueSource {
      * @throws InterruptedException if stream can't be closed within deadline.
      */
     public void shutdown() throws InterruptedException {
-        if (shutdown.getAndSet(true)) {
+        // Use atomic compareAndSet to ensure shutdown is only executed once
+        // This prevents race conditions when shutdown is called from multiple threads
+        if (!shutdown.compareAndSet(false, true)) {
+            log.debug("Shutdown already in progress or completed");
             return;
         }
         this.channelConnector.shutdown();
@@ -117,8 +121,18 @@ public class SyncStreamQueueSource implements QueueSource {
         // error conditions
         while (!shutdown.get()) {
             try {
+                if (shouldThrottle.getAndSet(false)) {
+                    log.debug("Previous stream ended with error, waiting {} ms before retry", this.maxBackoffMs);
+                    Thread.sleep(this.maxBackoffMs);
+
+                    // Check shutdown again after sleep to avoid unnecessary work
+                    if (shutdown.get()) {
+                        break;
+                    }
+                }
+
                 log.debug("Initializing sync stream request");
-                SyncStreamObserver observer = new SyncStreamObserver(outgoingQueue);
+                SyncStreamObserver observer = new SyncStreamObserver(outgoingQueue, shouldThrottle);
                 try {
                     observer.metadata = getMetadata();
                 } catch (Exception metaEx) {
@@ -126,7 +140,7 @@ public class SyncStreamQueueSource implements QueueSource {
                     String message = metaEx.getMessage();
                     log.debug("Metadata request error: {}, will restart", message, metaEx);
                     enqueueError(String.format("Error in getMetadata request: %s", message));
-                    Thread.sleep(this.maxBackoffMs);
+                    shouldThrottle.set(true);
                     continue;
                 }
 
@@ -135,7 +149,7 @@ public class SyncStreamQueueSource implements QueueSource {
                 } catch (Exception ex) {
                     log.error("Unexpected sync stream exception, will restart.", ex);
                     enqueueError(String.format("Error in syncStream: %s", ex.getMessage()));
-                    Thread.sleep(this.maxBackoffMs);
+                    shouldThrottle.set(true);
                 }
             } catch (InterruptedException ie) {
                 log.debug("Stream loop interrupted, most likely shutdown was invoked", ie);
@@ -209,12 +223,14 @@ public class SyncStreamQueueSource implements QueueSource {
 
     private static class SyncStreamObserver implements StreamObserver<SyncFlagsResponse> {
         private final BlockingQueue<QueuePayload> outgoingQueue;
+        private final AtomicBoolean shouldThrottle;
         private final Awaitable done = new Awaitable();
 
         private Struct metadata;
 
-        public SyncStreamObserver(BlockingQueue<QueuePayload> outgoingQueue) {
+        public SyncStreamObserver(BlockingQueue<QueuePayload> outgoingQueue, AtomicBoolean shouldThrottle) {
             this.outgoingQueue = outgoingQueue;
+            this.shouldThrottle = shouldThrottle;
         }
 
         @Override
@@ -235,6 +251,9 @@ public class SyncStreamQueueSource implements QueueSource {
                 String message = throwable != null ? throwable.getMessage() : "unknown";
                 log.debug("Stream error: {}, will restart", message, throwable);
                 enqueueError(outgoingQueue, String.format("Error from stream: %s", message));
+
+                // Set throttling flag to ensure backoff before retry
+                this.shouldThrottle.set(true);
             } finally {
                 done.wakeup();
             }


### PR DESCRIPTION
With https://github.com/open-feature/java-sdk-contrib/pull/1590, we fixed a few issues; one was a possible busy loop on certain connection errors. Unfortunately we missed the case that the error actually occurs on the stream (`onError`). This applies the same backoff in that case, and adds an associated test.

I tested this fix manually as well, with a Spring app and a flagd hard-coded to return errors.

Thanks @leakonvalinka and @guidobrei for finding this.

