### PR TITLE
fix: tight loop in RPC mode event stream reconnect

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
@@ -12,6 +12,7 @@ import dev.openfeature.contrib.providers.flagd.resolver.Resolver;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelBuilder;
 import dev.openfeature.contrib.providers.flagd.resolver.common.ChannelConnector;
 import dev.openfeature.contrib.providers.flagd.resolver.common.QueueingStreamObserver;
+import dev.openfeature.contrib.providers.flagd.resolver.common.ShutdownUtils;
 import dev.openfeature.contrib.providers.flagd.resolver.common.StreamResponseModel;
 import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.Cache;
 import dev.openfeature.contrib.providers.flagd.resolver.rpc.strategy.ResolveFactory;
@@ -144,6 +145,8 @@ public final class RpcResolver implements Resolver {
             return;
         }
         this.retryScheduler.shutdownNow();
+        ShutdownUtils.awaitTerminationQuietly(
+                () -> retryScheduler.awaitTermination(options.getDeadline(), TimeUnit.MILLISECONDS));
         this.connector.shutdown();
     }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
@@ -46,7 +46,10 @@ import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -62,16 +65,23 @@ import lombok.extern.slf4j.Slf4j;
 public final class RpcResolver implements Resolver {
     private static final int QUEUE_SIZE = 5;
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
+    private final AtomicBoolean shouldThrottle = new AtomicBoolean(false);
     private final AtomicBoolean successfulConnection = new AtomicBoolean(false);
     private final ChannelConnector connector;
     private final Cache cache;
     private final ResolveStrategy strategy;
     private final FlagdOptions options;
+    private final int maxBackoffMs;
     private final LinkedBlockingQueue<StreamResponseModel<EventStreamResponse>> incomingQueue;
     private final TriConsumer<ProviderEvent, ProviderEventDetails, Structure> onProviderEvent;
     private final ServiceStub stub;
     private final ServiceBlockingStub blockingStub;
     private final List<String> fatalStatusCodes;
+    private final ScheduledExecutorService retryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "flagd-rpc-retry-scheduler");
+        t.setDaemon(true);
+        return t;
+    });
 
     /**
      * Resolves flag values using
@@ -96,6 +106,7 @@ public final class RpcResolver implements Resolver {
         this.blockingStub =
                 ServiceGrpc.newBlockingStub(this.connector.getChannel()).withWaitForReady();
         this.fatalStatusCodes = options.getFatalStatusCodes();
+        this.maxBackoffMs = options.getRetryBackoffMaxMs();
     }
 
     // testing only
@@ -115,20 +126,14 @@ public final class RpcResolver implements Resolver {
         this.stub = mockStub;
         this.blockingStub = mockBlockingStub;
         this.fatalStatusCodes = options.getFatalStatusCodes();
+        this.maxBackoffMs = options.getRetryBackoffMaxMs();
     }
 
     /**
      * Initialize RpcResolver resolver.
      */
     public void init() throws Exception {
-        Thread listener = new Thread(() -> {
-            try {
-                observeEventStream();
-            } catch (InterruptedException e) {
-                log.warn("gRPC event stream interrupted, flag configurations are stale", e);
-                Thread.currentThread().interrupt();
-            }
-        });
+        Thread listener = new Thread(this::observeEventStream);
 
         listener.setDaemon(true);
         listener.start();
@@ -141,6 +146,7 @@ public final class RpcResolver implements Resolver {
         if (shutdown.getAndSet(true)) {
             return;
         }
+        this.retryScheduler.shutdownNow();
         this.connector.shutdown();
     }
 
@@ -337,63 +343,81 @@ public final class RpcResolver implements Resolver {
     }
 
     /** Contains blocking calls, to be used concurrently. */
-    private void observeEventStream() throws InterruptedException {
+    private void observeEventStream() {
 
         log.info("Initializing event stream observer");
 
         // outer loop for re-issuing the stream request
         // "waitForReady" on the channel, plus our retry policy slow this loop down in error conditions
         while (!shutdown.get()) {
-
-            log.debug("Initializing event stream request");
-            restartStream();
-            // inner loop for handling messages
-            while (!shutdown.get()) {
-                final StreamResponseModel<EventStreamResponse> taken = incomingQueue.take();
-                if (taken.isComplete()) {
-                    log.debug("Event stream completed, will reconnect");
-                    this.handleErrorOrComplete(false);
-                    // The stream is complete, we still try to reconnect
-                    break;
-                }
-
-                Throwable streamException = taken.getError();
-                if (streamException != null) {
-                    if (streamException instanceof StatusRuntimeException
-                            && fatalStatusCodes.contains(((StatusRuntimeException) streamException)
-                                    .getStatus()
-                                    .getCode()
-                                    .name())
-                            && !successfulConnection.get()) {
-                        log.debug(
-                                "Fatal error code received: {}",
-                                ((StatusRuntimeException) streamException)
-                                        .getStatus()
-                                        .getCode());
-                        this.handleErrorOrComplete(true);
-                    } else {
-                        log.debug(
-                                "Exception in event stream connection, streamException {}, will reconnect",
-                                streamException);
-                        this.handleErrorOrComplete(false);
+            try {
+                // explicit backoff after stream errors to prevent tight loops when errors are returned immediately
+                // (e.g., by intervening proxies like Envoy)
+                if (shouldThrottle.getAndSet(false)) {
+                    log.debug("Previous stream ended with error, waiting {} ms before retry", this.maxBackoffMs);
+                    try {
+                        retryScheduler.schedule(this::observeEventStream, this.maxBackoffMs, TimeUnit.MILLISECONDS);
+                    } catch (RejectedExecutionException e) {
+                        log.debug("Retry scheduling rejected, most likely shutdown was invoked", e);
                     }
-                    break;
+                    return;
                 }
 
-                successfulConnection.set(true);
-                final EventStreamResponse response = taken.getResponse();
-                log.debug("Got stream response: {}", response);
+                log.debug("Initializing event stream request");
+                restartStream();
+                // inner loop for handling messages
+                while (!shutdown.get()) {
+                    final StreamResponseModel<EventStreamResponse> taken = incomingQueue.take();
+                    if (taken.isComplete()) {
+                        log.debug("Event stream completed, will reconnect");
+                        this.handleErrorOrComplete(false);
+                        shouldThrottle.set(true);
+                        // the stream is complete, we still try to reconnect
+                        break;
+                    }
 
-                switch (response.getType()) {
-                    case Constants.CONFIGURATION_CHANGE:
-                        this.handleConfigurationChangeEvent(response);
+                    Throwable streamException = taken.getError();
+                    if (streamException != null) {
+                        if (streamException instanceof StatusRuntimeException
+                                && fatalStatusCodes.contains(((StatusRuntimeException) streamException)
+                                        .getStatus()
+                                        .getCode()
+                                        .name())
+                                && !successfulConnection.get()) {
+                            log.debug(
+                                    "Fatal error code received: {}",
+                                    ((StatusRuntimeException) streamException)
+                                            .getStatus()
+                                            .getCode());
+                            this.handleErrorOrComplete(true);
+                        } else {
+                            log.debug(
+                                    "Exception in event stream connection, streamException {}, will reconnect",
+                                    streamException);
+                            this.handleErrorOrComplete(false);
+                        }
+                        shouldThrottle.set(true);
                         break;
-                    case Constants.PROVIDER_READY:
-                        this.handleProviderReadyEvent();
-                        break;
-                    default:
-                        log.debug("Unhandled event type {}", response.getType());
+                    }
+
+                    successfulConnection.set(true);
+                    final EventStreamResponse response = taken.getResponse();
+                    log.debug("Got stream response: {}", response);
+
+                    switch (response.getType()) {
+                        case Constants.CONFIGURATION_CHANGE:
+                            this.handleConfigurationChangeEvent(response);
+                            break;
+                        case Constants.PROVIDER_READY:
+                            this.handleProviderReadyEvent();
+                            break;
+                        default:
+                            log.debug("Unhandled event type {}", response.getType());
+                    }
                 }
+            } catch (InterruptedException ie) {
+                log.debug("Stream observer interrupted, most likely shutdown was invoked", ie);
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
@@ -133,10 +133,7 @@ public final class RpcResolver implements Resolver {
      * Initialize RpcResolver resolver.
      */
     public void init() throws Exception {
-        Thread listener = new Thread(this::observeEventStream);
-
-        listener.setDaemon(true);
-        listener.start();
+        retryScheduler.execute(this::observeEventStream);
     }
 
     /**

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/storage/connector/sync/SyncStreamQueueSourceTest.java
@@ -176,7 +176,7 @@ class SyncStreamQueueSourceTest {
     }
 
     @Test
-    void syncInitError_DoesNotBusyWait() throws Exception {
+    void syncInitError_RetriesWithNonBlockingBackoff() throws Exception {
         // make sure we do not spin in a busy loop on immediately errors
 
         int maxBackoffMs = 1000;
@@ -201,7 +201,7 @@ class SyncStreamQueueSourceTest {
     }
 
     @Test
-    void asyncInitError_DoesNotBusyWait() throws Exception {
+    void asyncInitError_RetriesWithNonBlockingBackoff() throws Exception {
         // make sure we do not spin in a busy loop on async errors
 
         int maxBackoffMs = 1000;

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
@@ -31,6 +31,7 @@ class RpcResolverTest {
     private ChannelConnector mockConnector;
     private ServiceBlockingStub blockingStub;
     private ServiceStub stub;
+    private ServiceStub errorStub;
     private QueueingStreamObserver<EventStreamResponse> observer;
     private TriConsumer<ProviderEvent, ProviderEventDetails, Structure> consumer;
     private CountDownLatch latch; // used to wait for observer to be initialized
@@ -61,6 +62,29 @@ class RpcResolverTest {
                 })
                 .when(stub)
                 .eventStream(any(), any()); // Mock the initialize method
+
+        // stub that immediately fires onError on every eventStream call
+        errorStub = mock(ServiceStub.class);
+        when(errorStub.withDeadlineAfter(anyLong(), any())).thenReturn(errorStub);
+        doAnswer((Answer<Void>) invocation -> {
+                    @SuppressWarnings("unchecked")
+                    QueueingStreamObserver<EventStreamResponse> obs = (QueueingStreamObserver<EventStreamResponse>)
+                            invocation.getArguments()[1];
+                    latch.countDown();
+                    // immediately fire error on a separate thread
+                    new Thread(() -> {
+                                try {
+                                    Thread.sleep(10);
+                                    obs.onError(new Exception("immediate error"));
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            })
+                            .start();
+                    return null;
+                })
+                .when(errorStub)
+                .eventStream(any(), any());
     }
 
     @Test
@@ -102,8 +126,13 @@ class RpcResolverTest {
 
     @Test
     void onCompletedRerunsStreamWithError() throws Exception {
-        RpcResolver resolver =
-                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
+        RpcResolver resolver = new RpcResolver(
+                FlagdOptions.builder().retryBackoffMaxMs(100).build(),
+                null,
+                consumer,
+                stub,
+                blockingStub,
+                mockConnector);
         resolver.init();
         latch.await();
 
@@ -118,8 +147,13 @@ class RpcResolverTest {
 
     @Test
     void onErrorRunsConsumerWithError() throws Exception {
-        RpcResolver resolver =
-                new RpcResolver(FlagdOptions.builder().build(), null, consumer, stub, blockingStub, mockConnector);
+        RpcResolver resolver = new RpcResolver(
+                FlagdOptions.builder().retryBackoffMaxMs(100).build(),
+                null,
+                consumer,
+                stub,
+                blockingStub,
+                mockConnector);
         resolver.init();
         latch.await();
 
@@ -130,5 +164,52 @@ class RpcResolverTest {
         await().untilAsserted(() -> verify(consumer).accept(eq(ProviderEvent.PROVIDER_ERROR), any(), any()));
         // should have restarted the stream (2 calls)
         await().untilAsserted(() -> verify(stub, times(2)).eventStream(any(), any()));
+    }
+
+    @Test
+    void onError_RetriesWithNonBlockingBackoff() throws Exception {
+        // make sure we do not spin in a busy loop on immediate errors
+        int maxBackoffMs = 1000;
+        RpcResolver resolver = new RpcResolver(
+                FlagdOptions.builder().retryBackoffMaxMs(maxBackoffMs).build(),
+                null,
+                consumer,
+                errorStub,
+                blockingStub,
+                mockConnector);
+        resolver.init();
+        latch.await();
+
+        // wait 1.5x our delay for retries
+        Thread.sleep(maxBackoffMs + (maxBackoffMs / 2));
+
+        // should have retried the stream (2 calls); initial + 1 retry
+        // it's very important that the retry count is low, to confirm no busy-loop
+        verify(errorStub, times(2)).eventStream(any(), any());
+    }
+
+    @Test
+    void onCompleted_RetriesWithNonBlockingBackoff() throws Exception {
+        // make sure we do not spin in a busy loop on stream completion
+        int maxBackoffMs = 1000;
+        RpcResolver resolver = new RpcResolver(
+                FlagdOptions.builder().retryBackoffMaxMs(maxBackoffMs).build(),
+                null,
+                consumer,
+                stub,
+                blockingStub,
+                mockConnector);
+        resolver.init();
+        latch.await();
+
+        // fire completion
+        observer.onCompleted();
+
+        // wait 1.5x our delay for retries
+        Thread.sleep(maxBackoffMs + (maxBackoffMs / 2));
+
+        // should have retried the stream (2 calls); initial + 1 retry
+        // it's very important that the retry count is low, to confirm no busy-loop
+        verify(stub, times(2)).eventStream(any(), any());
     }
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolverTest.java
@@ -63,22 +63,21 @@ class RpcResolverTest {
                 .when(stub)
                 .eventStream(any(), any()); // Mock the initialize method
 
-        // stub that immediately fires onError on every eventStream call
+        // stub that fires onError shortly after every eventStream call
         errorStub = mock(ServiceStub.class);
         when(errorStub.withDeadlineAfter(anyLong(), any())).thenReturn(errorStub);
         doAnswer((Answer<Void>) invocation -> {
                     @SuppressWarnings("unchecked")
                     QueueingStreamObserver<EventStreamResponse> obs = (QueueingStreamObserver<EventStreamResponse>)
                             invocation.getArguments()[1];
-                    latch.countDown();
-                    // immediately fire error on a separate thread
                     new Thread(() -> {
                                 try {
                                     Thread.sleep(10);
-                                    obs.onError(new Exception("immediate error"));
                                 } catch (InterruptedException e) {
-                                    Thread.currentThread().interrupt();
+                                    throw new RuntimeException(e);
                                 }
+                                obs.onError(new Exception("error"));
+                                latch.countDown();
                             })
                             .start();
                     return null;


### PR DESCRIPTION
* the in-process sync stream has a [spec](https://flagd.dev/reference/specifications/providers/#stream-reconnection)-compliant delay of maxStreamBackoff, but the RPC does not
* this backoff is crucial to prevent tight loops sometimes cauesd by immediate error responses, often from proxies
* this adds the same backoff to RPC, plus tests, and adds same naming improvements to existing tests


FYI: a lot of the diff in non-test code is whitespace