### PR TITLE
feat!: DISABLED is a successful evaluation (still defaults)

### DIFF
--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
@@ -254,6 +254,8 @@ public final class RpcResolver implements Resolver {
         final ProviderEvaluation.ProviderEvaluationBuilder<ValT> resultBuilder;
         if ("DEFAULT".equals(reason) && variant.isEmpty()) {
             resultBuilder = ProviderEvaluation.<ValT>builder().value(defaultValue);
+        } else if ("DISABLED".equals(reason)) {
+            resultBuilder = ProviderEvaluation.<ValT>builder().value(defaultValue);
         } else {
             resultBuilder = ProviderEvaluation.<ValT>builder().value(value).variant(variant);
         }

--- a/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
+++ b/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/rpc/RpcResolver.java
@@ -252,9 +252,7 @@ public final class RpcResolver implements Resolver {
         final String variant = getField(response, Config.VARIANT_FIELD);
 
         final ProviderEvaluation.ProviderEvaluationBuilder<ValT> resultBuilder;
-        if ("DEFAULT".equals(reason) && variant.isEmpty()) {
-            resultBuilder = ProviderEvaluation.<ValT>builder().value(defaultValue);
-        } else if ("DISABLED".equals(reason)) {
+        if (variant.isEmpty() && ("DEFAULT".equals(reason) || "DISABLED".equals(reason))) {
             resultBuilder = ProviderEvaluation.<ValT>builder().value(defaultValue);
         } else {
             resultBuilder = ProviderEvaluation.<ValT>builder().value(value).variant(variant);

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -312,7 +312,10 @@ class InProcessResolverTest {
         // when/then
         ProviderEvaluation<Boolean> disabledFlag =
                 inProcessResolver.booleanEvaluation("disabledFlag", false, new ImmutableContext());
-        assertEquals(ErrorCode.FLAG_NOT_FOUND, disabledFlag.getErrorCode());
+        assertEquals(null, disabledFlag.getErrorCode());
+        assertEquals(null, disabledFlag.getValue());
+        assertEquals(null, disabledFlag.getVariant());
+        assertEquals(Reason.DISABLED.toString(), disabledFlag.getReason());
     }
 
     @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -316,6 +316,13 @@ class InProcessResolverTest {
         assertEquals(null, disabledFlag.getValue());
         assertEquals(null, disabledFlag.getVariant());
         assertEquals(Reason.DISABLED.toString(), disabledFlag.getReason());
+
+        ProviderEvaluation<Value> disabledObject =
+                inProcessResolver.objectEvaluation("disabledFlag", null, new ImmutableContext());
+        assertEquals(null, disabledObject.getErrorCode());
+        assertEquals(null, disabledObject.getValue());
+        assertEquals(null, disabledObject.getVariant());
+        assertEquals(Reason.DISABLED.toString(), disabledObject.getReason());
     }
 
     @Test

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/InProcessResolverTest.java
@@ -313,7 +313,7 @@ class InProcessResolverTest {
         ProviderEvaluation<Boolean> disabledFlag =
                 inProcessResolver.booleanEvaluation("disabledFlag", false, new ImmutableContext());
         assertEquals(null, disabledFlag.getErrorCode());
-        assertEquals(null, disabledFlag.getValue());
+        assertEquals(false, disabledFlag.getValue());
         assertEquals(null, disabledFlag.getVariant());
         assertEquals(Reason.DISABLED.toString(), disabledFlag.getReason());
 

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
@@ -76,7 +76,7 @@ public class MockEvaluator implements Evaluator {
     public ProviderEvaluation<Value> resolveObjectValue(String flagKey, Value defaultValue, EvaluationContext ctx) {
         final ProviderEvaluation<Object> evaluation = resolve(Object.class, flagKey, defaultValue, ctx);
         return ProviderEvaluation.<Value>builder()
-                .value(Value.objectToValue(evaluation.getValue()))
+                .value(evaluation.getValue() != null ? Value.objectToValue(evaluation.getValue()) : null)
                 .variant(evaluation.getVariant())
                 .reason(evaluation.getReason())
                 .errorCode(evaluation.getErrorCode())

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
@@ -101,8 +101,7 @@ public class MockEvaluator implements Evaluator {
         // state check
         if ("DISABLED".equals(flag.getState())) {
             return ProviderEvaluation.<T>builder()
-                    .errorMessage("flag: " + key + " is disabled")
-                    .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                    .reason(Reason.DISABLED.toString())
                     .flagMetadata(getFlagMetadata(flagSetMetadata, flag))
                     .build();
         }

--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/process/MockEvaluator.java
@@ -101,6 +101,7 @@ public class MockEvaluator implements Evaluator {
         // state check
         if ("DISABLED".equals(flag.getState())) {
             return ProviderEvaluation.<T>builder()
+                    .value(defaultValue)
                     .reason(Reason.DISABLED.toString())
                     .flagMetadata(getFlagMetadata(flagSetMetadata, flag))
                     .build();

--- a/tools/flagd-api-testkit/src/main/java/dev/openfeature/contrib/tools/flagd/api/testkit/EvaluationSteps.java
+++ b/tools/flagd-api-testkit/src/main/java/dev/openfeature/contrib/tools/flagd/api/testkit/EvaluationSteps.java
@@ -97,12 +97,6 @@ public class EvaluationSteps {
         assertThat(state.evaluation.getValue()).isEqualTo(EvaluatorUtils.convert(value, state.flagType));
     }
 
-    /** Asserts the resolved value is absent (null) — used for disabled flags where the evaluator omits the value. */
-    @Then("the resolved value should be absent")
-    public void resolvedValueIsAbsent() {
-        assertThat(state.evaluation.getValue()).isNull();
-    }
-
     /** Asserts the evaluation reason matches the expected value. */
     @Then("the reason should be {string}")
     public void reasonEquals(String reason) {

--- a/tools/flagd-api-testkit/src/main/java/dev/openfeature/contrib/tools/flagd/api/testkit/EvaluationSteps.java
+++ b/tools/flagd-api-testkit/src/main/java/dev/openfeature/contrib/tools/flagd/api/testkit/EvaluationSteps.java
@@ -97,6 +97,12 @@ public class EvaluationSteps {
         assertThat(state.evaluation.getValue()).isEqualTo(EvaluatorUtils.convert(value, state.flagType));
     }
 
+    /** Asserts the resolved value is absent (null) — used for disabled flags where the evaluator omits the value. */
+    @Then("the resolved value should be absent")
+    public void resolvedValueIsAbsent() {
+        assertThat(state.evaluation.getValue()).isNull();
+    }
+
     /** Asserts the evaluation reason matches the expected value. */
     @Then("the reason should be {string}")
     public void reasonEquals(String reason) {

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -180,7 +180,7 @@ public class FlagdCore implements Evaluator {
         final ProviderEvaluation<Object> evaluation = resolve(Object.class, flagKey, defaultValue, ctx);
 
         return ProviderEvaluation.<Value>builder()
-                .value(Value.objectToValue(evaluation.getValue()))
+                .value(evaluation.getValue() != null ? Value.objectToValue(evaluation.getValue()) : null)
                 .variant(evaluation.getVariant())
                 .reason(evaluation.getReason())
                 .errorCode(evaluation.getErrorCode())

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -210,9 +210,10 @@ public class FlagdCore implements Evaluator {
                     .build();
         }
 
-        // state check
+        // state check (DISABLED flags default with reason = DEFAULT)
         if ("DISABLED".equals(flag.getState())) {
             return ProviderEvaluation.<T>builder()
+                    .value(defaultValue)
                     .reason(Reason.DISABLED.toString())
                     .flagMetadata(getFlagMetadata(currentFlagSetMetadata, flag))
                     .build();

--- a/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
+++ b/tools/flagd-core/src/main/java/dev/openfeature/contrib/tools/flagd/core/FlagdCore.java
@@ -213,9 +213,8 @@ public class FlagdCore implements Evaluator {
         // state check
         if ("DISABLED".equals(flag.getState())) {
             return ProviderEvaluation.<T>builder()
-                    .errorMessage("flag: " + key + " is disabled")
-                    .errorCode(ErrorCode.FLAG_NOT_FOUND)
-                    .flagMetadata(getFlagMetadata(currentFlagSetMetadata, null))
+                    .reason(Reason.DISABLED.toString())
+                    .flagMetadata(getFlagMetadata(currentFlagSetMetadata, flag))
                     .build();
         }
 

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -7,6 +7,7 @@ import dev.openfeature.contrib.tools.flagd.api.FlagStoreException;
 import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Reason;
+import dev.openfeature.sdk.Value;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -82,6 +83,17 @@ class FlagdCoreTest {
     void resolveBooleanValue_disabledFlag_returnsDisabledReason() {
         ProviderEvaluation<Boolean> result =
                 flagdCore.resolveBooleanValue("disabledFlag", false, new ImmutableContext());
+
+        assertThat(result.getErrorCode()).isNull();
+        assertThat(result.getValue()).isNull();
+        assertThat(result.getVariant()).isNull();
+        assertThat(result.getReason()).isEqualTo(Reason.DISABLED.toString());
+    }
+
+    @Test
+    void resolveObjectValue_disabledFlag_returnsDisabledReasonWithNullValue() {
+        ProviderEvaluation<Value> result =
+                flagdCore.resolveObjectValue("disabledFlag", null, new ImmutableContext());
 
         assertThat(result.getErrorCode()).isNull();
         assertThat(result.getValue()).isNull();

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -79,12 +79,14 @@ class FlagdCoreTest {
     }
 
     @Test
-    void resolveBooleanValue_disabledFlag_returnsError() {
+    void resolveBooleanValue_disabledFlag_returnsDisabledReason() {
         ProviderEvaluation<Boolean> result =
                 flagdCore.resolveBooleanValue("disabledFlag", false, new ImmutableContext());
 
-        assertThat(result.getErrorCode()).isNotNull();
-        assertThat(result.getErrorMessage()).contains("disabled");
+        assertThat(result.getErrorCode()).isNull();
+        assertThat(result.getValue()).isNull();
+        assertThat(result.getVariant()).isNull();
+        assertThat(result.getReason()).isEqualTo(Reason.DISABLED.toString());
     }
 
     @Test

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -80,18 +80,18 @@ class FlagdCoreTest {
     }
 
     @Test
-    void resolveBooleanValue_disabledFlag_returnsDisabledReason() {
+    void resolveBooleanValue_disabledFlag_returnsDisabledReasonWithDefault() {
         ProviderEvaluation<Boolean> result =
                 flagdCore.resolveBooleanValue("disabledFlag", false, new ImmutableContext());
 
         assertThat(result.getErrorCode()).isNull();
-        assertThat(result.getValue()).isNull();
+        assertThat(result.getValue()).isFalse();
         assertThat(result.getVariant()).isNull();
         assertThat(result.getReason()).isEqualTo(Reason.DISABLED.toString());
     }
 
     @Test
-    void resolveObjectValue_disabledFlag_returnsDisabledReasonWithNullValue() {
+    void resolveObjectValue_disabledFlag_returnsDisabledReasonWithDefault() {
         ProviderEvaluation<Value> result =
                 flagdCore.resolveObjectValue("disabledFlag", null, new ImmutableContext());
 

--- a/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
+++ b/tools/flagd-core/src/test/java/dev/openfeature/contrib/tools/flagd/core/FlagdCoreTest.java
@@ -92,8 +92,7 @@ class FlagdCoreTest {
 
     @Test
     void resolveObjectValue_disabledFlag_returnsDisabledReasonWithDefault() {
-        ProviderEvaluation<Value> result =
-                flagdCore.resolveObjectValue("disabledFlag", null, new ImmutableContext());
+        ProviderEvaluation<Value> result = flagdCore.resolveObjectValue("disabledFlag", null, new ImmutableContext());
 
         assertThat(result.getErrorCode()).isNull();
         assertThat(result.getValue()).isNull();


### PR DESCRIPTION
- Disabled flags now resolve successfully with `reason=DISABLED` instead of `errorCode=FLAG_NOT_FOUND`. See the [ADR](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/disabled-flag-evaluation.md).
- Breaking, but barely: resolved values are unchanged (the caller-provided default is still surfaced).
- The break is only observable for consumers that inspect `reason` / `errorCode` on disabled-flag evaluations.

### Related Issues

Closes #1799
Part of open-feature/flagd#1965
