### PR TITLE
fix: use shaded netty transport jar

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- exclusion expression for e2e tests -->
         <testExclusions>**/e2e/*.java</testExclusions>
-        <io.grpc.version>1.77.0</io.grpc.version>
+        <io.grpc.version>1.79.0</io.grpc.version>
         <!-- caution - updating this will break compatibility with older protobuf-java versions -->
         <protobuf-java.min.version>3.25.6</protobuf-java.min.version>
     </properties>
@@ -44,7 +44,7 @@
 
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
             <version>${io.grpc.version}</version>
         </dependency>
 
@@ -60,14 +60,7 @@
             <version>${io.grpc.version}</version>
         </dependency>
 
-        <dependency>
-            <!-- we only support unix sockets on linux, via epoll native lib -->
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.2.7.Final</version>
-            <!-- TODO: with 5+ (still alpha), arm is support and we should package multiple versions -->
-            <classifier>linux-x86_64</classifier>
-        </dependency>
+        <!-- grpc-netty-shaded bundles netty with epoll support for unix sockets -->
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilder.java
@@ -13,14 +13,12 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolverRegistry;
 import io.grpc.Status.Code;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollIoHandler;
-import io.netty.channel.unix.DomainSocketAddress;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.epoll.Epoll;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.grpc.netty.shaded.io.netty.channel.unix.DomainSocketAddress;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -107,7 +105,6 @@ public class ChannelBuilder {
             }
             var channelBuilder = NettyChannelBuilder.forAddress(new DomainSocketAddress(options.getSocketPath()))
                     .keepAliveTime(keepAliveMs, TimeUnit.MILLISECONDS)
-                    .eventLoopGroup(new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory()))
                     .channelType(EpollDomainSocketChannel.class)
                     .usePlaintext()
                     .defaultServiceConfig(buildRetryPolicy(options))

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelBuilderTest.java
@@ -7,9 +7,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -19,15 +16,12 @@ import static org.mockito.Mockito.when;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollIoHandler;
-import io.netty.channel.unix.DomainSocketAddress;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.epoll.Epoll;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.grpc.netty.shaded.io.netty.channel.unix.DomainSocketAddress;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,12 +40,10 @@ class ChannelBuilderTest {
     @EnabledOnOs(OS.LINUX)
     void testNettyChannel_withSocketPath() {
         try (MockedStatic<Epoll> epollMock = mockStatic(Epoll.class);
-                MockedStatic<EpollIoHandler> nativeMock = mockStatic(EpollIoHandler.class);
                 MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
 
             // Mocks
             epollMock.when(Epoll::isAvailable).thenReturn(true);
-            nativeMock.when(EpollIoHandler::newFactory).thenReturn(mock(IoHandlerFactory.class));
             NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
             ManagedChannel mockChannel = mock(ManagedChannel.class);
 
@@ -60,8 +52,6 @@ class ChannelBuilderTest {
                     .thenReturn(mockBuilder);
 
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
-            when(mockBuilder.eventLoopGroup(any(MultiThreadIoEventLoopGroup.class)))
-                    .thenReturn(mockBuilder);
             when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
             when(mockBuilder.defaultServiceConfig(any())).thenReturn(mockBuilder);
             when(mockBuilder.maxRetryAttempts(anyInt())).thenReturn(mockBuilder);
@@ -82,7 +72,6 @@ class ChannelBuilderTest {
             assertThat(channel).isEqualTo(mockChannel);
             nettyMock.verify(() -> NettyChannelBuilder.forAddress(new DomainSocketAddress("/path/to/socket")));
             verify(mockBuilder).keepAliveTime(1000, TimeUnit.MILLISECONDS);
-            verify(mockBuilder).eventLoopGroup(any(MultiThreadIoEventLoopGroup.class));
             verify(mockBuilder).channelType(EpollDomainSocketChannel.class);
             verify(mockBuilder).usePlaintext();
             verify(mockBuilder).build();
@@ -93,12 +82,10 @@ class ChannelBuilderTest {
     @EnabledOnOs(OS.LINUX)
     void testNettyChannel_withSocketPath_withRetryPolicy() {
         try (MockedStatic<Epoll> epollMock = mockStatic(Epoll.class);
-                MockedStatic<EpollIoHandler> nativeMock = mockStatic(EpollIoHandler.class);
                 MockedStatic<NettyChannelBuilder> nettyMock = mockStatic(NettyChannelBuilder.class)) {
 
             // Mocks
             epollMock.when(Epoll::isAvailable).thenReturn(true);
-            nativeMock.when(EpollIoHandler::newFactory).thenReturn(mock(IoHandlerFactory.class));
             NettyChannelBuilder mockBuilder = mock(NettyChannelBuilder.class);
             ManagedChannel mockChannel = mock(ManagedChannel.class);
 
@@ -113,8 +100,6 @@ class ChannelBuilderTest {
                     .thenReturn(mockBuilder);
 
             when(mockBuilder.keepAliveTime(anyLong(), any(TimeUnit.class))).thenReturn(mockBuilder);
-            when(mockBuilder.eventLoopGroup(any(MultiThreadIoEventLoopGroup.class)))
-                    .thenReturn(mockBuilder);
             when(mockBuilder.channelType(EpollDomainSocketChannel.class)).thenReturn(mockBuilder);
             when(mockBuilder.defaultServiceConfig(ChannelBuilder.buildRetryPolicy(options)))
                     .thenReturn(mockBuilder);
@@ -129,7 +114,6 @@ class ChannelBuilderTest {
             assertThat(channel).isEqualTo(mockChannel);
             nettyMock.verify(() -> NettyChannelBuilder.forAddress(new DomainSocketAddress("/path/to/socket")));
             verify(mockBuilder).keepAliveTime(1000, TimeUnit.MILLISECONDS);
-            verify(mockBuilder).eventLoopGroup(any(MultiThreadIoEventLoopGroup.class));
             verify(mockBuilder).channelType(EpollDomainSocketChannel.class);
             verify(mockBuilder).defaultServiceConfig(ChannelBuilder.buildRetryPolicy(options));
             verify(mockBuilder).usePlaintext();


### PR DESCRIPTION
This uses the shaded netty-transport jars for gRPC to reduce dependency conflicts as recommended by grpc-java authors:

> The Netty-based HTTP/2 transport is the main transport implementation based on [Netty](https://netty.io/)...There is a "grpc-netty-shaded" version of this transport. _**It is generally preferred over using the Netty-based transport directly as it requires less dependency management and is easier to upgrade within many applications.**_

We've seen conflicts at Dynatrace with internal services, for example:

```
java.lang.NoSuchMethodError: 'void io.grpc.internal.KeepAliveManager$ClientKeepAlivePinger.<init>(io.grpc.internal.ConnectionClientTransport)'
```

This is an internal class, not exposed in the gRPC API. Mismatched gRPC versions various deps, with no breaking external changes, can have incompatible `internal` classes like this - switching to `shaded` version bundles all the internal packages together so this doesn't happen.