### PR TITLE
fix: ignore redundant interrupted exceptions

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdProvider.java
@@ -1,6 +1,7 @@
 package dev.openfeature.contrib.providers.flagd;
 
 import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ShutdownUtils;
 import dev.openfeature.contrib.providers.flagd.resolver.process.InProcessResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.rpc.RpcResolver;
 import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.Cache;
@@ -142,7 +143,8 @@ public class FlagdProvider extends EventProvider {
                 this.flagResolver.shutdown();
                 if (errorExecutor != null) {
                     errorExecutor.shutdownNow();
-                    errorExecutor.awaitTermination(deadline, TimeUnit.MILLISECONDS);
+                    ShutdownUtils.awaitTerminationQuietly(
+                            () -> errorExecutor.awaitTermination(deadline, TimeUnit.MILLISECONDS));
                 }
             } catch (Exception e) {
                 log.error("Error during shutdown {}", FLAGD_PROVIDER, e);

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelConnector.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ChannelConnector.java
@@ -36,15 +36,13 @@ public class ChannelConnector {
 
     /**
      * Shuts down the GRPC connection and cleans up associated resources.
-     *
-     * @throws InterruptedException if interrupted while waiting for termination
      */
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         log.info("Shutting down GRPC connection.");
 
         if (!channel.isShutdown()) {
             channel.shutdownNow();
-            channel.awaitTermination(deadline, TimeUnit.MILLISECONDS);
+            ShutdownUtils.awaitTerminationQuietly(() -> channel.awaitTermination(deadline, TimeUnit.MILLISECONDS));
         }
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ShutdownUtils.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/common/ShutdownUtils.java
@@ -1,0 +1,27 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+/**
+ * Utility for shutdown operations that involve interruptible waits.
+ */
+public final class ShutdownUtils {
+
+    private ShutdownUtils() {}
+
+    /** An action that may throw InterruptedException. */
+    @FunctionalInterface
+    public interface InterruptibleAction {
+        void run() throws InterruptedException;
+    }
+
+    /**
+     * Run an action that may throw InterruptedException (e.g. awaitTermination),
+     * suppressing the exception and restoring the interrupt flag.
+     */
+    public static void awaitTerminationQuietly(InterruptibleAction action) {
+        try {
+            action.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolver.java
@@ -131,10 +131,8 @@ public class InProcessResolver implements Resolver {
 
     /**
      * Shutdown in-process resolver.
-     *
-     * @throws InterruptedException if stream can't be closed within deadline.
      */
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         if (!shutdown.compareAndSet(false, true)) {
             log.debug("Shutdown already in progress or completed");
             return;

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/FlagStore.java
@@ -49,12 +49,10 @@ public class FlagStore implements Storage {
     }
 
     /**
-     * Shutdown storage layer.
-     *
-     * @throws InterruptedException if stream can't be closed within deadline.
+     * Shutdown storage connector.
      */
     @Override
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         if (shutdown.getAndSet(true)) {
             return;
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/Storage.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/Storage.java
@@ -6,7 +6,7 @@ import java.util.concurrent.BlockingQueue;
 public interface Storage {
     void init() throws Exception;
 
-    void shutdown() throws InterruptedException;
+    void shutdown();
 
     BlockingQueue<StorageStateChange> getStateQueue();
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/QueueSource.java
@@ -11,5 +11,5 @@ public interface QueueSource {
 
     BlockingQueue<QueuePayload> getStreamQueue();
 
-    void shutdown() throws InterruptedException;
+    void shutdown();
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/file/FileQueueSource.java
@@ -91,7 +91,7 @@ public class FileQueueSource implements QueueSource {
     }
 
     /** Shutdown file connector. */
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         shutdown = true;
     }
 }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSource.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Struct;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelConnector;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ShutdownUtils;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayload;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueuePayloadType;
 import dev.openfeature.contrib.providers.flagd.resolver.process.storage.connector.QueueSource;
@@ -161,10 +162,8 @@ public class SyncStreamQueueSource implements QueueSource {
 
     /**
      * Shutdown gRPC stream connector.
-     *
-     * @throws InterruptedException if stream can't be closed within deadline.
      */
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         // Do not enqueue errors from here, as this method can be called externally, causing multiple shutdown signals
         // Use atomic compareAndSet to ensure shutdown is only executed once
         // This prevents race conditions when shutdown is called from multiple threads
@@ -173,9 +172,12 @@ public class SyncStreamQueueSource implements QueueSource {
             return;
         }
 
-        retryScheduler.shutdownNow();
-        retryScheduler.awaitTermination(deadline, TimeUnit.MILLISECONDS);
-        grpcComponents.channelConnector.shutdown();
+        synchronized (this) {
+            retryScheduler.shutdownNow();
+            ShutdownUtils.awaitTerminationQuietly(
+                    () -> retryScheduler.awaitTermination(deadline, TimeUnit.MILLISECONDS));
+            grpcComponents.channelConnector.shutdown();
+        }
     }
 
     /** Contains blocking calls, to be used concurrently. */

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ShutdownUtilsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/common/ShutdownUtilsTest.java
@@ -1,0 +1,24 @@
+package dev.openfeature.contrib.providers.flagd.resolver.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ShutdownUtilsTest {
+
+    @Test
+    void doesNotThrowWhenActionSucceeds() {
+        assertDoesNotThrow(() -> ShutdownUtils.awaitTerminationQuietly(() -> {}));
+    }
+
+    @Test
+    void suppressesInterruptedExceptionAndRestoresFlag() {
+        Thread.interrupted(); // clear flag
+
+        ShutdownUtils.awaitTerminationQuietly(() -> {
+            throw new InterruptedException();
+        });
+
+        assertTrue(Thread.interrupted(), "interrupt flag should be restored");
+    }
+}


### PR DESCRIPTION
The `awaitTermination` on `retryScheduler` was added in https://github.com/open-feature/java-sdk-contrib/pull/1734 as boilerplate when we removed some `Thread.sleep`s. The `awaitTermination` calls in the shutdown chain throw `InterruptedException` when the SDK's shutdown timeout fires and sets the interrupt flag. This is harmless but noisy.

This PR adds a `ShutdownUtils.awaitTerminationQuietly()` utility that catches `InterruptedException` and restores the interrupt flag. It's applied to all three `awaitTermination` sites in the shutdown chain. This is safe because nothing further up the call stack relies on `InterruptedException` from shutdown; the interrupt flag is preserved so any subsequent interruptible operations still behave. I added some basic tests for this util.

Also adds `synchronized(this)` to `SyncStreamQueueSource.shutdown()` to prevent `grpcComponents` from being swapped by `reinitializeChannelComponents()` mid-shutdown as Gemini pointed out, there's a possible race here.

I manually tested this with a very contrived test to confirm my understanding, but I don't think adding the test will add much value long term and it's weird to test for the absence of a line-of-code IMO.
