### PR TITLE
fix: use-integer-and-default-environment-refresh-interval-to-60

### DIFF
--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithClientConfigurer.java
@@ -118,7 +118,7 @@ public class FlagsmithClientConfigurer {
             flagsmithConfig.withLocalEvaluation(options.isLocalEvaluation());
         }
 
-        if (options.getEnvironmentRefreshIntervalSeconds() > -1) {
+        if (options.getEnvironmentRefreshIntervalSeconds() != null) {
             flagsmithConfig.withEnvironmentRefreshIntervalSeconds(options.getEnvironmentRefreshIntervalSeconds());
         }
 

--- a/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
+++ b/providers/flagsmith/src/main/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderOptions.java
@@ -118,7 +118,8 @@ public class FlagsmithProviderOptions {
      * Set environment refresh rate with polling manager. Only needed when local evaluation is true.
      * Optional. Default: 60
      */
-    private int environmentRefreshIntervalSeconds = 60;
+    @Builder.Default
+    private Integer environmentRefreshIntervalSeconds = 60;
 
     /**
      * Controls whether Flag Analytics data is sent to the Flagsmith API See

--- a/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
+++ b/providers/flagsmith/src/test/java/dev.openfeature.contrib.providers.flagsmith/FlagsmithProviderTest.java
@@ -203,6 +203,15 @@ public class FlagsmithProviderTest {
                         .getName());
     }
 
+    @Test
+    void shouldDefaultEnvironmentRefreshIntervalSecondsTo60() {
+        FlagsmithProviderOptions options = FlagsmithProviderOptions.builder()
+                .apiKey("API_KEY")
+                .localEvaluation(true)
+                .build();
+        assertEquals(Integer.valueOf(60), options.getEnvironmentRefreshIntervalSeconds());
+    }
+
     @ParameterizedTest
     @MethodSource("invalidOptions")
     void shouldThrowAnExceptionWhenOptionsInvalid(FlagsmithProviderOptions options) {


### PR DESCRIPTION
## This PR
Fixes missing @Builder.Default annotation on environmentRefreshIntervalSeconds in `FlagsmithProviderOptions`, which caused the polling interval to default to 0 instead of 60 seconds when using the Lombok builder.
  - Changes int to Integer for environmentRefreshIntervalSeconds
  - Adds @Builder.Default annotation with default value of 60
  - Updates null check in FlagsmithClientConfigurer
  - Adds test to verify default value
 
### Notes
when using `local evaluation` without explicitly setting environmentRefreshIntervalSeconds, the Lombok builder would default and set the value to a valid `0` (`if (options.getEnvironmentRefreshIntervalSeconds() > -1)`). This caused the Flagsmith client to poll continuously (~10 requests/second) instead of every 60 seconds.

### How to test
- Added tests
- Use jbang with following scripts (and using local new OF branch to verify the fix using `//REPOS mavenlocal`

**Value update picked up immediately before versus after**
```
// Before
 [15:26:22.354112] T+0s | Value: Helloworld
  [15:26:25.360984] T+3s | Value: Helloworld
  [15:26:28.365589] T+6s | Value: Helloworld
  [15:26:31.371258] T+9s | Value: Helloworld
===========> Value changed 1st time 
  [15:26:34.376814] T+12s | Value: Hellobug
  [15:26:37.382339] T+15s | Value: Hellobug
  [15:26:40.387870] T+18s | Value: Hellobug
  [15:26:43.392281] T+21s | Value: Hellobug
  [15:26:46.394779] T+24s | Value: Hellobug
  [15:26:49.400245] T+27s | Value: Hellobug
===========> Value changed 1st time 
  [15:26:52.405692] T+30s | Value: Helloworld?
  [15:26:55.411126] T+33s | Value: Helloworld?
```

```
// After
[15:21:51.938757] T+0s | Value: 156
  [15:21:54.946233] T+3s | Value: 156
  [15:21:57.949051] T+6s | Value: 156
  [15:22:00.954691] T+9s | Value: 156
  [15:22:03.956215] T+12s | Value: 156
===========> Value changed around here, multiple times
  [15:22:06.962181] T+15s | Value: 156
  [15:22:09.964224] T+18s | Value: 156
  [15:22:12.969802] T+21s | Value: 156
  [15:22:15.975424] T+24s | Value: 156
  [15:22:18.978476] T+27s | Value: 156
  [15:22:21.981948] T+30s | Value: 156
  [15:22:24.988074] T+33s | Value: 156
  [15:22:27.989652] T+36s | Value: 156
  [15:22:30.993176] T+39s | Value: 156
  [15:22:33.996962] T+42s | Value: 156
  [15:22:37.001746] T+45s | Value: 156
  [15:22:40.005927] T+48s | Value: 156
  [15:22:43.007989] T+51s | Value: 156
  [15:22:46.013681] T+54s | Value: 156
  [15:22:49.014780] T+57s | Value: 156
  [15:22:52.016969] T+60s | Value: 156
  [15:22:55.022578] T+63s | Value: Helloworld
  [15:22:58.028724] T+66s | Value: Helloworld
```


**Polling number of requests without setting the refresh interval using interceptor logging**
```
// Before
environmentRefreshIntervalSeconds from options: 0

  [15:29:11.493447] >>> HTTP REQUEST #1
  [15:29:11.900138] >>> HTTP REQUEST #2

  Waiting 5 seconds to observe polling...
  [15:29:12.065231] >>> HTTP REQUEST #3
  [15:29:12.177698] >>> HTTP REQUEST #4
  [15:29:12.285619] >>> HTTP REQUEST #5
  [15:29:12.368665] >>> HTTP REQUEST #6
  [15:29:12.500379] >>> HTTP REQUEST #7
  [15:29:12.579842] >>> HTTP REQUEST #8
  [15:29:12.672500] >>> HTTP REQUEST #9
  [15:29:12.763055] >>> HTTP REQUEST #10
  [15:29:12.907252] >>> HTTP REQUEST #11
  [15:29:12.992189] >>> HTTP REQUEST #12
  [15:29:13.079095] >>> HTTP REQUEST #13
  [15:29:13.167259] >>> HTTP REQUEST #14
  [15:29:13.253953] >>> HTTP REQUEST #15
  [15:29:13.362205] >>> HTTP REQUEST #16
  [15:29:13.482384] >>> HTTP REQUEST #17
  [15:29:13.559670] >>> HTTP REQUEST #18
  [15:29:13.630365] >>> HTTP REQUEST #19
  [15:29:13.711101] >>> HTTP REQUEST #20
  [15:29:13.847461] >>> HTTP REQUEST #21
  [15:29:13.939550] >>> HTTP REQUEST #22
  [15:29:14.048523] >>> HTTP REQUEST #23
```

```
// After
  environmentRefreshIntervalSeconds from options: 60

  [15:29:58.296412] >>> HTTP REQUEST #1

  Waiting 5 seconds to observe polling...

  Total HTTP requests in 5 seconds: 1
  [15:30:58.704809] >>> HTTP REQUEST #2
```