### PR TITLE
chore: bump WASM to v0.1.3

### DIFF
--- a/providers/go-feature-flag/pom.xml
+++ b/providers/go-feature-flag/pom.xml
@@ -20,7 +20,7 @@
         <!-- override module name defined in parent ("-" is not allowed) -->
         <module-name>${groupId}.gofeatureflag</module-name>
 
-        <wasm.version>v1.45.4</wasm.version>
+        <wasm.version>v0.1.3</wasm.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
Automated pull request to bump the GO Feature Flag evaluation WASM version to v0.1.3.