### PR TITLE
docs: deprecate contrib multi-provider in favor of SDK implementation

### DIFF
--- a/providers/multiprovider/README.md
+++ b/providers/multiprovider/README.md
@@ -1,5 +1,9 @@
 # OpenFeature Multi-Provider for Java
 
+> **Deprecated:** This module has been superseded by the multi-provider implementation in the **core Java SDK**.  
+> For new projects, please use  [`dev.openfeature.sdk.multiprovider.MultiProvider`](https://github.com/open-feature/java-sdk/blob/main/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java) from the core SDK instead of this contrib module.  
+> This artifact remains available for backwards compatibility but may be removed in a future release.
+
 The OpenFeature Multi-Provider wraps multiple underlying providers in a unified interface, allowing the SDK client to transparently interact with all those providers at once.
 This allows use cases where a single client and evaluation interface is desired, but where the flag data should come from more than one source.
 
@@ -13,6 +17,11 @@ Some examples:
 - Setting a fallback for cloud providers.
   You can use the Multi-Provider to automatically fall back to a local configuration if an external vendor provider goes down, rather than using the default values.
   By using the FirstSuccessfulStrategy, the Multi-Provider will move on to the next provider in the list if an error is thrown.
+
+> **Recommended replacement:** For new integrations, see the multi-provider in the core SDK:
+>
+> - Class: [`dev.openfeature.sdk.multiprovider.MultiProvider`](https://github.com/open-feature/java-sdk/blob/main/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java)
+> - Documentation: refer to the [Java SDK README](https://github.com/open-feature/java-sdk#openfeature-java-sdk) Javadoc.
 
 ## Strategies
 
@@ -49,6 +58,9 @@ Rather than making assumptions about when to use a provider’s result and when 
 
 ## Installation
 
+> **Note: ** The following coordinates are kept for existing users of the contrib multi-provider.  
+> New projects should prefer the core SDK dependency and its `dev.openfeature.sdk.providers.multiprovider.MultiProvider` implementation.
+
 <!-- x-release-please-start-version -->
 
 ```xml
@@ -63,6 +75,8 @@ Rather than making assumptions about when to use a provider’s result and when 
 <!-- x-release-please-end-version -->
 
 ## Usage
+Legacy usage: This example shows how to use the contrib multi-provider.
+For new code, use dev.openfeature.sdk.providers.multiprovider.MultiProvider from the core SDK and follow the examples in the Java SDK README.
 
 Usage example:
 

--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/FirstMatchStrategy.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/FirstMatchStrategy.java
@@ -12,15 +12,21 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * First match strategy. Return the first result returned by a provider. Skip providers that
- * indicate they had no value due to FLAG_NOT_FOUND. In all other cases, use the value returned by
- * the provider. If any provider returns an error result other than FLAG_NOT_FOUND, the whole
- * evaluation should error and “bubble up” the individual provider’s error in the result. As soon as
- * a value is returned by a provider, the rest of the operation should short-circuit and not call
- * the rest of the providers.
+ * First Match strategy.
+ *
+ * <p>Return the first result returned by a provider. Skip providers that indicate they had no
+ * value due to {@code FLAG_NOT_FOUND}. In all other cases, use the value returned by the
+ * provider. If any provider returns an error result other than {@code FLAG_NOT_FOUND}, the whole
+ * evaluation should error and “bubble up” the individual provider’s error in the result. As soon
+ * as a value is returned by a provider, the rest of the operation should short-circuit and not
+ * call the rest of the providers.</p>
+ *
+ * @deprecated Use {@link dev.openfeature.sdk.multiprovider.FirstMatchStrategy}
+ *     from the core Java SDK instead.
  */
 @Slf4j
 @NoArgsConstructor
+@Deprecated
 public class FirstMatchStrategy implements Strategy {
 
     /**

--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/FirstSuccessfulStrategy.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/FirstSuccessfulStrategy.java
@@ -10,12 +10,18 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * First Successful Strategy. Similar to “First Match”, except that errors from evaluated providers
- * do not halt execution. Instead, it will return the first successful result from a provider. If no
- * provider successfully responds, it will throw an error result.
+ * First Successful strategy.
+ *
+ * <p>Similar to “First Match”, except that errors from evaluated providers do not halt execution.
+ * Instead, it will return the first successful result from a provider. If no provider successfully
+ * responds, it will throw an error result.</p>
+ *
+ * @deprecated Use {@link dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy}
+ *     from the core Java SDK instead.
  */
 @Slf4j
 @NoArgsConstructor
+@Deprecated
 public class FirstSuccessfulStrategy implements Strategy {
 
     @Override

--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
@@ -21,8 +21,17 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 
-/** Provider implementation for Multi-provider. */
+/**
+ * Multi-provider implementation that composes multiple providers.
+ *
+ * <p>This implementation lives in the contrib repository and is kept for backwards compatibility
+ * with existing users.</p>
+ *
+ * @deprecated Use {@link dev.openfeature.sdk.multiprovider.MultiProvider}
+ *     from the core Java SDK instead.
+ */
 @Slf4j
+@Deprecated
 public class MultiProvider extends EventProvider {
 
     @Getter

--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/Strategy.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/Strategy.java
@@ -6,7 +6,13 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import java.util.Map;
 import java.util.function.Function;
 
-/** strategy. */
+/**
+ * Strategy for evaluating flags across multiple providers.
+ *
+ * @deprecated Use the strategy classes in {@code dev.openfeature.sdk.multiprovider}
+ *     from the core Java SDK instead.
+ */
+@Deprecated
 public interface Strategy {
     <T> ProviderEvaluation<T> evaluate(
             Map<String, FeatureProvider> providers,


### PR DESCRIPTION
## Description

Deprecate the contrib multi-provider in favor of the new core SDK implementation, while keeping existing users backwards compatible.

Changes:

- Mark `dev.openfeature.contrib.providers.multiprovider.MultiProvider` (and related types) as `@Deprecated`.
- Update Javadoc on the contrib multi-provider to point to
  `dev.openfeature.sdk.multiprovider.MultiProvider` in the core SDK.
- Update the contrib `providers/multiprovider/README.md` with a deprecation notice and usage guidance
  for the SDK-based multi-provider.
- Ensure the contrib multi-provider continues to compile and can still be used by existing consumers,
  but clearly communicates the migration path.

## Related Issues

Related to open-feature/java-sdk#1486

## Notes

- This PR does not introduce new functionality in contrib; it only deprecates the existing
  multi-provider and redirects users to the SDK implementation.
- The goal is to keep current users unbroken while nudging them toward the new, experimental
  multi-provider in the core SDK.

## Follow-up Tasks

- None (unless maintainers want a follow-up issue to remove contrib multi-provider entirely).

## How to test

- Run the contrib module tests (e.g. `mvn test` from the contrib repo root).
- Verify that:
  - The contrib multi-provider still compiles and tests pass.
  - IDEs show `@Deprecated` warnings for contrib multi-provider classes.
  - README/Javadoc references correctly point to
    `dev.openfeature.sdk.multiprovider.MultiProvider` in the core SDK.
