### PR TITLE
fix: keep distributionManagement in flattened pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,10 @@
                 <version>1.7.0</version>
                 <configuration>
                     <flattenMode>ossrh</flattenMode>
+                    <pomElements>
+                        <!-- keep distributionManagement so the central-publishing plugin can resolve the snapshot repo during deploy -->
+                        <distributionManagement>resolve</distributionManagement>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Follow-up to #1806. Flatten was stripping `<distributionManagement>` from child POMs; keeping it avoids any risk to the deploy plugin lifecycle on releases.