### PR TITLE
fix(otel)!: bump opentelemetry-semconv-incubating to 1.43.0-alpha

### DIFF
--- a/hooks/open-telemetry/pom.xml
+++ b/hooks/open-telemetry/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv-incubating</artifactId>
-            <version>1.28.0-alpha</version>
+            <version>1.43.0-alpha</version>
         </dependency>
 
         <dependency>

--- a/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
+++ b/hooks/open-telemetry/src/test/java/dev/openfeature/contrib/hooks/otel/TracesHookTest.java
@@ -39,7 +39,7 @@ class TracesHookTest {
     }
 
     private final AttributeKey<String> flagKeyAttributeKey = AttributeKey.stringKey("feature_flag.key");
-    private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey("feature_flag.provider_name");
+    private final AttributeKey<String> providerNameAttributeKey = AttributeKey.stringKey("feature_flag.provider.name");
     private final AttributeKey<String> variantAttributeKey = AttributeKey.stringKey("feature_flag.variant");
 
     private final HookContext<String> hookContext = HookContext.<String>builder()


### PR DESCRIPTION
## This PR

Bumps `opentelemetry-semconv-incubating` to `1.43.0-alpha` in `hooks/open-telemetry` and updates the one hardcoded test assertion that relied on the old attribute string.

### Related Issues

Relates to #1843

### Notes

This version renames the `feature_flag.provider_name` span attribute to `feature_flag.provider.name` (underscore → dot). Our hook code references the `FEATURE_FLAG_PROVIDER_NAME` constant rather than a literal, so no source change is needed — only `TracesHookTest.java`'s hardcoded assertion string is updated to match.

**Breaking change**: consumers reading the `feature_flag.provider_name` span attribute (dashboards, alerts, queries) will need to update to `feature_flag.provider.name`.

### Follow-up Tasks

A separate PR will adopt newly available semconv attributes (e.g. `FEATURE_FLAG_RESULT_VARIANT`) — intentionally not bundled here.

### How to test

```
./mvnw --projects hooks/open-telemetry --also-make clean verify
```