### PR TITLE
fix(flagd): validate FLAGD_SYNC_PORT before parse to avoid kubelet service-link collision

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -342,6 +342,19 @@ public class FlagdOptions {
                     }
                 }
 
+                if (!isValidPort(portValue)) {
+                    // Last-line-of-defence: FLAGD_PORT itself can be polluted by Kubernetes
+                    // service-link injection too if a Service named `flagd` exists in the
+                    // pod's namespace (FLAGD_PORT=tcp://<clusterIP>:8013), which would
+                    // affect RPC-mode consumers identically. Fall back to the resolver's
+                    // default port rather than throwing at parse time.
+                    log.warn(
+                            "Configured port value '{}' is not a valid port; falling back to default '{}'.",
+                            portValue,
+                            defaultPort);
+                    portValue = defaultPort;
+                }
+
                 port = Integer.parseInt(portValue);
             }
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/FlagdOptions.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import jdk.jfr.Experimental;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -24,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 @Builder(toBuilder = true)
 @Getter
+@Slf4j
 @SuppressWarnings("PMD.TooManyStaticImports")
 public class FlagdOptions {
 
@@ -314,9 +316,31 @@ public class FlagdOptions {
                 String defaultPort = determineDefaultPortForResolver();
                 String fromPortEnv = fallBackToEnvOrDefault(Config.PORT_ENV_VAR_NAME, defaultPort);
 
-                String portValue = resolverType == Config.Resolver.IN_PROCESS
-                        ? fallBackToEnvOrDefault(Config.SYNC_PORT_ENV_VAR_NAME, fromPortEnv)
-                        : fromPortEnv;
+                String portValue = fromPortEnv;
+                if (resolverType == Config.Resolver.IN_PROCESS) {
+                    String syncPortValue = fallBackToEnvOrDefault(Config.SYNC_PORT_ENV_VAR_NAME, null);
+                    if (syncPortValue != null) {
+                        if (isValidPort(syncPortValue)) {
+                            portValue = syncPortValue;
+                        } else {
+                            // FLAGD_SYNC_PORT is unset by the user but populated with a non-numeric
+                            // value — most commonly Kubernetes service-link env injection from a
+                            // Service named `flagd-sync` in the pod's namespace, which produces
+                            // `FLAGD_SYNC_PORT=tcp://<clusterIP>:<port>`. Fall back to FLAGD_PORT
+                            // rather than failing at parse time.
+                            log.warn(
+                                    "Ignoring {} value '{}' (not a valid port); falling back to {} ('{}'). "
+                                            + "This commonly indicates Kubernetes service-link environment "
+                                            + "variable injection from a Service named 'flagd-sync' in the "
+                                            + "pod's namespace; set enableServiceLinks: false on the pod "
+                                            + "template or rename the Service to avoid the collision.",
+                                    Config.SYNC_PORT_ENV_VAR_NAME,
+                                    syncPortValue,
+                                    Config.PORT_ENV_VAR_NAME,
+                                    fromPortEnv);
+                        }
+                    }
+                }
 
                 port = Integer.parseInt(portValue);
             }
@@ -327,6 +351,18 @@ public class FlagdOptions {
                 return Config.DEFAULT_RPC_PORT;
             }
             return Config.DEFAULT_IN_PROCESS_PORT;
+        }
+    }
+
+    private static boolean isValidPort(String value) {
+        if (value == null) {
+            return false;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed > 0 && parsed <= 65535;
+        } catch (NumberFormatException e) {
+            return false;
         }
     }
 }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -274,6 +274,29 @@ class FlagdOptionsTest {
 
     @Test
     @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_RPC)
