### PR TITLE
chore: add deploy profile to ci; catches pkging issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
           os: [ubuntu-latest]
           build:
               - java: 21
-                profile: codequality
+                # deploy profile is included to catch javadoc/SBOM/source-jar issues at PR time
+                # note this is the publish PROFILE, not PHASE
+                profile: codequality,deploy
               - java: 11
                 profile: java11
 

--- a/providers/gcp/src/main/java/dev/openfeature/contrib/providers/gcp/GcpSecretManagerProvider.java
+++ b/providers/gcp/src/main/java/dev/openfeature/contrib/providers/gcp/GcpSecretManagerProvider.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>Each feature flag is stored as an individual secret in GCP Secret Manager. The flag key
  * maps directly to the secret name (with an optional prefix configured via
- * {@link GcpProviderOptions#getNamePrefix()}).
+ * {@link GcpProviderOptions}'s {@code namePrefix}).
  *
  * <p>Flag values are read as UTF-8 strings from the secret payload and parsed to the requested
  * type. Supported raw value formats:
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  * </ul>
  *
  * <p>Results are cached in-process for the duration configured in
- * {@link GcpProviderOptions#getCacheExpiry()}.
+ * {@link GcpProviderOptions}'s {@code cacheExpiry}.
  *
  * <p>Example:
  * <pre>{@code


### PR DESCRIPTION
This add some additional stuff to our CI, like javadoc gen, etc, so we can see failures that we until now only see on release earlier, in the CI checks.

Also fixes issues related to javadoc referencing lombok generated code.