### PR TITLE
fix: use shaded netty transport, update to 1.79

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- exclusion expression for e2e tests -->
         <testExclusions>**/e2e/*.java</testExclusions>
-        <io.grpc.version>1.77.0</io.grpc.version>
+        <io.grpc.version>1.79.0</io.grpc.version>
         <!-- caution - updating this will break compatibility with older protobuf-java versions -->
         <protobuf-java.min.version>3.25.6</protobuf-java.min.version>
     </properties>
@@ -44,7 +44,7 @@
 
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
             <version>${io.grpc.version}</version>
         </dependency>
 
@@ -60,14 +60,7 @@
             <version>${io.grpc.version}</version>
         </dependency>
 
-        <dependency>
-            <!-- we only support unix sockets on linux, via epoll native lib -->
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.2.7.Final</version>
-            <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
-            <classifier>linux-x86_64</classifier>
-        </dependency>
+        <!-- grpc-netty-shaded bundles netty with epoll support for unix sockets -->
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -13,14 +13,13 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolverRegistry;
 import io.grpc.Status.Code;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollIoHandler;
-import io.netty.channel.unix.DomainSocketAddress;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.epoll.Epoll;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.unix.DomainSocketAddress;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -107,7 +106,7 @@ public class ChannelBuilder {
             }
             var channelBuilder = NettyChannelBuilder.forAddress(new DomainSocketAddress(options.getSocketPath()))
                     .keepAliveTime(keepAliveMs, TimeUnit.MILLISECONDS)
-                    .eventLoopGroup(new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory()))
+                    .eventLoopGroup(new EpollEventLoopGroup())
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()
                     .defaultServiceConfig(buildRetryPolicy(options))


### PR DESCRIPTION
This uses the shaded netty-transport jars for gRPC to reduce dependency conflicts as recommended by grpc-java authors:

> The Netty-based HTTP/2 transport is the main transport implementation based on [Netty](https://netty.io/)...There is a "grpc-netty-shaded" version of this transport. _**It is generally preferred over using the Netty-based transport directly as it requires less dependency management and is easier to upgrade within many applications.**_