### PR TITLE
fix(multiprovider): Properly shutdown multiprovider initialization thread pool

### DIFF
--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
@@ -105,10 +105,10 @@ public class MultiProvider extends EventProvider {
         ExecutorService initPool = Executors.newFixedThreadPool(INIT_THREADS_COUNT);
         try {
             List<Future<Boolean>> results = initPool.invokeAll(tasks);
+            // Wait for all provider initializations to complete.
+            // If any provider.initialize() throws, result.get() will throw ExecutionException.
             for (Future<Boolean> result : results) {
-                if (!result.get()) {
-                    throw new GeneralError("init failed");
-                }
+                result.get();
             }
         } finally {
             initPool.shutdown();

--- a/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
+++ b/providers/multiprovider/src/main/java/dev/openfeature/contrib/providers/multiprovider/MultiProvider.java
@@ -6,7 +6,6 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.GeneralError;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;


### PR DESCRIPTION
## This PR

This pull request refactors the initialization logic in the `MultiProvider` class to ensure proper resource management for the thread pool used during provider initialization. The main change is moving the creation and shutdown of the `ExecutorService` into a try-finally block, which guarantees that the thread pool is always shut down, even if an exception occurs.

We observed issues with some of our apps that fail to shutdown properly because of a hanging non-daemon thread, the changes proposed in this PR fix the issue (tested on our previously failing app).