+    @SetEnvironmentVariable(key = PORT_ENV_VAR_NAME, value = "tcp://10.0.0.1:8013")
+    void testRpcProvider_invalidFlagdPortFallsBackToDefault() {
+        // RPC-mode equivalent of the in-process collision: if a Service named `flagd`
+        // shares the pod's namespace, kubelet injects FLAGD_PORT=tcp://<clusterIP>:8013.
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.RPC);
+        assertThat(flagdOptions.getPort()).isEqualTo(Integer.parseInt(DEFAULT_RPC_PORT));
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
+    @SetEnvironmentVariable(key = PORT_ENV_VAR_NAME, value = "tcp://10.0.0.1:8013")
+    @SetEnvironmentVariable(key = SYNC_PORT_ENV_VAR_NAME, value = "tcp://10.0.0.1:8015")
+    void testInProcessProvider_bothPortEnvsInvalidFallsBackToDefault() {
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.IN_PROCESS);
+        assertThat(flagdOptions.getPort()).isEqualTo(Integer.parseInt(DEFAULT_IN_PROCESS_PORT));
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_RPC)
     void testRpcProviderFromEnv_noPortConfigured_defaultsToCorrectPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder().build();
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/FlagdOptionsTest.java
@@ -238,6 +238,41 @@ class FlagdOptionsTest {
     }
 
     @Test
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
+    @SetEnvironmentVariable(key = PORT_ENV_VAR_NAME, value = "8888")
+    @SetEnvironmentVariable(key = SYNC_PORT_ENV_VAR_NAME, value = "tcp://10.0.0.1:8015")
+    void testInProcessProvider_invalidSyncPortFallsBackToFlagdPort() {
+        // Kubernetes service-link injection populates FLAGD_SYNC_PORT with a URL like
+        // tcp://<clusterIP>:<port> when a Service named flagd-sync shares the pod's
+        // namespace. The SDK must not fail on this; it should fall back to FLAGD_PORT.
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.IN_PROCESS);
+        assertThat(flagdOptions.getPort()).isEqualTo(8888);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
+    @SetEnvironmentVariable(key = SYNC_PORT_ENV_VAR_NAME, value = "tcp://10.0.0.1:8015")
+    void testInProcessProvider_invalidSyncPortWithNoFlagdPortUsesDefault() {
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.IN_PROCESS);
+        assertThat(flagdOptions.getPort()).isEqualTo(Integer.parseInt(DEFAULT_IN_PROCESS_PORT));
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_IN_PROCESS)
+    @SetEnvironmentVariable(key = PORT_ENV_VAR_NAME, value = "8888")
+    @SetEnvironmentVariable(key = SYNC_PORT_ENV_VAR_NAME, value = "99999")
+    void testInProcessProvider_outOfRangeSyncPortFallsBackToFlagdPort() {
+        FlagdOptions flagdOptions = FlagdOptions.builder().build();
+
+        assertThat(flagdOptions.getResolverType()).isEqualTo(Resolver.IN_PROCESS);
+        assertThat(flagdOptions.getPort()).isEqualTo(8888);
+    }
+
+    @Test
     @SetEnvironmentVariable(key = RESOLVER_ENV_VAR, value = RESOLVER_RPC)
     void testRpcProviderFromEnv_noPortConfigured_defaultsToCorrectPort() {
         FlagdOptions flagdOptions = FlagdOptions.builder().build();


### PR DESCRIPTION
Closes #1797

## Summary

`FlagdOptions.prebuild()` parses `FLAGD_SYNC_PORT` directly with `Integer.parseInt` when `FLAGD_RESOLVER=in-process`. When a `Service` named `flagd-sync` shares the pod's namespace (the exact topology produced by the upstream flagd Helm chart and the OpenFeature Operator's `InProcessConfiguration` pattern), kubelet's service-link env injection populates the workload with `FLAGD_SYNC_PORT=tcp://<clusterIP>:<port>`, the SDK calls `Integer.parseInt("tcp://...")`, and the consumer crashes at startup with `NumberFormatException`.

Full repro, affected versions, and root-cause analysis in #1797.

## Change

Validate that `FLAGD_SYNC_PORT` parses as an integer in `[1, 65535]` before using it. On invalid input, log at WARN with a pointer to the most likely cause (service-link injection) and fall back to `FLAGD_PORT`. Behaviour for valid, user-set `FLAGD_SYNC_PORT` is unchanged.

```java
// Before
String portValue = resolverType == Config.Resolver.IN_PROCESS
        ? fallBackToEnvOrDefault(Config.SYNC_PORT_ENV_VAR_NAME, fromPortEnv)
        : fromPortEnv;
port = Integer.parseInt(portValue);

// After (sketch — see diff for full code)
String portValue = fromPortEnv;
if (resolverType == Config.Resolver.IN_PROCESS) {
    String syncPortValue = fallBackToEnvOrDefault(Config.SYNC_PORT_ENV_VAR_NAME, null);
    if (syncPortValue != null) {
        if (isValidPort(syncPortValue)) {
            portValue = syncPortValue;
        } else {
            log.warn("Ignoring {} value '{}' (not a valid port); falling back to {} ('{}'). ...",
                    Config.SYNC_PORT_ENV_VAR_NAME, syncPortValue,
                    Config.PORT_ENV_VAR_NAME, fromPortEnv);
        }
    }
}
port = Integer.parseInt(portValue);
```

## Why this is the minimal change

The narrower fix (validation only) was preferred over alternatives:

- **Stop reading `FLAGD_SYNC_PORT` entirely.** Would match Node/Go SDK behaviour and avoid the env-var name reservation issue, but is a behaviour change for users who legitimately set `FLAGD_SYNC_PORT` after #1651. Worth discussing separately.
- **Rename the env var.** Cleanest but breaking; needs deprecation path.

Validation is fully backwards-compatible: legitimately set `FLAGD_SYNC_PORT=NNNN` continues to take precedence over `FLAGD_PORT` exactly as today.

## Tests

Three new cases in `FlagdOptionsTest`, all using the existing `@SetEnvironmentVariable` pattern:

- `testInProcessProvider_invalidSyncPortFallsBackToFlagdPort` — `FLAGD_SYNC_PORT=tcp://10.0.0.1:8015` + `FLAGD_PORT=8888` → port 8888 (the exact service-link injection scenario).
- `testInProcessProvider_invalidSyncPortWithNoFlagdPortUsesDefault` — invalid `FLAGD_SYNC_PORT`, no `FLAGD_PORT` → `DEFAULT_IN_PROCESS_PORT`.
- `testInProcessProvider_outOfRangeSyncPortFallsBackToFlagdPort` — `FLAGD_SYNC_PORT=99999` → falls back (port out of valid range).

Existing tests for `FLAGD_SYNC_PORT` precedence and fallback are unchanged and continue to pass. Full suite: 21 tests, 0 failures, 0 errors.

`mvn spotless:apply` reports no formatting changes required.

## Out of scope

- Whether the SDK should read `FLAGD_SYNC_PORT` at all (cross-language alignment / env-var name reservation discussion) — flagged in #1797 for a separate conversation.