### PR TITLE
fix: fixing null pointer exception error

### DIFF
--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -274,7 +274,7 @@ public class FlagdCore implements Evaluator {
             addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
         }
 
-        if (flag != null && flag.getTargeting() != null) {
+        if (flag != null && flag.getMetadata() != null) {
             for (Map.Entry<String, Object> entry : flag.getMetadata().entrySet()) {
                 addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
             }

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -274,7 +274,7 @@ public class FlagdCore implements Evaluator {
             addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
         }
 
-        if (flag != null) {
+        if (flag != null && flag.getTargeting() != null) {
             for (Map.Entry<String, Object> entry : flag.getMetadata().entrySet()) {
                 addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
             }

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -270,8 +270,11 @@ public class FlagdCore implements Evaluator {
 
     private static ImmutableMetadata getFlagMetadata(Map<String, Object> currentFlagSetMetadata, FeatureFlag flag) {
         ImmutableMetadata.ImmutableMetadataBuilder metadataBuilder = ImmutableMetadata.builder();
-        for (Map.Entry<String, Object> entry : currentFlagSetMetadata.entrySet()) {
-            addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
+
+        if (currentFlagSetMetadata != null) {
+            for (Map.Entry<String, Object> entry : currentFlagSetMetadata.entrySet()) {
+                addEntryToMetadataBuilder(metadataBuilder, entry.getKey(), entry.getValue());
+            }
         }
 
         if (flag != null && flag.getMetadata() != null) {

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -145,7 +145,7 @@ class FlagdCoreTest {
         assertThatNoException().isThrownBy(() -> {
             flagdCore.setFlags(configWithNullMetadata);
             ProviderEvaluation<Boolean> result =
-                    flagdCore.resolveBooleanValue("nullMetadataFlag", new ImmutableContext());
+                    flagdCore.resolveBooleanValue("nullMetadataFlag", false, new ImmutableContext());
             assertThat(result.getFlagMetadata()).isNotNull();
         });
     }

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -144,7 +144,8 @@ class FlagdCoreTest {
 
         assertThatNoException().isThrownBy(() -> {
             flagdCore.setFlags(configWithNullMetadata);
-            ProviderEvaluation<Boolean> result = flagdCore.resolveBooleanValue("nullMetadataFlag", new ImmutableContext());
+            ProviderEvaluation<Boolean> result =
+                    flagdCore.resolveBooleanValue("nullMetadataFlag", new ImmutableContext());
             assertThat(result.getFlagMetadata()).isNotNull();
         });
     }

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.tools.flagd.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import dev.openfeature.contrib.tools.flagd.api.FlagStoreException;
 import dev.openfeature.sdk.ImmutableContext;
@@ -126,5 +127,25 @@ class FlagdCoreTest {
 
         // Then: boolFlag should be in the changed keys (it was removed)
         assertThat(changedKeys).contains("boolFlag");
+    }
+
+    @Test
+    void resolveBooleanValue_flagWithNullMetadata_doesNotThrowNPE() {
+        String configWithNullMetadata = "{"
+                + "\"$schema\": \"https://flagd.dev/schema/v0/flags.json\","
+                + "\"flags\": {"
+                + "  \"nullMetadataFlag\": {"
+                + "    \"state\": \"ENABLED\","
+                + "    \"defaultVariant\": \"on\","
+                + "    \"variants\": { \"on\": true }"
+                + "  }"
+                + "}"
+                + "}";
+
+        assertThatNoException().isThrownBy(() -> {
+            flagdCore.setFlags(configWithNullMetadata);
+            ProviderEvaluation<Boolean> result = flagdCore.resolveBooleanValue("nullMetadataFlag", new ImmutableContext());
+            assertThat(result.getFlagMetadata()).isNotNull();
+        });
     }
 }


### PR DESCRIPTION
## fix: null pointer exceptionn error
- Adds null check for `flag.getMetadata()` in `getFlagMetadata()` to prevent 
  NullPointerException when a flagd server doesn't support metadata.

### Related Issues
Fixes #1708

### Notes
`currentFlagSetMetadata` is always initialized as a new HashMap so it won't 
be null, but `flag.getMetadata()` can return null on servers that don't support 
metadata. Added a null guard before iterating over it.

### How to test
A new test `resolveBooleanValue_flagWithNullMetadata_doesNotThrowNPE` has been 
added to `FlagdCoreTest` that verifies no NPE is thrown when evaluating a flag 
with no metadata defined.