### PR TITLE
fix(flagd): add logging for invalid env var parsing failures

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -1,11 +1,10 @@
 package dev.openfeature.contrib.providers.flagd;
 
+import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.CacheType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.CacheType;
 import lombok.extern.slf4j.Slf4j;
 
 /** Helper class to hold configuration default values. */
@@ -86,9 +85,9 @@ public final class Config {
         try {
             return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
         } catch (Exception e) {
-    log.error("Invalid value for environment variable: {}", key, e);
-    return defaultValue;
-}
+            log.error("Invalid value for environment variable: {}", key, e);
+            return defaultValue;
+        }
     }
 
     static long fallBackToEnvOrDefault(String key, long defaultValue) {

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/Config.java
@@ -1,10 +1,11 @@
 package dev.openfeature.contrib.providers.flagd;
 
-import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.CacheType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import dev.openfeature.contrib.providers.flagd.resolver.rpc.cache.CacheType;
 import lombok.extern.slf4j.Slf4j;
 
 /** Helper class to hold configuration default values. */
@@ -85,8 +86,9 @@ public final class Config {
         try {
             return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : defaultValue;
         } catch (Exception e) {
-            return defaultValue;
-        }
+    log.error("Invalid value for environment variable: {}", key, e);
+    return defaultValue;
+}
     }
 
     static long fallBackToEnvOrDefault(String key, long defaultValue) {


### PR DESCRIPTION
Added error logging when environment variable parsing fails in Config.java.

Previously invalid environment variables silently fell back to default values without notifying the user.
This change logs the parsing failure before returning the default value.