### PR TITLE
feat: switch to io.github.gzsombor json logic lib

### DIFF
--- a/providers/flagd/pom.xml
+++ b/providers/flagd/pom.xml
@@ -19,7 +19,7 @@
         <io.grpc.version>1.79.0</io.grpc.version>
         <!-- caution - updating this will break compatibility with older protobuf-java versions -->
         <protobuf-java.min.version>3.25.6</protobuf-java.min.version>
-        <com.vmlens.version>1.2.27</com.vmlens.version>
+        <com.vmlens.version>1.2.28</com.vmlens.version>
         <!-- Transitive flagd-core version -->
         <flagd-core.version>[1.0.0,2.0.0)</flagd-core.version>
     </properties>
@@ -239,6 +239,10 @@
                                         <include>**/*CTest.java</include>
                                     </includes>
                                     <failIfNoTests>true</failIfNoTests>
+                                    <environmentVariables>
+                                        <!-- disable JsonLogic compilation to reduce VMLens interleaving combinations -->
+                                        <FLAGD_DISABLE_TARGETING_COMPILATION>true</FLAGD_DISABLE_TARGETING_COMPILATION>
+                                    </environmentVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/tools/flagd-core/pom.xml
+++ b/tools/flagd-core/pom.xml
@@ -47,9 +47,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.jamsesso</groupId>
+            <groupId>io.github.gzsombor</groupId>
             <artifactId>json-logic-java</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.3</version>
         </dependency>
 
         <!-- Override gson usage of json-logic-java-->

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/targeting/Operator.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/targeting/Operator.java
@@ -19,13 +19,26 @@ public class Operator {
     static final String TARGET_KEY = "targetingKey";
     static final String TIME_STAMP = "timestamp";
 
+    static final String DISABLE_TARGETING_COMPILATION_ENV_VAR_NAME = "FLAGD_DISABLE_TARGETING_COMPILATION";
+
     private final JsonLogic jsonLogicHandler;
 
     /**
      * Construct a targeting operator.
+     * Compiles targeting rules into native Java methods by default, unless the
+     * FLAGD_DISABLE_TARGETING_COMPILATION environment variable is set.
      */
     public Operator() {
-        jsonLogicHandler = new JsonLogic();
+        this(!Boolean.parseBoolean(System.getenv(DISABLE_TARGETING_COMPILATION_ENV_VAR_NAME)));
+    }
+
+    /**
+     * Construct a targeting operator.
+     *
+     * @param compileExpressions whether to compile JsonLogic expressions for better performance
+     */
+    public Operator(boolean compileExpressions) {
+        jsonLogicHandler = new JsonLogic(compileExpressions);
         jsonLogicHandler.addOperation(new Fractional());
         jsonLogicHandler.addOperation(new SemVer());
         jsonLogicHandler.addOperation(new StringComp(StringComp.Type.STARTS_WITH));


### PR DESCRIPTION
The maintainer of the previous library was unresponsive.

This migrates to an implementation forked and maintained by @gzsombor, a Dynatrace employee: https://github.com/gzsombor/json-logic-java.

This version offers significant improvements in speed and memory usage, partially by pre-compiling operators.

Note: the `FLAGD_DISABLE_TARGETING_COMPILATION` option disables the pre-compilation, mostly because the compilation results in massively increased interleave search space for vmlens, so we leverage this option in the vmlens test step.

cc @chrfwow make sense to you?