### PR TITLE
feat(flagd): log error on invalid env var parsing

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -85,6 +85,11 @@ public final class Config {
         try {
             return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
         } catch (Exception e) {
+            log.error(
+                    "Failed to parse env variable '{}' with value '{}' as int, using default: {}",
+                    key,
+                    System.getenv(key),
+                    defaultValue);
             return defaultValue;
         }
     }
@@ -93,6 +98,11 @@ public final class Config {
         try {
             return System.getenv(key) != null ? Long.parseLong(System.getenv(key)) : defaultValue;
         } catch (Exception e) {
+            log.error(
+                    "Failed to parse env variable '{}' with value '{}' as long, using default: {}",
+                    key,
+                    System.getenv(key),
+                    defaultValue);
             return defaultValue;
         }
     }
@@ -105,6 +115,11 @@ public final class Config {
                             .collect(Collectors.toList())
                     : defaultValue;
         } catch (Exception e) {
+            log.error(
+                    "Failed to parse env variable '{}' with value '{}' as list, using default: {}",
+                    key,
+                    System.getenv(key),
+                    defaultValue);
             return defaultValue;
         }
     }


### PR DESCRIPTION
## Summary
- Adds ERROR-level log output when environment variables cannot be parsed, instead of silently falling back to defaults
- Covers integer, long, and list parsing in `Config.java`
- Uses the existing `@Slf4j` logger already present on the class

Fixes #1673