### PR TITLE
feat: add option to rebuild gRPC connection on error

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -20,6 +20,7 @@ public final class Config {
     static final int DEFAULT_MAX_CACHE_SIZE = 1000;
     static final int DEFAULT_OFFLINE_POLL_MS = 5000;
     static final long DEFAULT_KEEP_ALIVE = 0;
+    static final String DEFAULT_REINITIALIZE_ON_ERROR = "false";
 
     static final String RESOLVER_ENV_VAR = "FLAGD_RESOLVER";
     static final String HOST_ENV_VAR_NAME = "FLAGD_HOST";
@@ -51,6 +52,7 @@ public final class Config {
     static final String KEEP_ALIVE_MS_ENV_VAR_NAME = "FLAGD_KEEP_ALIVE_TIME_MS";
     static final String TARGET_URI_ENV_VAR_NAME = "FLAGD_TARGET_URI";
     static final String STREAM_RETRY_GRACE_PERIOD = "FLAGD_RETRY_GRACE_PERIOD";
+    static final String REINITIALIZE_ON_ERROR_ENV_VAR_NAME = "FLAGD_REINITIALIZE_ON_ERROR";
 
     static final String RESOLVER_RPC = "rpc";
     static final String RESOLVER_IN_PROCESS = "in-process";

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -205,6 +205,16 @@ public class FlagdOptions {
     private String defaultAuthority = fallBackToEnvOrDefault(Config.DEFAULT_AUTHORITY_ENV_VAR_NAME, null);
 
     /**
+     * !EXPERIMENTAL!
+     * Whether to reinitialize the channel (TCP connection) after the grace period is exceeded.
+     * This can help recover from connection issues by creating fresh connections.
+     * Particularly useful for troubleshooting network issues related to proxies or service meshes.
+     */
+    @Builder.Default
+    private boolean reinitializeOnError = Boolean.parseBoolean(
+            fallBackToEnvOrDefault(Config.REINITIALIZE_ON_ERROR_ENV_VAR_NAME, Config.DEFAULT_REINITIALIZE_ON_ERROR));
+
+    /**
      * Builder overwrite in order to customize the "build" method.
      *
      * @return the flagd options builder

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -104,10 +104,8 @@ public class InProcessResolver implements Resolver {
     public void onError() {
         if (queueSource instanceof SyncStreamQueueSource) {
             SyncStreamQueueSource syncConnector = (SyncStreamQueueSource) queueSource;
-            if (syncConnector.getStreamQueue() != null) {
-                // Only reinitialize if option is enabled
-                syncConnector.reinitializeChannelComponents();
-            }
+            // only reinitialize if option is enabled
+            syncConnector.reinitializeChannelComponents();
         }
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -41,6 +41,7 @@ public class InProcessResolver implements Resolver {
     private final Consumer<FlagdProviderEvent> onConnectionEvent;
     private final Operator operator;
     private final String scope;
+    private final QueueSource queueSource;
 
     /**
      * Resolves flag values using
@@ -52,7 +53,8 @@ public class InProcessResolver implements Resolver {
      *                          connection/stream
      */
     public InProcessResolver(FlagdOptions options, Consumer<FlagdProviderEvent> onConnectionEvent) {
-        this.flagStore = new FlagStore(getConnector(options));
+        this.queueSource = getQueueSource(options);
+        this.flagStore = new FlagStore(queueSource);
         this.onConnectionEvent = onConnectionEvent;
         this.operator = new Operator();
         this.scope = options.getSelector();
@@ -92,6 +94,21 @@ public class InProcessResolver implements Resolver {
         });
         stateWatcher.setDaemon(true);
         stateWatcher.start();
+    }
+
+    /**
+     * Called when the provider enters error state after grace period.
+     * Attempts to reinitialize the sync connector if enabled.
+     */
+    @Override
+    public void onError() {
+        if (queueSource instanceof SyncStreamQueueSource) {
+            SyncStreamQueueSource syncConnector = (SyncStreamQueueSource) queueSource;
+            if (syncConnector.getStreamQueue() != null) {
+                // Only reinitialize if option is enabled
+                syncConnector.reinitializeChannelComponents();
+            }
+        }
     }
 
     /**
@@ -147,7 +164,7 @@ public class InProcessResolver implements Resolver {
                 .build();
     }
 
-    static QueueSource getConnector(final FlagdOptions options) {
+    static QueueSource getQueueSource(final FlagdOptions options) {
         if (options.getCustomConnector() != null) {
             return options.getCustomConnector();
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -101,8 +101,7 @@ public class SyncStreamQueueSource implements QueueSource {
 
     /** Initialize channel connector and stubs. */
     private synchronized void initializeChannelComponents() {
-        ChannelConnector newConnector =
-                new ChannelConnector(options, ChannelBuilder.nettyChannel(options));
+        ChannelConnector newConnector = new ChannelConnector(options, ChannelBuilder.nettyChannel(options));
         FlagSyncServiceStub newFlagSyncStub =
                 FlagSyncServiceGrpc.newStub(newConnector.getChannel()).withWaitForReady();
         FlagSyncServiceBlockingStub newMetadataStub =

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -4,7 +4,6 @@ import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelConnector;
-import dev.openfeature.contrib.providers.flagd.resolver.common.FlagdProviderEvent;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueueSource;
@@ -24,7 +23,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -99,7 +97,6 @@ public class SyncStreamQueueSource implements QueueSource {
         syncMetadataDisabled = options.isSyncMetadataDisabled();
         reinitializeOnError = options.isReinitializeOnError();
         this.options = options;
-        //this.onConnectionEvent = null;
         this.grpcComponents = new GrpcComponents(connectorMock, stubMock, blockingStubMock);
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -23,7 +23,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -119,7 +119,7 @@ public class SyncStreamQueueSource implements QueueSource {
             return;
         }
 
-        log.info("Reinitializing channel gRPC components in attempt to restore stream...");
+        log.info("Reinitializing channel gRPC components in attempt to restore stream.");
         GrpcComponents oldComponents = grpcComponents;
 
         try {

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -33,7 +33,7 @@ import org.mockito.stubbing.Answer;
 
 class SyncStreamQueueSourceTest {
     @Test
-    void reinitializeChannelComponents_reinitializesWhenEnabled() {
+    void reinitializeChannelComponents_reinitializesWhenEnabled() throws InterruptedException {
         FlagdOptions options = FlagdOptions.builder().reinitializeOnError(true).build();
         ChannelConnector initialConnector = mock(ChannelConnector.class);
         FlagSyncServiceStub initialStub = mock(FlagSyncServiceStub.class);
@@ -41,17 +41,21 @@ class SyncStreamQueueSourceTest {
         SyncStreamQueueSource queueSource =
                 new SyncStreamQueueSource(options, initialConnector, initialStub, initialBlockingStub);
 
-        // save reference to old GrpcComponents
-        Object oldComponents = getPrivateField(queueSource, "grpcComponents");
-        queueSource.reinitializeChannelComponents();
-        Object newComponents = getPrivateField(queueSource, "grpcComponents");
-        // should have replaced grpcComponents
-        assertNotNull(newComponents);
-        org.junit.jupiter.api.Assertions.assertNotSame(oldComponents, newComponents);
+        try {
+            // save reference to old GrpcComponents
+            Object oldComponents = getPrivateField(queueSource, "grpcComponents");
+            queueSource.reinitializeChannelComponents();
+            Object newComponents = getPrivateField(queueSource, "grpcComponents");
+            // should have replaced grpcComponents
+            assertNotNull(newComponents);
+            org.junit.jupiter.api.Assertions.assertNotSame(oldComponents, newComponents);
+        } finally {
+            queueSource.shutdown();
+        }
     }
 
     @Test
-    void reinitializeChannelComponents_doesNothingWhenDisabled() {
+    void reinitializeChannelComponents_doesNothingWhenDisabled() throws InterruptedException {
         FlagdOptions options = FlagdOptions.builder().reinitializeOnError(false).build();
         ChannelConnector initialConnector = mock(ChannelConnector.class);
         FlagSyncServiceStub initialStub = mock(FlagSyncServiceStub.class);
@@ -59,11 +63,15 @@ class SyncStreamQueueSourceTest {
         SyncStreamQueueSource queueSource =
                 new SyncStreamQueueSource(options, initialConnector, initialStub, initialBlockingStub);
 
-        Object oldComponents = getPrivateField(queueSource, "grpcComponents");
-        queueSource.reinitializeChannelComponents();
-        Object newComponents = getPrivateField(queueSource, "grpcComponents");
-        // should NOT have replaced grpcComponents
-        org.junit.jupiter.api.Assertions.assertSame(oldComponents, newComponents);
+        try {
+            Object oldComponents = getPrivateField(queueSource, "grpcComponents");
+            queueSource.reinitializeChannelComponents();
+            Object newComponents = getPrivateField(queueSource, "grpcComponents");
+            // should NOT have replaced grpcComponents
+            org.junit.jupiter.api.Assertions.assertSame(oldComponents, newComponents);
+        } finally {
+            queueSource.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR adds an experimental option which rebuilds the entire gRPC connection if the provider goes into error state (after grace period). This can be useful for troublehsooting network issues, especially in the context of service meshes/proxies.

I added unit tests, but I also tested locally, and it works as expected. The feature can be enabled through config, but also with an env var: `FLAGD_REINITIALIZE_ON_ERROR`. It defaults to off.

Optionally depends on: https://github.com/open-feature/java-sdk-contrib/pull/1670